### PR TITLE
[Bugzilla#18786] make showMethods() display a syntactic name

### DIFF
--- a/src/library/methods/R/show.R
+++ b/src/library/methods/R/show.R
@@ -109,6 +109,7 @@ show <- function(object) showDefault(object)
                       nam %in% names(.getNamespaceInfo(ns, "exports"))
                   showGen <- if(exported) nam # was dQuote(nam, NULL)
                              else paste(pkg, nam, sep=":::")
+                  if (make.names(showGen) != showGen) showGen <- paste0("`", showGen, "`")
                   cat("Methods may be defined for arguments: ",
                       paste0(object@signature, collapse=", "), "\n",
                       "Use  showMethods(", showGen,

--- a/tests/reg-S4.R
+++ b/tests/reg-S4.R
@@ -888,3 +888,6 @@ setClass("foo")
 sealClass("foo") # failed in R < 4.5.0
 stopifnot(isSealedClass("foo"))
 stopifnot(removeClass("foo"))
+
+# show(<non-syntactic name>) should recommend backticks for showMethods()
+stopifnot(any(grepl("showMethods(`body<-`)", capture.output(show(`body<-`)), fixed=TRUE)))

--- a/tests/reg-S4.Rout.save
+++ b/tests/reg-S4.Rout.save
@@ -1187,3 +1187,6 @@ class(from) <- "foo"
 > stopifnot(isSealedClass("foo"))
 > stopifnot(removeClass("foo"))
 > 
+> # show(<non-syntactic name>) should recommend backticks for showMethods()
+> stopifnot(any(grepl("showMethods(`body<-`)", capture.output(show(`body<-`)), fixed=TRUE)))
+>


### PR DESCRIPTION
https://bugs.r-project.org/show_bug.cgi?id=18786