### PR TITLE
[Bugzilla#18796] Try do.call(c, ans) instead of unlist() in tapply(simplify=TRUE)

### DIFF
--- a/src/library/base/R/tapply.R
+++ b/src/library/base/R/tapply.R
@@ -50,7 +50,7 @@ tapply <- function (X, INDEX, FUN = NULL, ..., default = NA, simplify = TRUE)
     ans <- lapply(X = ans[index], FUN = FUN, ...)
     ansmat <- array(
 	if (simplify && all(lengths(ans) == 1L)) {
-	    ans <- unlist(ans, recursive = FALSE, use.names = FALSE)
+	    ans <- do.call(c, ans)
 	    if(is.na(default) && is.atomic(ans))
 		vector(typeof(ans))
 	    else default


### PR DESCRIPTION
https://bugs.r-project.org/show_bug.cgi?id=18796

Not sure all the subtle ways `unlist(., recursive=FALSE, use.names=FALSE)` might differ from `do.call(c, .)` besides method dispatch, but the method dispatch part at least WAI:

```r
ans <- list(as.difftime(1, units='secs'), as.difftime(3, units='hours'))

unlist(ans)
# [1] 1 3

do.call(c, ans)
# Time differences in secs
# [1]     1 10800
```