### PR TITLE
Normalize timeval timeout before select()

### DIFF
--- a/src/modules/internet/Rsock.c
+++ b/src/modules/internet/Rsock.c
@@ -309,8 +309,8 @@ int R_SocketWaitMultiple(int nsock, int *insockfd, int *ready, int *write,
 		delta = R_wait_usec;
 	    else
 		delta = (int)ceil(1e6 * (mytimeout - used));
-	    tv.tv_sec = 0;
-	    tv.tv_usec = delta;
+	    tv.tv_sec = delta / (int)1e6;
+	    tv.tv_usec = delta % (int)1e6;
 	} else if (mytimeout >= 0) {
 	    tv.tv_sec = (int)(mytimeout - used);
 	    tv.tv_usec = (int)ceil(1e6 * (mytimeout - used - tv.tv_sec));


### PR DESCRIPTION
This fixes https://github.com/rstudio/rstudio/issues/6692 and https://github.com/rstudio/rstudio/issues/1997.

I think what happens is that `select()` returns immediately `EINVAL` instead of waiting when timeout is not “normalized”. I can’t find a canonical reference that this is required but for example https://www.gnu.org/software/libc/manual/html_node/Time-Types.html says:

>  When `struct timeval` values are produced by GNU C Library functions, the value in this field will always be greater than or equal to zero, __and less than 1,000,000__. When struct timeval values are supplied to GNU C Library functions, the value in __this field must be in the same range__.

It seems that [the problem was diagnosed](https://github.com/rstudio/rstudio/issues/1997#issuecomment-358359232) 3 years ago, not sure why it wasn't reported in R.

@ltierney @kalibera