### PR TITLE
Expose current windows CRT in R

### DIFF
--- a/src/gnuwin32/system.c
+++ b/src/gnuwin32/system.c
@@ -741,6 +741,9 @@ void R_SetWin32(Rstart Rp)
     }
     putenv("MSYS2_ENV_CONV_EXCL=R_ARCH");
 
+#ifdef _UCRT
+    putenv("UCRT=UCRT");
+#endif
     
     /* This is here temporarily while the GCC version is chosen */
     char gccversion[30];


### PR DESCRIPTION
Set an environment variable to let the user or package know if we are running under UCRT.