### PR TITLE
Bug 18674 tools::toTitleCase() 

### DIFF
--- a/src/library/tools/R/utils.R
+++ b/src/library/tools/R/utils.R
@@ -2688,6 +2688,8 @@ function(text)
         ## do not remove capitalization immediately after ": " or "- "
         ind <- grep("[-:]$", xx); ind <- ind[ind + 2L <= length(l)]
         ind <- ind[(xx[ind + 1L] == " ") & grepl("^['[:alnum:]]", xx[ind + 2L])]
+        # don't capitalize lpat words after hyphenation
+        ind <- ind[!(xx[ind] == "-" & grepl(lpat, xx[ind + 2L]))]
         l[ind + 2L] <- FALSE
         ## Also after " (e.g. "A Book Title")
         ind <- which(xx == '"'); ind <- ind[ind + 1L <= length(l)]

--- a/src/library/tools/man/toTitleCase.Rd
+++ b/src/library/tools/man/toTitleCase.Rd
@@ -18,7 +18,7 @@ toTitleCase(text)
 \details{
   This is intended for English text only.
 
-  No definition of\sQuote{title case} is universally accepted: all agree
+  No definition of \sQuote{title case} is universally accepted: all agree
   that \sQuote{principal} words are capitalized and common words like
   \sQuote{for} are not, but not which words fall into each category.
 
@@ -32,4 +32,8 @@ toTitleCase(text)
 }
 \value{
   A character vector of the same length as \code{text}, without names.
+}
+\examples{
+toTitleCase("bayesian network modeling and analysis")
+toTitleCase("ensemble tool for predictions from species distribution models")
 }

--- a/tests/reg-tests-1e.R
+++ b/tests/reg-tests-1e.R
@@ -1399,6 +1399,11 @@ ch0 <- character(0L)
 stopifnot(identical(ch0, tools::toTitleCase(ch0)))
 ## was list() in R <= 4.4.0
 
+## Bug 18674 - tools::toTitleCase() incorrectly capitalizes conjunctions
+## (e.g. 'and') when using suspensive hyphenation
+stopifnot(identical(tools::toTitleCase("pre and post estimation"), "Pre and Post Estimation"))
+stopifnot(identical(tools::toTitleCase("pre- and post estimation"), "Pre- and Post Estimation"))
+
 
 ## PR#18745 (+ PR#18702)   format.data.frame() -> as.data.frame.list()
 x <- setNames(data.frame(TRUE), NA_character_)


### PR DESCRIPTION
Bug 18674 tools::toTitleCase() incorrectly capitalizes conjunctions (e.g. 'and') when using suspensive hyphenation corrected.

Also fixed spacing in documentation, added two examples in documentation, and added two tests for the fix.