### PR TITLE
fix matrixOps signature in tools pkg checks

### DIFF
--- a/src/library/tools/R/utils.R
+++ b/src/library/tools/R/utils.R
@@ -1746,7 +1746,7 @@ function(parent = parent.frame())
            envir = env)
     assign("Ops", function(e1, e2) UseMethod("Ops"),
            envir = env)
-    assign("matrixOps", function(e1, e2) UseMethod("matrixOps"),
+    assign("matrixOps", function(x, y) UseMethod("matrixOps"),
            envir = env)
     assign("Summary", function(..., na.rm = FALSE) UseMethod("Summary"),
            envir = env)


### PR DESCRIPTION
Updates the signature of the matrixOps generic in the tools static analysis routines to the actual signature of matrixOps as it is documented, from `e1, e2` to `x, y`.

Otherwise, defining a `matrixOps.foo <- function(x, y) {....}` method causes an R CMD check warning like this:
```
W  checking S3 generic/method consistency ...
   matrixOps:
     function(e1, e2)
   matrixOps.S7_object:
     function(x, y)
   See section ‘Generic functions and methods’ in the ‘Writing R
   Extensions’ manual.
```

As seen in https://github.com/RConsortium/OOP-WG/pull/328