### PR TITLE
[Bugzilla#18058] lm(..., subset=...) producing incorrect model matrix

### DIFF
--- a/src/library/stats/man/lm.Rd
+++ b/src/library/stats/man/lm.Rd
@@ -37,7 +37,7 @@ lm(formula, data, subset, weights, na.action,
   \item{subset}{an optional vector specifying a subset of observations
     to be used in the fitting process. (See additional details about how
     this argument interacts with data-dependent bases under \sQuote{Details}
-    below.)
+    below.)}
 
   \item{weights}{an optional vector of weights to be used in the fitting
     process.  Should be \code{NULL} or a numeric vector.

--- a/src/library/stats/man/lm.Rd
+++ b/src/library/stats/man/lm.Rd
@@ -35,10 +35,9 @@ lm(formula, data, subset, weights, na.action,
     typically the environment from which \code{lm} is called.}
 
   \item{subset}{an optional vector specifying a subset of observations
-    to be used in the fitting process.  (See additional details about how
-    this argument interacts with data-dependent bases in the
-    \sQuote{Details} section of the \code{\link{model.frame}}
-    documentation.)}
+    to be used in the fitting process. (See additional details about how
+    this argument interacts with data-dependent bases under \sQuote{Details}
+    below.)
 
   \item{weights}{an optional vector of weights to be used in the fitting
     process.  Should be \code{NULL} or a numeric vector.
@@ -132,6 +131,10 @@ lm(formula, data, subset, weights, na.action,
   All of \code{weights}, \code{subset} and \code{offset} are evaluated
   in the same way as variables in \code{formula}, that is first in
   \code{data} and then in the environment of \code{formula}.
+  Note that values calculated inside the formula, such as \code{mean(x)},
+  are evaluated before subsetting - which may lead to unexpected results
+  if used with \code{subset}. For more information see the
+  \sQuote{Details} section of the \code{\link{model.frame}}.
 }
 \value{
   \code{lm} returns an object of \code{\link{class}} \code{"lm"} or for


### PR DESCRIPTION
Update documentation of `lm()` (`subset` argument)
Related issue: https://github.com/r-devel/r-dev-day/issues/90

with @wlangera, @jgodet and @brehel1 
