### PR TITLE
copy srcref for .traceback()

### DIFF
--- a/src/main/errors.c
+++ b/src/main/errors.c
@@ -1550,8 +1550,12 @@ SEXP R_GetTraceback(int skip)
     u = v = PROTECT(allocList(nback));
 
     for(t = s; t != R_NilValue; t = CDR(t), v=CDR(v)) {
-        SETCAR(v, PROTECT(deparse1m(CAR(t), 0, DEFAULTDEPARSE)));
-        UNPROTECT(1);
+	SEXP sref = getAttrib(CAR(t), R_SrcrefSymbol);
+	SEXP dep = PROTECT(deparse1m(CAR(t), 0, DEFAULTDEPARSE));
+	if (!isNull(sref))
+	    setAttrib(dep, R_SrcrefSymbol, duplicate(sref));
+	SETCAR(v, dep);
+	UNPROTECT(1);
     }
     UNPROTECT(2);
     return u;


### PR DESCRIPTION
Introduced regression in r76872 by failing to copy
srcref attribute for '.traceback(n)' case.