### PR TITLE
Lockdir prefix for install packages

### DIFF
--- a/doc/NEWS.Rd
+++ b/doc/NEWS.Rd
@@ -423,6 +423,15 @@
 
       \item There is preliminary support for C++26 with GCC \eqn{>=} 14, Apple
       \command{clang++} \eqn{>=} 16 and \I{LLVM} \command{clang++} \eqn{>=} 17.
+
+      \item \code{install.packages()} supports setting a different path for the
+	  intermediate \code{00LOCK} directories through the environment variable
+	  \code{R_LOCKDIR_PREFIX}. This helps source package installation in some
+	  distributed filesystems available in cloud environments like databricks.
+	  Check the
+	  \dQuote{R Installation and Administration} manual for further details on
+	  this option.
+
     }
   }
 

--- a/doc/NEWS.Rd
+++ b/doc/NEWS.Rd
@@ -26,7 +26,15 @@
 
   \subsection{PACKAGE INSTALLATION}{
     \itemize{
-      \item .
+
+      \item \code{install.packages()} supports setting a different path for the
+	  intermediate \code{00LOCK} directories through the environment variable
+	  \code{R_LOCKDIR_PREFIX}. This helps source package installation in some
+	  distributed filesystems available in cloud environments like databricks.
+	  Check the
+	  \dQuote{R Installation and Administration} manual for further details on
+	  this option.
+
     }
   }
 
@@ -423,14 +431,6 @@
 
       \item There is preliminary support for C++26 with GCC \eqn{>=} 14, Apple
       \command{clang++} \eqn{>=} 16 and \I{LLVM} \command{clang++} \eqn{>=} 17.
-
-      \item \code{install.packages()} supports setting a different path for the
-	  intermediate \code{00LOCK} directories through the environment variable
-	  \code{R_LOCKDIR_PREFIX}. This helps source package installation in some
-	  distributed filesystems available in cloud environments like databricks.
-	  Check the
-	  \dQuote{R Installation and Administration} manual for further details on
-	  this option.
 
     }
   }

--- a/doc/manual/R-admin.texi
+++ b/doc/manual/R-admin.texi
@@ -2061,6 +2061,20 @@ comparable age to your version of @R{}).
 Naive users sometimes forget that as well as installing a package, they
 have to use @code{library} to make its functionality available.
 
+The package installation process has some standard requirements on the
+file system where packages are installed. Specifically, when a \emph{source
+package} needs to be installed, R needs to be able
+to open files in append mode \code{open(filename, "a")}. R also expects to
+be able to perform atomic directory moves during package installation
+to ensure correct error recovery from package installation errors (see
+@uref{https://developer.r-project.org/Blog/public/2019/02/14/staged-install/index.html}).
+Both requirements are fullfilled by POSIX and Windows filesystems, but not by
+some distributed file systems. In scenarios where opening append mode is not available, the
+@env{R_LOCKDIR_PREFIX} environment variable can be set to specify the absolute path to
+a different directory (in a compliant file system) where the package can be preinstalled
+before being moved to its final destination. While this approach makes package installation
+in those file systems possible, the error recovery capabilities will not be as robust as
+on supported filesystems.
 
 @node Windows packages
 @subsection Windows

--- a/src/library/tools/R/install.R
+++ b/src/library/tools/R/install.R
@@ -56,7 +56,7 @@ if(FALSE) {
     curPkg <- character() # list of packages in current pkg
 
     ## Path to where lockdirs will be created. If empty, use lib directory
-    lockdir_prefix <- Sys.getenv("PKG_LOCKDIR_PREFIX", "")
+    lockdir_prefix <- Sys.getenv("R_LOCKDIR_PREFIX", "")
     if (lockdir_prefix == "")
         lockdir_prefix <- NULL
     else


### PR DESCRIPTION
Some distributed file systems do not support opening files in append mode. These file systems are often used in data analysis cloud platforms.

R package installation relies on appending to files, for instance collating R code or when installing help pages.

Therefore, packages can't be installed in those filesystems. Instead, users are forced to install packages into a local directory and copy them afterwards.

However, the current package installation procedure already uses a 00LOCK directory to install packages there, before copying them to the final library directory.

By globally modifying the location of the 00LOCK directory, it is possible to use a local filesystem to install packages, where append is allowed. The installation process takes care of copying the resulting package into the final out directory.

This change introduces the environment variable PKG_LOCKDIR_PREFIX that, when set to a directory like "/tmp/r-lockdir", uses that root path to create all 00LOCK folders.

This allows to install packages on file systems that do not support opening files in append mode.