### PR TITLE
multi-byte safe string truncations

### DIFF
--- a/src/include/Defn.h
+++ b/src/include/Defn.h
@@ -1399,6 +1399,7 @@ Rboolean utf8Valid(const char *str);
 char *Rf_strchr(const char *s, int c);
 char *Rf_strrchr(const char *s, int c);
 int Rvsnprintf_mbcs(char *buf, size_t size, const char *format, va_list ap);
+int Rsnprintf_mbcs(char *str, size_t size, const char *format, ...);
 
 SEXP fixup_NaRm(SEXP args); /* summary.c */
 void invalidate_cached_recodings(void);  /* from sysutils.c */

--- a/src/main/errors.c
+++ b/src/main/errors.c
@@ -303,12 +303,13 @@ int Rvsnprintf_mbcs(char *buf, size_t size, const char *format, va_list ap)
 }
 #endif
 
-/* Rsnprintf: like snprintf, but guaranteed to null-terminate and not to split
-   multi-byte characters, except if size is zero in which case the buffer is
-   untouched and thus may not be null-terminated.
+/* Rsnprintf_mbcs: like snprintf, but guaranteed to null-terminate and
+   not to split multi-byte characters, except if size is zero in which
+   case the buffer is untouched and thus may not be null-terminated.
 
-   Dangerous pattern: `Rsnprintf(buf, size - n, )` with maybe n >= size*/
-static int Rsnprintf(char *str, size_t size, const char *format, ...)
+   Dangerous pattern: `Rsnprintf_mbcs(buf, size - n, )` with maybe n >= size*/
+attribute_hidden
+int Rsnprintf_mbcs(char *str, size_t size, const char *format, ...)
 {
     int val;
     va_list ap;
@@ -782,22 +783,22 @@ verrorcall_dflt(SEXP call, const char *format, va_list ap)
 	}
 
 	const char *dcall = CHAR(STRING_ELT(deparse1s(call), 0));
-	Rsnprintf(tmp2, BUFSIZE,  "%s", head);
+	Rsnprintf_mbcs(tmp2, BUFSIZE,  "%s", head);
 	if (skip != NA_INTEGER) {
 	    PROTECT(srcloc = GetSrcLoc(R_GetCurrentSrcref(skip)));
 	    protected++;
 	    len = strlen(CHAR(STRING_ELT(srcloc, 0)));
 	    if (len)
-		Rsnprintf(tmp2, BUFSIZE,  _("Error in %s (from %s) : "),
+		Rsnprintf_mbcs(tmp2, BUFSIZE,  _("Error in %s (from %s) : "),
 			 dcall, CHAR(STRING_ELT(srcloc, 0)));
 	}
 
 	Rvsnprintf_mbcs(tmp, max(msg_len - strlen(head), 0), format, ap);
 	if (strlen(tmp2) + strlen(tail) + strlen(tmp) < BUFSIZE) {
-	    if(len) Rsnprintf(errbuf, BUFSIZE,
+	    if(len) Rsnprintf_mbcs(errbuf, BUFSIZE,
 			     _("Error in %s (from %s) : "),
 			     dcall, CHAR(STRING_ELT(srcloc, 0)));
-	    else Rsnprintf(errbuf, BUFSIZE,  _("Error in %s : "), dcall);
+	    else Rsnprintf_mbcs(errbuf, BUFSIZE,  _("Error in %s : "), dcall);
 	    if (mbcslocale) {
 		int msgline1;
 		char *p = strchr(tmp, '\n');
@@ -820,13 +821,13 @@ verrorcall_dflt(SEXP call, const char *format, va_list ap)
 	    }
 	    ERRBUFCAT(tmp);
 	} else {
-	    Rsnprintf(errbuf, BUFSIZE, _("Error: "));
+	    Rsnprintf_mbcs(errbuf, BUFSIZE, _("Error: "));
 	    ERRBUFCAT(tmp);
 	}
 	UNPROTECT(protected);
     }
     else {
-	Rsnprintf(errbuf, BUFSIZE, _("Error: "));
+	Rsnprintf_mbcs(errbuf, BUFSIZE, _("Error: "));
 	p = errbuf + strlen(errbuf);
 	Rvsnprintf_mbcs(p, max(msg_len - strlen(errbuf), 0), format, ap);
     }
@@ -1117,7 +1118,7 @@ SEXP attribute_hidden do_gettext(SEXP call, SEXP op, SEXP args, SEXP rho)
 	    size_t len = strlen(domain)+3;
 	    R_CheckStack2(len);
 	    buf = (char *) alloca(len);
-	    Rsnprintf(buf, len, "R-%s", domain);
+	    Rsnprintf_mbcs(buf, len, "R-%s", domain);
 	    domain = buf;
 	}
     } else if(isString(CAR(args)))
