### PR TITLE
Use TAR workarounds as documented

### DIFF
--- a/.github/scripts/win-check.sh
+++ b/.github/scripts/win-check.sh
@@ -33,4 +33,6 @@ cd src/gnuwin32
 make all cairodevices recommended vignettes manuals
 
 # Run checks
+export TAR="/usr/bin/tar"
+export TAR_OPTIONS="--force-local"
 make check-all


### PR DESCRIPTION
The native windows `tar` hangs on win2022 when extracting `tar.xz`. This "solution" is described on https://cran.r-project.org/bin/windows/base/howto-R-devel.html