### PR TITLE
Add comma as a splitting token in toTitleCase()

### DIFF
--- a/src/library/tools/R/utils.R
+++ b/src/library/tools/R/utils.R
@@ -2678,7 +2678,7 @@ function(text)
             else paste0(toupper(x1), tolower(substring(x, 2L)))
         }
         if(is.na(x)) return(NA_character_)
-        xx <- .Call(C_splitString, x, ' -/"()\n\t')
+        xx <- .Call(C_splitString, x, ' -/"()\n\t,')
         ## for 'alone' we could insist on that exact capitalization
         alone <- xx %in% c(alone, either)
         alone <- alone | grepl("^'.*'$", xx)

--- a/tests/reg-tests-1e.R
+++ b/tests/reg-tests-1e.R
@@ -1399,6 +1399,11 @@ ch0 <- character(0L)
 stopifnot(identical(ch0, tools::toTitleCase(ch0)))
 ## was list() in R <= 4.4.0
 
+## toTitleCase("'PROTECTED',")
+stopifnot(identical(
+  tools::toTitleCase("'SPSS', 'Stata' and 'R' are statistical software"),
+  "'SPSS', 'Stata' and 'R' are Statistical Software"
+))
 
 ## PR#18745 (+ PR#18702)   format.data.frame() -> as.data.frame.list()
 x <- setNames(data.frame(TRUE), NA_character_)


### PR DESCRIPTION
`tools::toTitleCase()` documentation indicates that words surrounded by single quotes are protected from change:

> However, unknown technical terms will be capitalized unless they are single words enclosed in single quotes: names of packages and libraries should be quoted in titles.

But this doesn't work when the quoted word is immediately followed by a comma:

``` r
tools::toTitleCase("Import and Export 'SPSS', 'Stata' and 'SAS' Files")
#> [1] "Import and Export 'Spss', 'Stata' and 'SAS' Files"

tools::toTitleCase("Import and Export 'SPSS' 'Stata' and 'SAS' Files")
#> [1] "Import and Export 'SPSS' 'Stata' and 'SAS' Files"
```

<sup>Created on 2024-07-12 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>

The proposed patch fixes this by adding the comma to the splitting tokens.

I have verified on my local library on 1400 R packages that this does not cause any unexpected changes when applied to their `Title` field in `DESCRIPTION`.

This is the result of a collaboration with @sarahzeller @shannonpileggi @reikookamoto at the R Dev Day PLUS 2024.

Once checks have been confirmed passing, I will submit this report & patch proposal as a new bugzilla entry.