### PR TITLE
Port gethostbyname to getaddrinfo

### DIFF
--- a/src/modules/internet/Rsock.c
+++ b/src/modules/internet/Rsock.c
@@ -195,7 +195,6 @@ void in_Rsockwrite(int *sockp, char **buf, int *start, int *end, int *len)
 #include <sys/select.h>
 #endif
 
-//struct hostent *R_gethostbyname(const char *name);
 struct addrinfo *R_getaddrinfo(const char *name, int port);
 
 #ifdef Unix
@@ -661,18 +660,6 @@ ssize_t R_SockWrite(int sockp, const void *buf, size_t len, int timeout)
 	}
     } while (/* ! blocking && */len > 0);
     return out;
-}
-
-struct hostent *R_gethostbyname(const char *name)
-{
-    struct hostent *ans = gethostbyname(name);
-
-    /* hard-code IPv4 address for localhost to be robust against
-       misconfigured systems */
-
-    if (ans == NULL && !strcmp(name, "localhost"))
-	ans = gethostbyname("127.0.0.1");
-    return ans;
 }
 
 struct addrinfo *R_getaddrinfo(const char *name, int port)

--- a/src/modules/internet/sock.h
+++ b/src/modules/internet/sock.h
@@ -42,7 +42,8 @@ ssize_t Sock_write(int fd, const void *buf, size_t nbytes, Sock_error_t perr);
 #ifndef Win32
 # define SOCKET int
 #else
-# define FD_SETSIZE 1024
+# undef S /* both ws2tcpip.h and graphapp.h define macro S */
+# include<ws2tcpip.h>
 # include<winsock2.h>
 #endif
 


### PR DESCRIPTION
In both Linux and Windows, gethostbyname and gethostbyaddr are marked as obsolete: 

 - https://man7.org/linux/man-pages/man3/gethostbyname.3.html
 - https://docs.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-gethostbyname

POSIX.1-2008 removes the specifications of gethostbyname(), gethostbyaddr(), and h_errno, recommending the use of getaddrinfo(3) and getnameinfo(3) instead.

This will solve a bug that R does not account for the case where `gethostbyname()` returns an IPv6 address, depending on the local DNS server. If this happens, the connection will fail, because R only implements `AF_INET` and not `AF_INET6`.

https://github.com/r-devel/r-svn/blob/ae023a6018bdc73e3d4052180703b13e4cf3a503/src/modules/internet/Rsock.c#L420



The advantage of `getaddrinfo()` is that one can set in the `hints` parameter that we want an `ai_family = AF_INET;` address


