### PR TITLE
Use ddot for scalar output

### DIFF
--- a/src/main/array.c
+++ b/src/main/array.c
@@ -1193,9 +1193,16 @@ static void tcrossprod(double *x, int nrx, int ncx,
     double one = 1.0, zero = 0.0;
     int ione = 1;
 
-    if (nry == 1) /* matrix-vector or dot product */
-	F77_CALL(dgemv)(transN, &nrx, &ncx, &one, x,
-			&nrx, y, &ione, &zero, z, &ione FCONE);
+    if (nry == 1) { /* Result is a vector of length nrx */
+        if (nrx == 1) {
+            /* Row Vector (1 x ncx) * Row Vector (1 x ncy)^T = Scalar */
+            *z = F77_CALL(ddot)(&ncx, x, &ione, y, &ione);
+        } else {
+            /* Matrix (nrx x ncx) * Row Vector (1 x ncy)^T = Vector (nrx x 1) */
+            F77_CALL(dgemv)(transN, &nrx, &ncx, &one, x,
+                            &nrx, y, &ione, &zero, z, &ione FCONE);
+        }
+    }
     else if (nrx == 1) /* vector-matrix */
 	/* Instead of x(Y^T), compute (x(Y^T))^T == Y(x^T)
 	   The result is a vector, so transposing its content is no-op */

--- a/src/main/array.c
+++ b/src/main/array.c
@@ -1052,9 +1052,16 @@ static void crossprod(double *x, int nrx, int ncx,
     double one = 1.0, zero = 0.0;
     int ione = 1;
 
-    if (ncy == 1) /* matrix-vector or dot product */
-	F77_CALL(dgemv)(transT, &nrx, &ncx, &one, x,
-			&nrx, y, &ione, &zero, z, &ione FCONE);
+    if (ncy == 1) {
+        if (ncx == 1) {
+            /* Vector(n x 1)^T * Vector(n x 1) = Scalar */
+            *z = F77_CALL(ddot)(&nrx, x, &ione, y, &ione);
+        } else {
+            /* Matrix(n x m)^T * Vector(n x 1) = Vector(m x 1) */
+            F77_CALL(dgemv)(transT, &nrx, &ncx, &one, x,
+                            &nrx, y, &ione, &zero, z, &ione FCONE);
+        }
+    }
     else if (ncx == 1) /* vector-matrix */
 	/* Instead of (x^T)Y, compute ((x^T)Y)^T == (Y^T)x
 	   The result is a vector, so transposing its content is no-op */


### PR DESCRIPTION
Related linked blog post in https://fosstodon.org/@Mehrad/115773657671691983. 

`crossprod()` and `tcrossprod()` do not use `ddot` for scalar output.

``` r
Rcpp::sourceCpp(code = '
  #include <Rcpp.h>
  #include <R_ext/BLAS.h>
  
  // [[Rcpp::export]]
  double blas_dot_product(Rcpp::NumericVector a, Rcpp::NumericVector b) {
    int n = a.size();
    if (n != b.size()) {
      Rcpp::stop("Incompatible lengths: vectors must be the same size.");
    }
  
    int inc = 1;
    // ddot(n, x, incx, y, incy)
    double result = F77_CALL(ddot)(&n, a.begin(), &inc, b.begin(), &inc);
  
    return result;
  }
')
  
n <- 1e7
a <- runif(n)
b <- runif(n)

microbenchmark::microbenchmark(
  blas_dot_product(a, b)  
)
#> Warning in microbenchmark::microbenchmark(blas_dot_product(a, b)): less
#> accurate nanosecond times to avoid potential integer overflows
#> Unit: milliseconds
#>                    expr      min       lq    mean   median       uq      max
#>  blas_dot_product(a, b) 2.562377 2.566046 2.62774 2.570885 2.579802 5.793259
#>  neval
#>    100
```