### PR TITLE
PR18862 follow-ups to 'parallel' enhancements:

### DIFF
--- a/src/library/parallel/R/snow.R
+++ b/src/library/parallel/R/snow.R
@@ -146,11 +146,34 @@ setDefaultClusterOptions <- function(...) {
 
 clusterStarters <- new.env()
 registerClusterType <- function(type, starter, make.default = FALSE) {
+    if (missing(type))
+        return(as.list(clusterStarters))
     if (exists(type, clusterStarters))
         warning(sprintf("replacing registration for cluster type '%s'", type))
     assign(type, starter, clusterStarters)
     if (make.default)
         setDefaultClusterOptions(type = type)
+}
+
+initRegisterClusterTypes <- function() {
+    ## Register PSOCK and FORK to be listed by registerClusterType()
+    registerClusterType("PSOCK", function(spec, ...)
+        makePSOCKcluster(names = spec, ...))
+
+    registerClusterType("FORK", function(spec, ...)
+        makeForkCluster(nnodes = spec, ...))
+
+    registerClusterType("SOCK", function(spec, ...)
+        snow::makeSOCKcluster(names = spec, ...))
+    
+    registerClusterType("MPI", function(spec, ...)
+        snow::makeMPIcluster(count = spec, ...))
+      
+    registerClusterType("MIRAI", function(spec, ...)
+        mirai::make_cluster(n = spec, ...))
+      
+    registerClusterType("RPSOCK", function(spec, ...)
+        parallelly::makeClusterPSOCK(workers = spec, ...))
 }
 
 makeCluster <-
@@ -159,11 +182,6 @@ makeCluster <-
     switch(type,
            PSOCK = makePSOCKcluster(names = spec, ...),
            FORK = makeForkCluster(nnodes = spec, ...),
-           SOCK = snow::makeSOCKcluster(names = spec, ...),
-           MPI = snow::makeMPIcluster(count = spec, ...),
-           MIRAI = mirai::make_cluster(n = spec, ...),
-           RPSOCK = parallelly::makeClusterPSOCK(workers = spec, ...),
-           ## NWS = snow::makeNWScluster(names = spec, ...),
            if (exists(type, clusterStarters))
                get(type, clusterStarters)(spec, ...)
            else stop(sprintf("unknown cluster type: '%s'", type)))

--- a/src/library/parallel/R/zzz.R
+++ b/src/library/parallel/R/zzz.R
@@ -26,7 +26,9 @@ if (.Platform$OS.type == "windows")
 
 .onLoad <- function(libname, pkgname)
 {
+    initRegisterClusterTypes()
     initDefaultClusterOptions(libname)
+    
     cores <- getOption("mc.cores", NULL)
     if(is.null(cores) && !is.na(nc <- as.integer(Sys.getenv("MC_CORES"))))
         options("mc.cores" = nc)

--- a/src/library/parallel/man/makeCluster.Rd
+++ b/src/library/parallel/man/makeCluster.Rd
@@ -40,7 +40,7 @@ registerClusterType(type, starter, make.default = FALSE)
   \item{nnodes}{The number of nodes to be forked.}
   \item{type}{One of the supported types: see \sQuote{Details}. For
     \code{registerClusterType}, a name for the newly-registered type of
-    cluster.}
+    cluster, or missing.}
   \item{\dots}{Options to be passed to the function spawning the workers.
     See \sQuote{Details}.}
   \item{cl}{an object of class \code{"cluster"}.}
@@ -52,10 +52,14 @@ registerClusterType(type, starter, make.default = FALSE)
     type remains unchanged.}
 }
 \details{
-  \code{makeCluster} creates a cluster of one of the supported types.
-  The default type, \code{"PSOCK"}, calls \code{makePSOCKcluster}.  Type
-  \code{"FORK"} calls \code{makeForkCluster}.  Other types are passed to
-  package \CRANpkg{snow}.
+  \code{makeCluster} creates a cluster of one of the registered types in
+  \code{names(registerClusterType())}.  The default type, \code{"PSOCK"},
+  calls \code{makePSOCKcluster}.  Type \code{"FORK"} calls
+  \code{makeForkCluster}.  Other pre-registered types are \code{"SOCK"}
+  for \code{makeSOCKcluster} in package \CRANpkg{snow}, \code{"MPI"} for
+  \code{makeMPIcluster} in \CRANpkg{snow}, \code{"MIRAI"} for
+  \code{make_cluster} in package \CRANpkg{mirai}, and \code{"RPSOCK"}
+  for \code{makeClusterPSOCK} in package \CRANpkg{parallelly}.
 
   \code{makePSOCKcluster} is an enhanced version of
   \code{makeSOCKcluster} in package \CRANpkg{snow}.  It runs
@@ -146,9 +150,9 @@ registerClusterType(type, starter, make.default = FALSE)
   the registered cluster, as does stopping that cluster.
 
   Function \code{registerClusterType} registers a new type of parallel cluster
-  in the current session. When \code{makeCluster} is called with the
-  newly-registered \code{type}, a cluster of that type is created using the
-  \code{starter} function.
+  in the current session or lists registered types. When \code{makeCluster} is
+  called with the newly-registered \code{type}, a cluster of that type is
+  created using the \code{starter} function.
 }
 
 \value{
@@ -160,7 +164,8 @@ registerClusterType(type, starter, make.default = FALSE)
 
   \code{registerClusterType} is invoked for its side effect which is to define
   a mechanism for creating a parallel socket cluster of a given named
-  \code{type}.
+  \code{type}. If called without arguments, a named list of registered cluster
+  starter functions.
 }
 
 \note{


### PR DESCRIPTION
 * registerClusterType() without arguments return registered types

 * internal initRegisterClusterTypes() for pre-registering cluster types

 * add cluster type 'RPSOCK' for parallelly::makeClusterPSOCK()

 * update help(makeCluster)