### PR TITLE
Fix merge.data.frame to keep column names for empty data frames (Bug 18930)

### DIFF
--- a/src/library/base/R/merge.R
+++ b/src/library/base/R/merge.R
@@ -74,7 +74,10 @@ merge.data.frame <-
             names(y)[cnm] <- paste0(nm.y[cnm], suffixes[2L])
         }
         if (nx == 0L || ny == 0L) {
-            res <- cbind(x[FALSE, ], y[FALSE, ])
+            res <- cbind(
+                x[0L, , drop=FALSE],
+                y[0L, , drop=FALSE]
+            )
         } else {
             ij <- expand.grid(seq_len(nx), seq_len(ny))
             res <- cbind(x[ij[, 1L], , drop = FALSE],


### PR DESCRIPTION
Fixes Bug 18930: merging empty data frames with merge() was losing column names. 

This patch preserves all column names when one or both data frames are empty, 
without changing behavior for non-empty merges.

Example test cases:

# Merge with one empty data frame
df1 <- data.frame(x = numeric())
df2 <- data.frame(y = 1:2)
merge(df1, df2, all.x = TRUE, all.y = TRUE)
#> Column names: "x" "y"
#> 0 rows

# Merge with both empty data frames
df3 <- data.frame(a = numeric(), b = numeric())
df4 <- data.frame(c = numeric(), d = numeric())
merge(df3, df4, all.x = TRUE, all.y = TRUE)
#> Column names: "a" "b" "c" "d"
#> 0 rows