### PR TITLE
Use pkgconf from Rtools44

### DIFF
--- a/src/gnuwin32/MkRules.rules
+++ b/src/gnuwin32/MkRules.rules
@@ -19,25 +19,18 @@ RC_ARCH ?=
 DT_ARCH ?=
 ## only WIN=64 is supported from R 4.2.0
 WIN ?= 64
+
+## Rtools44 and up include pkgconf
+PKG_CONFIG ?= pkgconf
 USE_ICU ?= YES
 ICU_PATH ?= 
-ICU_LIBS ?= -lsicuin -lsicuuc $(EXT_LIBS)/lib/sicudt.a -lstdc++
-# (dynamic linking) ICU_LIBS ?= -licuin -licuuc -licudt -lstdc++
+ICU_LIBS ?= $(shell $(PKG_CONFIG) --libs icu-i18n)
 USE_CAIRO ?= YES
-CAIRO_CPPFLAGS ?= "-I$(EXT_LIBS)/include/cairo -I$(EXT_LIBS)/include/freetype2 -DCAIRO_WIN32_STATIC_BUILD"
-## support freetype, curl built with libbrotli and without
-LIBBROTLI = $(or $(and $(wildcard $(EXT_LIBS)/lib/libbrotlidec.a),-lbrotlidec -lbrotlicommon),)
-## support curl built with libpsl and without
-LIBPSL = $(or $(and $(wildcard $(EXT_LIBS)/lib/libpsl.a),-lpsl),)
-CAIRO_LIBS ?= "-lcairo -lfontconfig -lfreetype -lpng -lpixman-1 -lexpat -lharfbuzz \
-              -lbz2 -lintl -lz -liconv -luuid -lstdc++ -lgdi32 -lmsimg32 -lole32 \
-              $(LIBBROTLI)"
+CAIRO_CPPFLAGS ?= "$(shell $(PKG_CONFIG) --cflags --static cairo)"
+CAIRO_LIBS ?= "$(shell $(PKG_CONFIG) --libs cairo)"
 CURL_CA_BUNDLE ?=
 USE_LIBCURL = yes
-CURL_LIBS ?= -lcurl $(LIBPSL) -lbcrypt -lzstd -lrtmp -lssl -lssh2 -lbcrypt -lgcrypt \
-             -lcrypto -lgdi32 -lz \
-             -lws2_32 -lgdi32 -lcrypt32 -lidn2 -lunistring -liconv -lgpg-error -lwldap32 \
-             -lwinmm $(LIBBROTLI)
+CURL_LIBS ?= $(shell $(PKG_CONFIG) --libs libcurl)
 
 BUILD_HTML ?= NO
 MIKTEX ?= TRUE


### PR DESCRIPTION
Given that base R now [requires rtools44](https://github.com/r-devel/r-svn/commit/85be5dbfb6ac585ff41ffe1b9b251a81ae9572aa) to build, we can take advantage of pkgconf and remove some hardcoded flags. This makes the code more portable for other toolchains, including future versions of rtools.