### PR TITLE
Strip URL parameters for local filename

### DIFF
--- a/src/library/utils/R/packages.R
+++ b/src/library/utils/R/packages.R
@@ -877,7 +877,10 @@ download.packages <- function(pkgs, destdir, available = NULL,
                             domain = NA, immediate. = TRUE)
             } else {
                 url <- paste(repos, fn, sep = "/")
-                destfile <- file.path(destdir, fn)
+
+                # For http:// repos we remove potential http parameter part to get the actual
+                # filename, in case of URLs like pkg_1.0.tar.gz?checksum=12345
+                destfile <- file.path(destdir, sub("\\?.*$", "", fn))
 
                 if (is.null(bulkdown)) {
                     # serial download


### PR DESCRIPTION
Currently `download.packages()` copies the full `File` field from the URL in PACKAGES, including http parameters, as the local filename. So for example, if the `PACKAGES` file contains

```
Package: jsonlite
Version: 2.0.0
File: jsonlite_2.0.0.tar.gz?somekey=79fad1b6092c1d1cc71e096d02cbc7618837fda1f90b61443f09adc25caab095
...
```

Then the file is saved locally not as  `jsonlite_2.0.0.tar.gz` but as the full url including the `?` and `=` characters which are not allowed in filenames on some platforms.

To reproduce this I created a testing repo: 

```r
available.packages(repos = 'https://jeroen.github.io/testrepo/')
download.packages('jsonlite', '.', repos = 'https://jeroen.github.io/testrepo/')
```

The above patch makes the download behavior of R correspond to browsers, which is to remove the http-query part from the url when saving a file locally.