### PR TITLE
mbcs safe truncations for R*vprintf*

### DIFF
--- a/src/gnuwin32/run.c
+++ b/src/gnuwin32/run.c
@@ -935,13 +935,12 @@ static int Wpipe_vfprintf(Rconnection con, const char *format, va_list ap)
     char buf[BUFSIZE], *b = buf;
     int res = 0;
 
-    res = vsnprintf(b, BUFSIZE, format, ap);
-    if(res < 0) { /* a failure indication, so try again */
-	b[BUFSIZE -1] = '\0';
-	warning("printing of extremely long output is truncated");
-	res = BUFSIZE;
+    res = Rvsnprintf_mbcs(b, BUFSIZE, format, ap);
+    if(res < 0 || res >= BUFSIZE) {
+	warning(_("printing of extremely long output is truncated"));
+	res = strlen(b);
     }
-    return Wpipe_write(buf, res, 1, con);
+    return Wpipe_write(buf, (size_t)1, (size_t)res, con);
 }
 
 

--- a/src/main/errors.c
+++ b/src/main/errors.c
@@ -265,9 +265,17 @@ static void setupwarnings(void)
     setAttrib(R_Warnings, R_NamesSymbol, allocVector(STRSXP, R_nwarnings));
 }
 
-/* Rvsnprintf_mbcs: like vsnprintf, but guaranteed to null-terminate and not to split
-   multi-byte characters, except if size is zero in which case the buffer is
-   untouched and thus may not be null-terminated.
+/* Rvsnprintf_mbcs: like vsnprintf, but guaranteed to null-terminate and not to
+   split multi-byte characters, except if size is zero in which case the buffer
+   is untouched and thus may not be null-terminated.
+
+   This function may be invoked by the error
+   handler via REvprintf.  Do not change it
+   unless you are SURE that your changes are
+   compatible with the error handling
+   mechanism.
+
+   REvprintf is also used in R_Suicide on Unix.
 
    Dangerous pattern: `Rvsnprintf_mbcs(buf, size - n, )` with maybe n >= size*/
 #ifdef Win32

--- a/src/main/printutils.c
+++ b/src/main/printutils.c
@@ -989,9 +989,8 @@ void REvprintf(const char *format, va_list arg)
 	va_list aq;
 
 	va_copy(aq, arg);
-	int res = vsnprintf(buf, BUFSIZE, format, aq);
+	int res = Rvsnprintf_mbcs(buf, BUFSIZE, format, aq);
 	va_end(aq);
-	buf[BUFSIZE-1] = '\0';
 	if (res >= BUFSIZE) {
 	    /* A very long string has been truncated. Try to allocate a large
 	       buffer for it to print it in full. Do not use R_alloc() as this

--- a/src/main/util.c
+++ b/src/main/util.c
@@ -1479,7 +1479,16 @@ size_t Mbrtowc(wchar_t *wc, const char *s, size_t n, mbstate_t *ps)
 }
 
 /* Truncate a string in place (in native encoding) so that it only contains
-   valid multi-byte characters. Has no effect in non-mbcs locales. */
+   valid multi-byte characters. Has no effect in non-mbcs locales. 
+
+   This function may be invoked by the error
+   handler via REvprintf->Rvsnprintf_mbcs.
+   Do not change it unless you are SURE that
+   your changes are compatible with the error
+   handling mechanism.
+
+   REvprintf is also used in R_Suicide on Unix.
+   */
 attribute_hidden
 char* mbcsTruncateToValid(char *s)
 {


### PR DESCRIPTION
For Rvprintf, only affects Windows when outputing to a
pipe.  REvprintf, only when R_ConsoleFile is not set and
message connection not sunk