### PR TITLE
oob code points are not automatically width 1

### DIFF
--- a/src/main/rlocale.c
+++ b/src/main/rlocale.c
@@ -128,9 +128,9 @@ static int wcwidthsearch(int wint, const struct interval_wcwidth *table,
     int mid;
     max--;
 
-    /* This quickly gives one for ASCII characters since the table
-       starts at 0xa1 */
-    if (wint < table[0].first || wint > table[max].last) return 1;
+    /* This quickly gives one for printing ASCII characters */
+    if (wint > 0x1F && wint < 0x7F) return 1;
+    else if (wint < table[min].first || wint > table[max].last) return -1;
     while (max >= min) {
 	mid = (min + max) / 2;
 	if (wint > table[mid].last)


### PR DESCRIPTION
oob is in reference to the width table, some oob code points
may be width 0.