@@ -1222,7 +1223,7 @@ SEXP attribute_hidden do_ngettext(SEXP call, SEXP op, SEXP args, SEXP rho)
 	    size_t len = strlen(domain)+3;
 	    R_CheckStack2(len);
 	    buf = (char *) alloca(len);
-	    Rsnprintf(buf, len, "R-%s", domain);
+	    Rsnprintf_mbcs(buf, len, "R-%s", domain);
 	    domain = buf;
 	}
     } else if(isString(sdom))

--- a/src/main/print.c
+++ b/src/main/print.c
@@ -434,9 +434,9 @@ static void PrintGenericVector(SEXP s, R_PrintData *data)
 		    snprintf(pbuf, 115, "%s", str);
 		else {
 		    SEXP cls = PROTECT(R_data_class2(tmp));
-		    snprintf(pbuf, 115, "%s,%d",
-			     translateChar(STRING_ELT(cls, 0)),
-			     length(tmp));
+		    Rsnprintf_mbcs(pbuf, 115, "%s,%d",
+			      translateChar(STRING_ELT(cls, 0)),
+			      length(tmp));
 		    UNPROTECT(1);
 		}
 		UNPROTECT(3);
@@ -501,8 +501,9 @@ static void PrintGenericVector(SEXP s, R_PrintData *data)
 		    if(len < 100)
 			snprintf(pbuf, 115, "\"%s\"", ctmp);
 		    else {
-			snprintf(pbuf, 101, "\"%s\"", ctmp);
-			pbuf[100] = '"'; pbuf[101] = '\0';
+			Rsnprintf_mbcs(pbuf, 101, "\"%s\"", ctmp);
+			size_t pbuflen = strlen(pbuf);
+			pbuf[pbuflen] = '"'; pbuf[pbuflen+1] = '\0';
 			strcat(pbuf, " [truncated]");
 		    }
 		    vmaxset(vmax);
@@ -618,9 +619,10 @@ static void PrintGenericVector(SEXP s, R_PrintData *data)
 		    /* internal version of isClass() */
 		    char str[201];
 		    const char *ss = translateChar(STRING_ELT(klass, 0));
-		    snprintf(str, 200, ".__C__%s", ss);
-		    if(findVar(install(str), data->env) != R_UnboundValue)
-			className = ss;
+		    int res = Rsnprintf_mbcs(str, 200, ".__C__%s", ss);
+		    if(res > 0 && res < 200 &&
+		       findVar(install(str), data->env) != R_UnboundValue)
+		        className = ss;
 		}
 	    }
 	    if(className) {
@@ -1026,13 +1028,13 @@ static void printAttributes(SEXP s, R_PrintData *data, Rboolean useSlots)
 		goto nextattr;
 	    if(useSlots) {
 		size_t space = TAGBUFLEN0 - strlen(tagbuf);
-		snprintf(ptag, space,
-			 "Slot \"%s\":", EncodeChar(PRINTNAME(TAG(a))));
+		Rsnprintf_mbcs(ptag, space,
+			       "Slot \"%s\":", EncodeChar(PRINTNAME(TAG(a))));
 	    }
 	    else {
 		size_t space = TAGBUFLEN0 - strlen(tagbuf);
-		snprintf(ptag, space,
-			 "attr(,\"%s\")", EncodeChar(PRINTNAME(TAG(a))));
+		Rsnprintf_mbcs(ptag, space,
+			       "attr(,\"%s\")", EncodeChar(PRINTNAME(TAG(a))));
 	    }
 	    Rprintf("%s", tagbuf); Rprintf("\n");
 	    if (TAG(a) == R_RowNamesSymbol) {


### PR DESCRIPTION
Continuing process of ensuring that string truncation do not occur 
in the middle of multi-byte characters by using the `R*snprintf_mbcs`
functions.