### PR TITLE
Use LOGICAL_RO() instead of LOGICAL() in copyVector() to avoid ALTREP materialization

### DIFF
--- a/src/main/duplicate.c
+++ b/src/main/duplicate.c
@@ -382,23 +382,23 @@ void copyVector(SEXP s, SEXP t)
 	xcopyStringWithRecycle(s, t, 0, ns, nt);
 	break;
     case LGLSXP:
-	xcopyLogicalWithRecycle(LOGICAL(s), LOGICAL(t), 0, ns, nt);
+	xcopyLogicalWithRecycle(LOGICAL(s), LOGICAL_RO(t), 0, ns, nt);
 	break;
     case INTSXP:
-	xcopyIntegerWithRecycle(INTEGER(s), INTEGER(t), 0, ns, nt);
+	xcopyIntegerWithRecycle(INTEGER(s), INTEGER_RO(t), 0, ns, nt);
 	break;
     case REALSXP:
-	xcopyRealWithRecycle(REAL(s), REAL(t), 0, ns, nt);
+	xcopyRealWithRecycle(REAL(s), REAL_RO(t), 0, ns, nt);
 	break;
     case CPLXSXP:
-	xcopyComplexWithRecycle(COMPLEX(s), COMPLEX(t), 0, ns, nt);
+	xcopyComplexWithRecycle(COMPLEX(s), COMPLEX_RO(t), 0, ns, nt);
 	break;
     case EXPRSXP:
     case VECSXP:
 	xcopyVectorWithRecycle(s, t, 0, ns, nt);
 	break;
     case RAWSXP:
-	xcopyRawWithRecycle(RAW(s), RAW(t), 0, ns, nt);
+	xcopyRawWithRecycle(RAW(s), RAW_RO(t), 0, ns, nt);
 	break;
     default:
 	UNIMPLEMENTED_TYPE("copyVector", s);
@@ -486,7 +486,7 @@ void copyMatrix(SEXP s, SEXP t, Rboolean byrow)
 
 #define COPY_WITH_RECYCLE(VALTYPE, TNAME) \
 attribute_hidden void \
-xcopy##TNAME##WithRecycle(VALTYPE *dst, VALTYPE *src, R_xlen_t dstart, R_xlen_t n, R_xlen_t nsrc) { \
+xcopy##TNAME##WithRecycle(VALTYPE *dst, const VALTYPE *src, R_xlen_t dstart, R_xlen_t n, R_xlen_t nsrc) { \
 							\
     if (nsrc >= n) { /* no recycle needed */		\
 	for(R_xlen_t i = 0; i < n; i++)		\

--- a/src/main/duplicate.h
+++ b/src/main/duplicate.h
@@ -42,11 +42,11 @@ Iterator macro to fill a matrix from a vector with re-use of vector
             (sidx >= nsrc) ? sidx -= nsrc : 0,				\
             didx += drows)
 
-void xcopyComplexWithRecycle(Rcomplex *dst, Rcomplex *src, R_xlen_t dstart, R_xlen_t n, R_xlen_t nsrc);
-void xcopyIntegerWithRecycle(int *dst, int *src, R_xlen_t dstart, R_xlen_t n, R_xlen_t nsrc);
-void xcopyLogicalWithRecycle(int *dst, int *src, R_xlen_t dstart, R_xlen_t n, R_xlen_t nsrc);
-void xcopyRawWithRecycle(Rbyte *dst, Rbyte *src, R_xlen_t dstart, R_xlen_t n, R_xlen_t nsrc);
-void xcopyRealWithRecycle(double *dst, double *src, R_xlen_t dstart, R_xlen_t n, R_xlen_t nsrc);
+void xcopyComplexWithRecycle(Rcomplex *dst, const Rcomplex *src, R_xlen_t dstart, R_xlen_t n, R_xlen_t nsrc);
+void xcopyIntegerWithRecycle(int *dst, const int *src, R_xlen_t dstart, R_xlen_t n, R_xlen_t nsrc);
+void xcopyLogicalWithRecycle(int *dst, const int *src, R_xlen_t dstart, R_xlen_t n, R_xlen_t nsrc);
+void xcopyRawWithRecycle(Rbyte *dst, const Rbyte *src, R_xlen_t dstart, R_xlen_t n, R_xlen_t nsrc);
+void xcopyRealWithRecycle(double *dst, const double *src, R_xlen_t dstart, R_xlen_t n, R_xlen_t nsrc);
 void xcopyStringWithRecycle(SEXP dst, SEXP src, R_xlen_t dstart, R_xlen_t n, R_xlen_t nsrc);
 void xcopyVectorWithRecycle(SEXP dst, SEXP src, R_xlen_t dstart, R_xlen_t n, R_xlen_t nsrc);
 


### PR DESCRIPTION
https://github.com/r-devel/r-dev-day/issues/23