### PR TITLE
Make qnbinom faster for small values of size

### DIFF
--- a/src/nmath/qnbinom.c
+++ b/src/nmath/qnbinom.c
@@ -51,8 +51,16 @@ do_search(double y, double *z, double p, double n, double pr, double incr)
 	for(;;) {
         y = fmax2(0, y - incr);
 	    if(y == 0 ||
-	       (*z = pnbinom(y, n, pr, /*l._t.*/TRUE, /*log_p*/FALSE)) < p)
-		return y;
+	       (*z = pnbinom(y, n, pr, /*l._t.*/TRUE, /*log_p*/FALSE)) < p){
+            if(incr == 1){
+                // we know that the search is stopped if incr == 1
+                // and we know that the correct result is just right 
+                // of the current y
+                return y + 1;
+            }else{
+                return y;
+            }
+        }
 	}
     }
     else {		/* search to the right */

--- a/src/nmath/qnbinom.c
+++ b/src/nmath/qnbinom.c
@@ -49,10 +49,10 @@ do_search(double y, double *z, double p, double n, double pr, double incr)
 {
     if(*z >= p) {	/* search to the left */
 	for(;;) {
+        y = fmax2(0, y - incr);
 	    if(y == 0 ||
-	       (*z = pnbinom(y - incr, n, pr, /*l._t.*/TRUE, /*log_p*/FALSE)) < p)
+	       (*z = pnbinom(y, n, pr, /*l._t.*/TRUE, /*log_p*/FALSE)) < p)
 		return y;
-	    y = fmax2(0, y - incr);
 	}
     }
     else {		/* search to the right */

--- a/src/nmath/qnbinom.c
+++ b/src/nmath/qnbinom.c
@@ -104,6 +104,7 @@ double qnbinom(double p, double size, double prob, int lower_tail, int log_p)
     /* y := approx.value (Cornish-Fisher expansion) :  */
     z = qnorm(p, 0., 1., /*lower_tail*/TRUE, /*log_p*/FALSE);
     y = R_forceint(mu + sigma * (z + gamma * (z*z - 1) / 6));
+    y = fmax2(0.0, y);
 
     z = pnbinom(y, size, prob, /*lower_tail*/TRUE, /*log_p*/FALSE);
 


### PR DESCRIPTION
Hi, 

I encountered a problem where `qnbinom()` becomes really slow if the `size` parameter becomes small:
```
qnbinom(0.5, mu = 3, size = 1e-10)
```
takes ~30 seconds on my machine. I posted the issue on the r-devel mailing list ([link](https://stat.ethz.ch/pipermail/r-devel/2020-August/079817.html) to archive) and got a response that this could worth reporting.

I think the fix is pretty trivial, so I wanted to give it a stab. 

Best,
Constantin