### PR TITLE
remove CTEXT_POP() to fix octal parse data issue

### DIFF
--- a/src/main/gram.c
+++ b/src/main/gram.c
@@ -5022,11 +5022,9 @@ static int StringValue(int c, Rboolean forSymbol)
 			octal = 8 * octal + c - '0';
 		    } else {
 			xxungetc(c);
-			CTEXT_POP();
 		    }
 		} else {
 		    xxungetc(c);
-		    CTEXT_POP();
 		}
 		if (!octal)
 		    error(_("nul character not allowed (line %d)"), ParseState.xxlineno);

--- a/src/main/gram.y
+++ b/src/main/gram.y
@@ -2791,11 +2791,9 @@ static int StringValue(int c, Rboolean forSymbol)
 			octal = 8 * octal + c - '0';
 		    } else {
 			xxungetc(c);
-			CTEXT_POP();
 		    }
 		} else {
 		    xxungetc(c);
-		    CTEXT_POP();
 		}
 		if (!octal)
 		    error(_("nul character not allowed (line %d)"), ParseState.xxlineno);


### PR DESCRIPTION
bug: https://bugs.r-project.org/show_bug.cgi?id=18323