### PR TITLE
Use shared curl multi handle with cleanup on exit

### DIFF
--- a/src/gnuwin32/embeddedR.c
+++ b/src/gnuwin32/embeddedR.c
@@ -141,6 +141,7 @@ void Rf_endEmbeddedR(int fatal)
 {
     R_RunExitFinalizers();
     CleanEd();
+    CurlCleanup();
     R_CleanTempDir();
     if(!fatal){
 	Rf_KillAllDevices();

--- a/src/gnuwin32/system.c
+++ b/src/gnuwin32/system.c
@@ -603,6 +603,7 @@ static void Rstd_CleanUp(SA_TYPE saveact, int status, int runLast)
     CleanEd();
     KillAllDevices(); /* Unix does not do this under SA_SUICIDE */
     AllDevicesKilled = TRUE; /* used in devWindows.c to inhibit callbacks */
+    CurlCleanup();
     R_CleanTempDir(); /* changes directory */
     if (R_Interactive && CharacterMode == RTerm)
 	SetConsoleTitle(oldtitle);

--- a/src/include/Defn.h
+++ b/src/include/Defn.h
@@ -2294,6 +2294,7 @@ SEXP fixup_NaRm(SEXP args); /* summary.c */
 void invalidate_cached_recodings(void);  /* from sysutils.c */
 void resetICUcollator(Rboolean disable); /* from util.c */
 void dt_invalidate_locale(void); /* from Rstrptime.h */
+extern void CurlCleanup(void); /* from internet.c */
 extern int R_OutputCon; /* from connections.c */
 extern int R_InitReadItemDepth, R_ReadItemDepth; /* from serialize.c */
 void get_current_mem(size_t *,size_t *,size_t *); /* from memory.c */

--- a/src/include/Rmodules/Rinternet.h
+++ b/src/include/Rmodules/Rinternet.h
@@ -45,6 +45,7 @@ typedef int    (*R_HTTPDCreateRoutine)(const char *ip, int port);
 typedef void   (*R_HTTPDStopRoutine)(void);
 
 typedef SEXP (*R_CurlRoutine)(SEXP call, SEXP op, SEXP args, SEXP rho);
+typedef void   (*R_CurlCleanupRoutine)(void);
 
 typedef struct {
     R_DownloadRoutine download;
@@ -67,6 +68,7 @@ typedef struct {
     R_CurlRoutine curlVersion;
     R_CurlRoutine curlGetHeaders;
     R_CurlRoutine curlDownload;
+    R_CurlCleanupRoutine curlCleanup;
     R_NewUrlRoutine   newcurlurl;
 } R_InternetRoutines;
 

--- a/src/main/internet.c
+++ b/src/main/internet.c
@@ -285,6 +285,15 @@ attribute_hidden SEXP do_curlDownload(SEXP call, SEXP op, SEXP args, SEXP rho)
     }
 }
 
+void CurlCleanup(void)
+{
+    if(!initialized) internet_Init();
+    if(initialized > 0)
+    (*ptr->curlCleanup)();
+    else
+    error(_("internet routines cannot be loaded"));
+}
+
 Rconnection attribute_hidden
 R_newCurlUrl(const char *description, const char * const mode, SEXP headers, int type)
 {

--- a/src/modules/internet/internet.c
+++ b/src/modules/internet/internet.c
@@ -39,6 +39,7 @@ typedef int_fast64_t DLsize_t; // used for download lengths and sizes
 SEXP in_do_curlVersion(SEXP call, SEXP op, SEXP args, SEXP rho);
 SEXP in_do_curlGetHeaders(SEXP call, SEXP op, SEXP args, SEXP rho);
 SEXP in_do_curlDownload(SEXP call, SEXP op, SEXP args, SEXP rho);
+void in_curlCleanup(void);
 Rconnection
 in_newCurlUrl(const char *description, const char * const mode, SEXP headers, int type);
 
@@ -729,6 +730,7 @@ R_init_internet(DllInfo *info)
     tmp->curlVersion = in_do_curlVersion;
     tmp->curlGetHeaders = in_do_curlGetHeaders;
     tmp->curlDownload = in_do_curlDownload;
+    tmp->curlCleanup = in_curlCleanup;
     tmp->newcurlurl =  in_newCurlUrl;
 
     R_setInternetRoutines(tmp);

--- a/src/unix/Rembedded.c
+++ b/src/unix/Rembedded.c
@@ -70,6 +70,7 @@ void Rf_endEmbeddedR(int fatal)
     R_RunExitFinalizers();
     CleanEd();
     if(!fatal) KillAllDevices();
+    CurlCleanup();
     R_CleanTempDir();
     if(!fatal && R_CollectWarnings)
 	PrintWarnings();	/* from device close and .Last */

--- a/src/unix/sys-std.c
+++ b/src/unix/sys-std.c
@@ -1242,6 +1242,7 @@ void Rstd_CleanUp(SA_TYPE saveact, int status, int runLast)
     R_RunExitFinalizers();
     CleanEd();
     if(saveact != SA_SUICIDE) KillAllDevices();
+    CurlCleanup();
     R_CleanTempDir();
     if(saveact != SA_SUICIDE && R_CollectWarnings)
 	PrintWarnings();	/* from device close and (if run) .Last */


### PR DESCRIPTION
This is a more extensive version of #155, with a hook to cleanup libcurl when R quits.

