### PR TITLE
Allow zstd compression level up to 22

### DIFF
--- a/src/library/base/man/connections.Rd
+++ b/src/library/base/man/connections.Rd
@@ -121,7 +121,7 @@ socketTimeout(socket, timeout = -1)
     requests.  It is ignored for non-HTTP URLs.  The \code{User-Agent}
     header, coming from the \code{HTTPUserAgent} option (see
     \code{\link{options}}) is used as the first header, automatically.}
-  \item{compression}{integer in 0--9 (1--19 for \code{zstdfile}).  The
+  \item{compression}{integer in 0--9 (1--22 for \code{zstdfile}).  The
     amount of compression to be applied when writing, from minimal to
     maximal available.  For \code{xzfile} and \code{zstdfile} can also
     be negative: see the \sQuote{Compression} section.}

--- a/src/main/connections.c
+++ b/src/main/connections.c
@@ -2761,7 +2761,7 @@ attribute_hidden SEXP do_gzfile(SEXP call, SEXP op, SEXP args, SEXP env)
     }
     if(type == 3) {
 	compress = asInteger(CADDDR(args));
-	if(compress == NA_LOGICAL || abs(compress) > 19)
+	if(compress == NA_LOGICAL || abs(compress) > 22)
 	    error(_("invalid '%s' argument"), "compress");
     }
     open = CHAR(STRING_ELT(sopen, 0)); /* ASCII */


### PR DESCRIPTION
The latest documentation states:

>   The library supports regular compression levels from 1 up to ZSTD_maxCLevel(),
  which is currently 22. Levels >= 20, labeled `--ultra`, should be used with
  caution, as they require more memory. The library also offers negative
  compression levels, which extend the range of speed vs. ratio preferences.
  The lower the level, the faster the speed (at the cost of compression).

https://facebook.github.io/zstd/doc/api_manual_latest.html