### PR TITLE
Change in graphics::persp documentation example codes owing to a bug report

### DIFF
--- a/src/library/graphics/man/persp.Rd
+++ b/src/library/graphics/man/persp.Rd
@@ -151,13 +151,14 @@ require(grDevices) # for trans3d
 
 x <- seq(-10, 10, length.out = 30)
 y <- x
-f <- function(x, y) { r <- sqrt(x^2+y^2); return(ifelse(is.na(sin(r)/r), 1, sin(r)/r)) }
+f <- function(x, y) { r <- sqrt(x^2+y^2); sin(r)/r }
 z <- outer(x, y, f)
 op <- par(bg = "white")
-persp(x, y, z, theta = 30, phi = 30, expand = 0.75, col = "lightblue")
-persp(x, y, z, theta = 30, phi = 30, expand = 0.75, col = "lightblue",
+persp(x, y, z, theta = 30, phi = 30, expand = 0.5, col = "lightblue")
+persp(x, y, z, theta = 30, phi = 30, expand = 0.5, col = "lightblue",
       ltheta = 120, shade = 0.75, ticktype = "detailed",
-      xlab = "X", ylab = "Y", zlab = "Sinc( r )"
+      xlab = "X", ylab = "Y", zlab = "Sinc( r )",
+      cex.axis = 0.62, cex.lab = 0.8
 ) -> res
 round(res, 3)
 

--- a/src/library/graphics/man/persp.Rd
+++ b/src/library/graphics/man/persp.Rd
@@ -151,12 +151,11 @@ require(grDevices) # for trans3d
 
 x <- seq(-10, 10, length.out = 30)
 y <- x
-f <- function(x, y) { r <- sqrt(x^2+y^2); 10 * sin(r)/r }
+f <- function(x, y) { r <- sqrt(x^2+y^2); return(ifelse(is.na(sin(r)/r), 1, sin(r)/r)) }
 z <- outer(x, y, f)
-z[is.na(z)] <- 1
 op <- par(bg = "white")
-persp(x, y, z, theta = 30, phi = 30, expand = 0.5, col = "lightblue")
-persp(x, y, z, theta = 30, phi = 30, expand = 0.5, col = "lightblue",
+persp(x, y, z, theta = 30, phi = 30, expand = 0.75, col = "lightblue")
+persp(x, y, z, theta = 30, phi = 30, expand = 0.75, col = "lightblue",
       ltheta = 120, shade = 0.75, ticktype = "detailed",
       xlab = "X", ylab = "Y", zlab = "Sinc( r )"
 ) -> res
@@ -165,8 +164,8 @@ round(res, 3)
 # (2) Add to existing persp plot - using trans3d() :
 
 xE <- c(-10,10); xy <- expand.grid(xE, xE)
-points(trans3d(xy[,1], xy[,2], 6, pmat = res), col = 2, pch = 16)
-lines (trans3d(x, y = 10, z = 6 + sin(x), pmat = res), col = 3)
+points(trans3d(xy[,1], xy[,2], 0.6, pmat = res), col = 2, pch = 16)
+lines (trans3d(x, y = 10, z = 0.6 + sin(x)/10, pmat = res), col = 3)
 
 phi <- seq(0, 2*pi, length.out = 201)
 r1 <- 7.725 # radius of 2nd maximum


### PR DESCRIPTION
This is a change in documentation, owing to the bug report at https://bugs.r-project.org/show_bug.cgi?id=17699. Changes made:
- modify the function f so that it does not return NAs
- remove the scale of the function f
- modify the expand parameter of persp to better represent the changes in the graph
- modify the z-axis values of trans3d in both points and lines