### PR TITLE
Windows: expose path to pkgconfig

### DIFF
--- a/src/gnuwin32/fixed/etc/Makeconf
+++ b/src/gnuwin32/fixed/etc/Makeconf
@@ -159,6 +159,7 @@ OBJCFLAGS = -O2
 OBJC_LIBS = -lobjc
 OBJCXX =
 OBJDUMP = $(BINPREF)objdump
+PKG_CONFIG = $(BINPREF)pkg-config
 R_ARCH =
 RANLIB = $(BINPREF)ranlib
 SAFE_FFLAGS = -O2 -msse2 -mfpmath=sse

--- a/src/scripts/config
+++ b/src/scripts/config
@@ -288,7 +288,7 @@ ok_tcltk_vars="TCLTK_CPPFLAGS TCLTK_LIBS"
 ok_other_vars="BLAS_LIBS LAPACK_LIBS MAKE LIBnn AR NM RANLIB LTO LTO_FC LTO_LD"
 defunct_vars="CPP CXXCPP"
 if test "${R_OSTYPE}" = "windows"; then
-  ok_win_vars="LOCAL_SOFT COMPILED_BY OBJDUMP"
+  ok_win_vars="LOCAL_SOFT COMPILED_BY OBJDUMP PKG_CONFIG"
 fi
 
 if test "${all}" = "yes"; then


### PR DESCRIPTION
This gives packages a way to query locally available system libraries and get the proper cflags/libs on Windows.

Finding locally installed libraries on Windows is currently very difficult for packages because there are multiple sets of system libraries, for mingw32, mingw64, and soon UCRT. The only reliable way for packages to find the right CPPFLAGS/LDFLAGS for a given system library is checking pkg-config.

In msys2, pkgconfig is part of the toolchain. It is installed by default in `C:/mingw64/bin/` and `C:/mingw32/bin/` alongside gcc and binutils, and ties everything together. Therefore it makes sense to expose this to packages.

ps: it would also be possible to [do this on unix](https://github.com/r-devel/r-svn/pull/26) but perhaps on unix it makes more sense to rely on the PATH, because the environment in which R gets built may be different from where the package is getting built.