### PR TITLE
Fix three issues with ALTREP lists

### DIFF
--- a/src/main/altclasses.c
+++ b/src/main/altclasses.c
@@ -1963,7 +1963,8 @@ static SEXP wrap_meta(SEXP x, int srt, int no_na)
     case LGLSXP:
     case CPLXSXP:
     case RAWSXP:
-    case STRSXP: break;
+    case STRSXP:
+    case VECSXP: break;
     default: return x;
     }
 

--- a/src/main/memory.c
+++ b/src/main/memory.c
@@ -82,8 +82,8 @@
 #endif
 
 /* For speed in cases when the argument is known to not be an ALTREP list. */
-#define VECTOR_ELT_0(x,i)        ((SEXP *) DATAPTR(x))[i]
-#define SET_VECTOR_ELT_0(x,i, v) (((SEXP *) DATAPTR(x))[i] = (v))
+#define VECTOR_ELT_0(x,i)        ((SEXP *) STDVEC_DATAPTR(x))[i]
+#define SET_VECTOR_ELT_0(x,i, v) (((SEXP *) STDVEC_DATAPTR(x))[i] = (v))
 
 #define R_USE_SIGNALS 1
 #include <Defn.h>

--- a/src/main/memory.c
+++ b/src/main/memory.c
@@ -4102,12 +4102,15 @@ SEXP (SET_VECTOR_ELT)(SEXP x, R_xlen_t i, SEXP v) {
     if (i < 0 || i >= XLENGTH(x))
 	error(_("attempt to set index %lld/%lld in SET_VECTOR_ELT"),
 	      (long long)i, (long long)XLENGTH(x));
-    FIX_REFCNT(x, VECTOR_ELT_0(x, i), v);
-    CHECK_OLD_TO_NEW(x, v);
-    if (ALTREP(x))
+    if (ALTREP(x)) {
+        FIX_REFCNT(x, VECTOR_ELT(x, i), v);
+        CHECK_OLD_TO_NEW(x, v);
         ALTLIST_SET_ELT(x, i, v);
-    else
+    } else {
+        FIX_REFCNT(x, VECTOR_ELT_0(x, i), v);
+        CHECK_OLD_TO_NEW(x, v);
         SET_VECTOR_ELT_0(x, i, v);
+    }
     return v;
 }
 


### PR DESCRIPTION
- The `VECTOR_ELT_0` and `SET_VECTOR_ELT_0` macros need to use `STDVEC_DATAPTR` to avoid the ALTREP dispatch.
- `SET_VECTOR_ELT()` needs to use `VECTOR_ELT()` and not `VECTOR_ELT_0()` when adjusting the refcount of the element that was removed.
- Make VECSXP also wrappable in `wrap_meta()`.