### PR TITLE
Allow Dataptr_or_null method in ALTLIST classes

### DIFF
--- a/src/main/altclasses.c
+++ b/src/main/altclasses.c
@@ -1963,7 +1963,8 @@ static SEXP wrap_meta(SEXP x, int srt, int no_na)
     case LGLSXP:
     case CPLXSXP:
     case RAWSXP:
-    case STRSXP: break;
+    case STRSXP:
+    case VECSXP: break;
     default: return x;
     }
 

--- a/src/main/altclasses.c
+++ b/src/main/altclasses.c
@@ -1891,6 +1891,11 @@ static void InitWrapListClass(DllInfo *dll)
     R_set_altrep_Inspect_method(cls, wrapper_Inspect);
     R_set_altrep_Length_method(cls, wrapper_Length);
 
+    /* override ALTVEC methods */
+    R_set_altvec_Dataptr_method(cls, wrapper_Dataptr);
+    R_set_altvec_Dataptr_or_null_method(cls, wrapper_Dataptr_or_null);
+    R_set_altvec_Extract_subset_method(cls, wrapper_Extract_subset);
+
     /* override ALTLIST methods */
     R_set_altlist_Elt_method(cls, wrapper_list_Elt);
     R_set_altlist_Set_elt_method(cls, wrapper_list_Set_elt);

--- a/src/main/memory.c
+++ b/src/main/memory.c
@@ -82,8 +82,8 @@
 #endif
 
 /* For speed in cases when the argument is known to not be an ALTREP list. */
-#define VECTOR_ELT_0(x,i)        ((SEXP *) DATAPTR(x))[i]
-#define SET_VECTOR_ELT_0(x,i, v) (((SEXP *) DATAPTR(x))[i] = (v))
+#define VECTOR_ELT_0(x,i)        ((SEXP *) STDVEC_DATAPTR(x))[i]
+#define SET_VECTOR_ELT_0(x,i, v) (((SEXP *) STDVEC_DATAPTR(x))[i] = (v))
 
 #define R_USE_SIGNALS 1
 #include <Defn.h>

--- a/src/main/memory.c
+++ b/src/main/memory.c
@@ -4102,12 +4102,15 @@ SEXP (SET_VECTOR_ELT)(SEXP x, R_xlen_t i, SEXP v) {
     if (i < 0 || i >= XLENGTH(x))
 	error(_("attempt to set index %lld/%lld in SET_VECTOR_ELT"),
 	      (long long)i, (long long)XLENGTH(x));
-    FIX_REFCNT(x, VECTOR_ELT_0(x, i), v);
-    CHECK_OLD_TO_NEW(x, v);
-    if (ALTREP(x))
+    if (ALTREP(x)) {
+        FIX_REFCNT(x, VECTOR_ELT(x, i), v);
+        CHECK_OLD_TO_NEW(x, v);
         ALTLIST_SET_ELT(x, i, v);
-    else
+    } else {
+        FIX_REFCNT(x, VECTOR_ELT_0(x, i), v);
+        CHECK_OLD_TO_NEW(x, v);
         SET_VECTOR_ELT_0(x, i, v);
+    }
     return v;
 }
 


### PR DESCRIPTION
This can be very useful to iterate over an ALTLIST
very quickly. For example, in an ALTLIST class
that implements a sublist, no copying is needed.

This method always returns a const pointer, so
it cannot be used to change the list.