### PR TITLE
Look for R_unload_lib symbol regardless of registration status

### DIFF
--- a/src/main/Rdynload.c
+++ b/src/main/Rdynload.c
@@ -696,11 +696,9 @@ R_callDLLUnload(DllInfo *dllInfo)
 {
     char buf[1024];
     DllInfoUnloadCall f;
-    R_RegisteredNativeSymbol symbol;
-    symbol.type = R_ANY_SYM;
 
     snprintf(buf, 1024, "R_unload_%s", dllInfo->name);
-    f = (DllInfoUnloadCall) R_dlsym(dllInfo, buf, &symbol);
+    f = (DllInfoUnloadCall) R_osDynSymbol->dlsym(dllInfo, buf);
     if(f) f(dllInfo);
 
     return(TRUE);


### PR DESCRIPTION
This PR addresses the [following bug report](https://bugs.r-project.org/show_bug.cgi?id=18962).
Details are provided [there](https://bugs.r-project.org/show_bug.cgi?id=18962#c0).