### PR TITLE
[Bugzilla #18958] Use an empty vector, not "", for methods_message

### DIFF
--- a/src/library/tools/R/QC.R
+++ b/src/library/tools/R/QC.R
@@ -6202,7 +6202,7 @@ function(package, dir, lib.loc = NULL)
     methods_message <-
         if(uses_methods && "methods" %notin% c(depends, imports))
             gettext("package 'methods' is used but not declared")
-        else ""
+        else character()
 
     extras <- list(
         base = c("Sys.junction", "shell", "shell.exec"),
@@ -6503,7 +6503,7 @@ function(x, ...)
                        sQuote(xx))
           }
       },
-      if(nzchar(x$methods_message)) {
+      if(length(x$methods_message)) {
           x$methods_message
       })
 }
@@ -6621,7 +6621,7 @@ function(db, files)
     res <- list(others = unique(bad_exprs),
                 imports = unique(bad_imports),
                 data = unique(bad_data),
-                methods_message = ""
+                methods_message = character()
               , parse_errors = unique(parse_errors)
             )
     class(res) <- "check_packages_used"


### PR DESCRIPTION
https://bugs.r-project.org/show_bug.cgi?id=18958