### PR TITLE
Use single curl multi handle to re-use connections

### DIFF
--- a/src/modules/internet/libcurl.c
+++ b/src/modules/internet/libcurl.c
@@ -565,8 +565,8 @@ static void download_cleanup(void *data)
 	if (c->hnd && c->hnd[i])
 	    curl_easy_cleanup(c->hnd[i]);
     }
-    if (c->mhnd)
-	curl_multi_cleanup(c->mhnd);
+    //if (c->mhnd)
+	//curl_multi_cleanup(c->mhnd);
     if (c->headers)
 	curl_slist_free_all(c->headers);
 
@@ -668,7 +668,11 @@ in_do_curlDownload(SEXP call, SEXP op, SEXP args, SEXP rho)
 	c.headers = headers = tmp;
     }
 
-    CURLM *mhnd = curl_multi_init();
+    static CURLM *mhnd = NULL;
+    if(!mhnd) {
+      //REprintf("Creating new multi handle!\n");
+      mhnd = curl_multi_init();
+    }
     if (!mhnd)
 	error(_("could not create curl handle"));
     c.mhnd = mhnd;


### PR DESCRIPTION
This is a minimal proof of concept patch to test the performance implications of using a shared curl "multi-handle" to re-use http connections for multiple downloads to the same server (hence avoiding repeated TLS handshakes).

A more extensive patch, which includes cleaning up all connections when R quits, is available in #166

Quick benchmark:

```r
options(repos=c(CRAN='https://cloud.r-project.org'))
x <- available.packages()
pkgs <- row.names(x)[1:100]
system.time(download.packages(pkgs, tempdir(), available = x))
```

Before:

```
   user  system elapsed
 15.212   1.113  24.098
```

After:

```
   user  system elapsed
  0.327   0.521   1.661
```