### PR TITLE
[Bugzilla#17289] Error in scan() for string NA when na.strings is empty

### DIFF
--- a/src/main/scan.c
+++ b/src/main/scan.c
@@ -522,8 +522,8 @@ static void extractItem(char *buffer, SEXP ans, R_xlen_t i, LocalData *d)
 	if (isNAstring(buffer, 0, d))
 	    REAL(ans)[i] = NA_REAL;
 	else {
-	    REAL(ans)[i] = Strtod(buffer, &endp, TRUE, d);
-	    if (!isBlankString(endp))
+	    REAL(ans)[i] = Strtod(buffer, &endp, FALSE, d);
+	    if (!isBlankString(endp) || REAL(ans)[i] == NA_REAL)
 		expected("a real", buffer, d);
 	}
 	break;

--- a/tests/reg-tests-1e.R
+++ b/tests/reg-tests-1e.R
@@ -1332,7 +1332,8 @@ stopifnot(exprs = {
 })
 ## as.raw(rl) and as.integer(rl) failed in R <= 4.4.x
 
-
+stopifnot("'NA' shouldn't parse as NA if it's missing from na.strings in scan()" =
+          tryCatch(scan(text="NA", what=double(), na.strings=character(), quiet=TRUE), error = \(c) TRUE))
 
 ## keep at end
 rbind(last =  proc.time() - .pt,


### PR DESCRIPTION
https://bugs.r-project.org/show_bug.cgi?id=17289