### PR TITLE
base: use a symlink for which instead of hard-coded path

### DIFF
--- a/share/make/basepkg.mk
+++ b/share/make/basepkg.mk
@@ -72,15 +72,15 @@ mkRbase:
 	  else \
 	    cat $(RSRC) > "$${f}"; \
 	  fi; \
-	  f2=$${TMPDIR:-/tmp}/R2$$$$; \
-	  sed -e "s:@WHICH@:${WHICH}:" "$${f}" > "$${f2}"; \
-	  rm -f "$${f}"; \
-	  $(SHELL) $(top_srcdir)/tools/move-if-change "$${f2}" all.R)
+	  $(SHELL) $(top_srcdir)/tools/move-if-change "$${f}" all.R)
 	@if ! test -f $(top_builddir)/library/$(pkg)/R/$(pkg); then \
 	  $(INSTALL_DATA) all.R $(top_builddir)/library/$(pkg)/R/$(pkg); \
 	else if test all.R -nt $(top_builddir)/library/$(pkg)/R/$(pkg); then \
 	  $(INSTALL_DATA) all.R $(top_builddir)/library/$(pkg)/R/$(pkg); \
 	  fi \
+	fi
+	@if ! test -f $(top_builddir)/library/$(pkg)/R/which; then \
+	  cd $(top_builddir)/library/$(pkg)/R/ && $(LN_S) $(WHICH) which; \
 	fi
 
 mkdesc:

--- a/src/library/base/R/unix/system.unix.R
+++ b/src/library/base/R/unix/system.unix.R
@@ -114,9 +114,9 @@ system2 <- function(command, args = character(),
 Sys.which <- function(names)
 {
     res <- character(length(names)); names(res) <- names
-    ## hopefully configure found [/usr]/bin/which
-    which <- "@WHICH@"
-    if (!nzchar(which)) {
+    which <- file.path(R.home(), "library", "base", "R", "which")
+    ## which should be a symlink to the system's which
+    if (!file.exists(which)) {
         warning("'which' was not found on this platform")
         return(res)
     }


### PR DESCRIPTION
R hard-codes the path to the `which` executable inside bytecode, which is
stored in a compressed format.

This makes it very hard to relocate R itself at a later stage, or update the
path to `which` if it ever moves on the system.

This patch creates a symlink `rlib/R/library/base/R/which ->`
`/path/to/bin/which` so it's easier to relocate R / which, as you can just
modify a symlink instead of dealing with `base.rdb` and `base.rdx` files.

