### PR TITLE
Simplify format.POSIXlt() to improve bugzilla issue 17350

### DIFF
--- a/src/library/base/R/datetime.R
+++ b/src/library/base/R/datetime.R
@@ -384,12 +384,19 @@ format.POSIXlt <- function(x, format = "", usetz = FALSE,
     if(!inherits(x, "POSIXlt")) stop("wrong class")
     if(any(f0 <- format == "" | grepl("%OS$", format))) {
         ## need list [ method here.
-        times <- unlist(unclass(x)[1L:3L])[f0]
+    times <- unlist(unclass(x)[1L:3L])[f0]
+    secs <- x$sec[f0]; secs <- secs[is.finite(secs)]
         np <- if(is.null(digits)) 0L else min(6L, digits)
-        format[f0] <-
-            if(all(times[is.finite(times)] == 0)) "%Y-%m-%d"
-            else if(np == 0L) "%Y-%m-%d %H:%M:%S"
-            else paste0("%Y-%m-%d %H:%M:%OS", np)
+        if(np >= 1L) # no unnecessary trailing '0' :
+            for (i in seq_len(np)- 1L)
+                if(all( abs(secs - trunc(secs*10^i)/10^i) < 1e-6 )) {
+                    np <- i
+                    break
+                }
+    format[f0] <-
+        if(all(times[is.finite(times)] == 0)) "%Y-%m-%d"
+        else if(np == 0L) "%Y-%m-%d %H:%M:%S"
+        else paste0("%Y-%m-%d %H:%M:%OS", np)
     }
     .Internal(format.POSIXlt(x, format, usetz))
 }

--- a/src/library/base/R/datetime.R
+++ b/src/library/base/R/datetime.R
@@ -382,7 +382,7 @@ format.POSIXlt <- function(x, format = "", usetz = FALSE,
                            digits = getOption("digits.secs"), ...)
 {
     if(!inherits(x, "POSIXlt")) stop("wrong class")
-    if(any(f0 <- format == "")) {
+    if(any(f0 <- format == "" | grepl("%OS$", format))) {
         ## need list [ method here.
         times <- unlist(unclass(x)[1L:3L])[f0]
         np <- if(is.null(digits)) 0L else min(6L, digits)

--- a/src/library/base/R/datetime.R
+++ b/src/library/base/R/datetime.R
@@ -384,19 +384,12 @@ format.POSIXlt <- function(x, format = "", usetz = FALSE,
     if(!inherits(x, "POSIXlt")) stop("wrong class")
     if(any(f0 <- format == "")) {
         ## need list [ method here.
-    times <- unlist(unclass(x)[1L:3L])[f0]
-    secs <- x$sec[f0]; secs <- secs[is.finite(secs)]
+        times <- unlist(unclass(x)[1L:3L])[f0]
         np <- if(is.null(digits)) 0L else min(6L, digits)
-        if(np >= 1L) # no unnecessary trailing '0' :
-            for (i in seq_len(np)- 1L)
-                if(all( abs(secs - round(secs, i)) < 1e-6 )) {
-                    np <- i
-                    break
-                }
-    format[f0] <-
-        if(all(times[is.finite(times)] == 0)) "%Y-%m-%d"
-        else if(np == 0L) "%Y-%m-%d %H:%M:%S"
-        else paste0("%Y-%m-%d %H:%M:%OS", np)
+        format[f0] <-
+            if(all(times[is.finite(times)] == 0)) "%Y-%m-%d"
+            else if(np == 0L) "%Y-%m-%d %H:%M:%S"
+            else paste0("%Y-%m-%d %H:%M:%OS", np)
     }
     .Internal(format.POSIXlt(x, format, usetz))
 }

--- a/src/library/base/man/strptime.Rd
+++ b/src/library/base/man/strptime.Rd
@@ -39,7 +39,7 @@ strptime(x, format, tz = "")
     methods is
     \code{"\%Y-\%m-\%d \%H:\%M:\%S"} if any element has a time
     component which is not midnight, and \code{"\%Y-\%m-\%d"}
-    otherwise.  If \code{\link{options}("digits.secs")} is set, up to
+    otherwise.  If \code{\link{options}("digits.secs")} is set,
     the specified number of digits will be printed for seconds.}
   \item{\dots}{further arguments to be passed from or to other methods.}
   \item{usetz}{logical.  Should the time zone abbreviation be appended


### PR DESCRIPTION
Context:  https://github.com/r-devel/r-dev-day/issues/83
Original bugzilla issue:  https://bugs.r-project.org/show_bug.cgi?id=17350

Basic idea is to simplify by removing the calculation of `np` which has been seen to leading to unwanted truncation as discussed in the bugzilla report.  This tested out fine on my machine but my svn checkout is no longer pristine so trying here too.

There is also a bit of whitespace change as the indentation was off for under Emacs/ESS which is unusual for base R code.