### PR TITLE
Short-circuit `crossprod` and `tcrossprod` with `ddot`

### DIFF
--- a/src/main/array.c
+++ b/src/main/array.c
@@ -791,6 +791,13 @@ static void matprod(double *x, int nrx, int ncx,
 	return;
     }
 
+    /* Short-circuit for dot product. ddot handles NaN/Inf. */
+    if (nrx == 1 && ncy == 1) {
+    int ione = 1;
+    *z = F77_CALL(ddot)(&ncx, x, &ione, y, &ione);
+    return;
+    }
+
     switch(R_Matprod) {
 	case MATPROD_DEFAULT:
 	/* Don't trust the BLAS to handle NA/NaNs correctly: PR#4582
@@ -824,7 +831,7 @@ static void matprod(double *x, int nrx, int ncx,
     double one = 1.0, zero = 0.0;
     int ione = 1;
 
-    if (ncy == 1) /* matrix-vector or dot product */
+    if (ncy == 1) /* matrix-vector */
 	F77_CALL(dgemv)(transN, &nrx, &ncx, &one, x,
 			&nrx, y, &ione, &zero, z, &ione FCONE);
     else if (nrx == 1) /* vector-matrix */
@@ -1026,6 +1033,13 @@ static void crossprod(double *x, int nrx, int ncx,
 	return;
     }
 
+    /* Short-circuit for dot product. ddot handles NaN/Inf. */
+    if (ncx == 1 && ncy == 1) {
+    int ione = 1;
+    *z = F77_CALL(ddot)(&nrx, x, &ione, y, &ione);
+    return;
+    }
+
     switch(R_Matprod) {
 	case MATPROD_DEFAULT:
 	    /* see matprod for more details */
@@ -1052,7 +1066,7 @@ static void crossprod(double *x, int nrx, int ncx,
     double one = 1.0, zero = 0.0;
     int ione = 1;
 
-    if (ncy == 1) /* matrix-vector or dot product */
+    if (ncy == 1) /* matrix-vector  */
 	F77_CALL(dgemv)(transT, &nrx, &ncx, &one, x,
 			&nrx, y, &ione, &zero, z, &ione FCONE);
     else if (ncx == 1) /* vector-matrix */
@@ -1161,6 +1175,13 @@ static void tcrossprod(double *x, int nrx, int ncx,
 	return;
     }
 
+    /* Short-circuit for dot product. ddot handles NaN/Inf. */
+    if (nry == 1 && nrx == 1) {
+    int ione = 1;
+    *z = F77_CALL(ddot)(&ncx, x, &ione, y, &ione);
+    return;
+    }
+
     switch(R_Matprod) {
 	case MATPROD_DEFAULT:
 	    if (mayHaveNaNOrInf(x, NRX*ncx) || mayHaveNaNOrInf(y, NRY*ncy)) {
@@ -1186,7 +1207,7 @@ static void tcrossprod(double *x, int nrx, int ncx,
     double one = 1.0, zero = 0.0;
     int ione = 1;
 
-    if (nry == 1) /* matrix-vector or dot product */
+    if (nry == 1) /* matrix-vector */
 	F77_CALL(dgemv)(transN, &nrx, &ncx, &one, x,
 			&nrx, y, &ione, &zero, z, &ione FCONE);
     else if (nrx == 1) /* vector-matrix */


### PR DESCRIPTION
Follow up after #220

```R
n <- 1e7
a <- runif(n)
b <- runif(n)

ta <- matrix(a, nrow = 1)
tb <- matrix(b, nrow = 1)

f_crossprod <- function(){
  crossprod(a, b)
}

f_tcrossprod <- function(){
  tcrossprod(ta, tb)
}

f_matcrossprod <- function(){
  t(a) %*% b
}

f_mattcrossprod <- function(){
  ta %*% t(tb)
}

f_crossprod()
f_tcrossprod()
f_matcrossprod()
f_mattcrossprod()

microbenchmark::microbenchmark(
  f_crossprod(),
  f_tcrossprod(),
  f_matcrossprod(),
  f_mattcrossprod(),
  times = 100,
  unit = "ms"
)

# R 4.5.2 - Arch Linux build
# Unit: milliseconds
#               expr      min       lq     mean   median       uq       max neval
#      f_crossprod() 13.95430 15.72571 15.91694 15.99984 16.13971  18.72512   100
#     f_tcrossprod() 14.34191 15.26864 15.47572 15.56467 15.72144  16.46870   100
#   f_matcrossprod() 39.62551 40.21044 43.26844 40.62410 46.60324 116.71673   100
#  f_mattcrossprod() 39.38368 40.32907 43.74657 40.62216 46.37327 119.44589   100

# This PR - R 4.6.0 development build
# Unit: milliseconds
#               expr       min        lq      mean    median        uq       max neval
#      f_crossprod()  5.552102  5.582362  5.637989  5.596952  5.610962  7.061572   100
#     f_tcrossprod()  5.568582  5.586697  5.688488  5.601971  5.635287  7.345252   100
#   f_matcrossprod() 30.750169 31.465394 34.046693 32.199969 37.031711 77.641612   100
#  f_mattcrossprod() 30.829049 31.420729 34.487954 31.757410 36.778391 79.355763   100
```

https://bugs.r-project.org/show_bug.cgi?id=18986