### PR TITLE
Update checkS3methods to ignore deprecated/defunct functions - R Dev Day issue 76

### DIFF
--- a/src/library/tools/R/QC.R
+++ b/src/library/tools/R/QC.R
@@ -2387,7 +2387,7 @@ checkTopLevelCall <- function(expr, fun_name) {
     fun_name <- as.name(fun_name)
     fun_called <- expr[[1]]
     if (is.call(fun_called)) {
-        inner_called <- fun_called[[1]
+        inner_called <- fun_called[[1]]
         if (identical(inner_called, quote(`:::`)) ||
             identical(inner_called, quote(`::`))) {
            fun_called <- fun_called[[3]]

--- a/src/library/tools/R/QC.R
+++ b/src/library/tools/R/QC.R
@@ -2635,6 +2635,11 @@ function(package, dir, lib.loc = NULL)
                   function(g) {
                       methods <-
                           gen_dot_cls_matches(g, functions_in_code)
+                      method_funs <-
+                          Filter(Negate(function(x) {
+                              isDefunct(x) || isDeprecated(x)
+                              }), mget(methods, code_env))
+                      methods <- names(method_funs)
                       if((n <- length(methods)) > 0L) {
                           gargs <- nfg(g, code_env)
                           entries <-

--- a/src/library/tools/R/QC.R
+++ b/src/library/tools/R/QC.R
@@ -2381,34 +2381,35 @@ function(x, ...)
 
 ### Additional functions for checkS3methods
 checkTopLevelCall <- function(expr, fun_name) {
-  if (inherits(expr, "if") || !is.call(expr)) {
-    return(FALSE)
-  }
-  fun_name <- as.name(fun_name)
-  fun_called <- expr[[1]]
-  if (is.call(fun_called)) {
-    inner_called <- fun_called[[1]] 
-    if (as.character(inner_called) %in% c(":::", "::")) {
-      fun_called <- fun_called[[3]]
+    if (inherits(expr, "if") || !is.call(expr)) {
+        return(FALSE)
     }
-  }
-  identical(fun_called, fun_name)
+    fun_name <- as.name(fun_name)
+    fun_called <- expr[[1]]
+    if (is.call(fun_called)) {
+        inner_called <- fun_called[[1]
+        if (identical(inner_called, quote(`:::`)) ||
+            identical(inner_called, quote(`::`))) {
+           fun_called <- fun_called[[3]]
+        }
+    }
+    identical(fun_called, fun_name)
 }
 
 containsTopLevelCall <- function(x, fun_name) {
-  fun_body <- body(x)
-  if (inherits(fun_body, "{")) {
-    any(vapply(fun_body, checkTopLevelCall, TRUE, fun = fun_name))
-  } else {
-    checkTopLevelCall(fun_body, fun_name)
-  }
+    fun_body <- body(x)
+    if (inherits(fun_body, "{")) {
+        any(vapply(fun_body, checkTopLevelCall, TRUE, fun = fun_name))
+    } else {
+        checkTopLevelCall(fun_body, fun_name)
+    }
 }
 
 isDeprecated <- function(fun) {
-  containsTopLevelCall(fun, quote(.Deprecated))
+    containsTopLevelCall(fun, quote(.Deprecated))
 }
 isDefunct <- function(fun) {
-  containsTopLevelCall(fun, quote(.Defunct))   
+    containsTopLevelCall(fun, quote(.Defunct))
 }
 
 ### * checkS3methods

--- a/src/library/tools/R/QC.R
+++ b/src/library/tools/R/QC.R
@@ -2379,6 +2379,38 @@ function(x, ...)
    res
 }
 
+### Additional functions for checkS3methods
+checkTopLevelCall <- function(expr, fun_name) {
+  if (inherits(expr, "if") || !is.call(expr)) {
+    return(FALSE)
+  }
+  fun_name <- as.name(fun_name)
+  fun_called <- expr[[1]]
+  if (is.call(fun_called)) {
+    inner_called <- fun_called[[1]] 
+    if (as.character(inner_called) %in% c(":::", "::")) {
+      fun_called <- fun_called[[3]]
+    }
+  }
+  identical(fun_called, fun_name)
+}
+
+containsTopLevelCall <- function(x, fun_name) {
+  fun_body <- body(x)
+  if (inherits(fun_body, "{")) {
+    any(vapply(fun_body, checkTopLevelCall, TRUE, fun = fun_name))
+  } else {
+    checkTopLevelCall(fun_body, fun_name)
+  }
+}
+
+isDeprecated <- function(fun) {
+  containsTopLevelCall(fun, quote(.Deprecated))
+}
+isDefunct <- function(fun) {
+  containsTopLevelCall(fun, quote(.Defunct))   
+}
+
 ### * checkS3methods
 
 checkS3methods <-


### PR DESCRIPTION
Context: [r-devel/r-dev-day#76](https://github.com/r-devel/r-dev-day/issues/76)

Also related: [r-devel/cran-cookbook/discussions/53](https://github.com/r-devel/cran-cookbook/discussions/53)

This Pull Request introduces two new auxiliary functions, `isDefunct()` and `isDeprecated()`, and also integrates them into `checkS3methods()` to handle deprecated and defunct methods.

The development of this feature was carried out under the guidance of @gmbecker and @lawremi.