### PR TITLE
Account for WSAEWOULDBLOCK on recent mingw-w64

### DIFF
--- a/src/modules/internet/Rsock.c
+++ b/src/modules/internet/Rsock.c
@@ -425,6 +425,9 @@ int R_SockConnect(int port, char *host, int timeout)
 	switch (R_socket_errno()) {
 	case EINPROGRESS:
 	case EWOULDBLOCK:
+#if defined(WSAEWOULDBLOCK) && WSAEWOULDBLOCK != EWOULDBLOCK
+	case WSAEWOULDBLOCK:
+#endif
 #if !defined(Win32) && EAGAIN != EWOULDBLOCK
 	case EAGAIN:
 #endif
@@ -527,6 +530,9 @@ ssize_t R_SockRead(int sockp, void *buf, size_t len, int blocking, int timeout)
 	if (R_socket_error((int)res)) {
 	    switch(R_socket_errno()) {
 	    case EWOULDBLOCK:
+#if defined(WSAEWOULDBLOCK) && WSAEWOULDBLOCK != EWOULDBLOCK
+	case WSAEWOULDBLOCK:
+#endif
 #if !defined(Win32) && EAGAIN != EWOULDBLOCK
 	    case EAGAIN:
 #endif
@@ -605,6 +611,9 @@ int R_SockListen(int sockp, char *buf, int len, int timeout)
 		switch(perr.error) {
 		case EINPROGRESS:
 		case EWOULDBLOCK:
+#if defined(WSAEWOULDBLOCK) && WSAEWOULDBLOCK != EWOULDBLOCK
+	case WSAEWOULDBLOCK:
+#endif
 		case ECONNABORTED:
 #ifndef Win32
 # if EAGAIN != EWOULDBLOCK
@@ -651,6 +660,9 @@ ssize_t R_SockWrite(int sockp, const void *buf, size_t len, int timeout)
 	if (R_socket_error((int)res)) {
 	    switch(R_socket_errno()) {
 	    case EWOULDBLOCK:
+#if defined(WSAEWOULDBLOCK) && WSAEWOULDBLOCK != EWOULDBLOCK
+	case WSAEWOULDBLOCK:
+#endif
 #if !defined(Win32) && EAGAIN != EWOULDBLOCK
 	    case EAGAIN:
 #endif


### PR DESCRIPTION
## Summary 
This fixes a bug with non-blocking connections on Windows, for example `parallel::makeCluster()`. To reproduce the bug, you can either use a recent mingw-w64 version, or you can reproduce it using any older mingw-w64 toolchain by adding:

```
#include <errno.h>
```

to `src/modules/internet/Rsock.c`.

## Details

Windows has both `WSAEWOULDBLOCK` and `EWOULDBLOCK` and they are not the same. For non-blocking sockets it uses `WSAEWOULDBLOCK` (I think `EWOULDBLOCK` is not actually used much). However R does this:

https://github.com/r-devel/r-svn/blob/fcdc63d9462fee5e748c8d9358516530e252577d/src/modules/internet/Rsock.c#L176-L178

And then only checks for `EWOULDBLOCK` the code.

This happened to work by coincidence, because the R code does not `#include <errno.h>` and therefore `EWOULDBLOCK` is not defined, and gets the value of `WSAEWOULDBLOCK`.

However recent versions of mingw-w64 include `errno.h` by default via one of the other includes. Therefore `EWOULDBLOCK` is now pre-defined, and no longer equals `WSAEWOULDBLOCK`. The result is:

```r
library(parallel)
makeCluster(1)
## Error in makePSOCKcluster(names = spec, ...) : 
##   Cluster setup failed. 1 worker of 1 failed to connect.
```

The patch explicitly tests for `WSAEWOULDBLOCK` in the code. 
