### PR TITLE
[Bugzilla#18994] Fix contextstack off-by-one error

### DIFF
--- a/src/main/gram.c
+++ b/src/main/gram.c
@@ -4430,7 +4430,7 @@ static void IfPush(void)
 	*contextp=='['    ||
 	*contextp=='('    ||
 	*contextp == 'i') {
-	if(contextp - contextstack >= CONTEXTSTACK_SIZE)
+	if(contextp - contextstack >= CONTEXTSTACK_SIZE - 1)
 	    raiseLexError("contextstackOverflow", NO_VALUE, NULL,
 	        _("contextstack overflow (%s:%d:%d)"));
 	*++contextp = 'i';
@@ -6287,7 +6287,7 @@ static int yylex(void)
 	/* Handle brackets, braces and parentheses */
 
     case LBB:
-	if(contextp - contextstack >= CONTEXTSTACK_SIZE - 1)
+	if(contextp - contextstack >= CONTEXTSTACK_SIZE - 2)
 	    raiseLexError("contextstackOverflow", NO_VALUE, NULL,
 	        _("contextstack overflow (%s:%d:%d)"));
 	*++contextp = '[';
@@ -6295,14 +6295,14 @@ static int yylex(void)
 	break;
 
     case '[':
-	if(contextp - contextstack >= CONTEXTSTACK_SIZE)
+	if(contextp - contextstack >= CONTEXTSTACK_SIZE - 1)
 	    raiseLexError("contextstackOverflow", NO_VALUE, NULL,
 	        _("contextstack overflow (%s:%d:%d)"));
 	*++contextp = (char) tok;
 	break;
 
     case LBRACE:
-	if(contextp - contextstack >= CONTEXTSTACK_SIZE)
+	if(contextp - contextstack >= CONTEXTSTACK_SIZE - 1)
 	    raiseLexError("contextstackOverflow", NO_VALUE, NULL,
 	        _("contextstack overflow (%s:%d:%d)"));
 	*++contextp = (char) tok;
@@ -6310,7 +6310,7 @@ static int yylex(void)
 	break;
 
     case '(':
-	if(contextp - contextstack >= CONTEXTSTACK_SIZE)
+	if(contextp - contextstack >= CONTEXTSTACK_SIZE - 1)
 	    raiseLexError("contextstackOverflow", NO_VALUE, NULL,
 	        _("contextstack overflow (%s:%d:%d)"));
 	*++contextp = (char) tok;

--- a/tests/reg-tests-1e.R
+++ b/tests/reg-tests-1e.R
@@ -2573,7 +2573,13 @@ stopifnot(is.null(names(rep.int(x, 2))),
           is.null(names(rep_len(x, 10))))
 ## had names in 4.0.0 <= R <= 4.5.z because of dispatch to rep() method
 
-
+## Context stack overflow checks (PR#18458)
+## These used to segfault (on some platforms with ASAN) due to off-by-one in context stack checks
+tools::assertError(parse(text = strrep("{", 50)))
+tools::assertError(parse(text = strrep("(", 50)))
+tools::assertError(parse(text = strrep("[", 50)))
+tools::assertError(parse(text = strrep("[[", 25)))
+tools::assertError(parse(text = paste0("{", strrep("if(1)", 50), "}")))
 
 ## keep at end
 rbind(last =  proc.time() - .pt,

--- a/tests/reg-tests-1e.R
+++ b/tests/reg-tests-1e.R
@@ -2577,8 +2577,8 @@ stopifnot(is.null(names(rep.int(x, 2))),
 ## These used to segfault (on some platforms with ASAN) due to off-by-one in context stack checks
 tools::assertError(parse(text = strrep("{", 50)))
 tools::assertError(parse(text = strrep("(", 50)))
-tools::assertError(parse(text = strrep("[", 50)))
-tools::assertError(parse(text = strrep("[[", 25)))
+tools::assertError(parse(text = strrep("x[", 50)))
+tools::assertError(parse(text = strrep("x[[", 25)))
 tools::assertError(parse(text = paste0("{", strrep("if(1)", 50), "}")))
 
 ## keep at end


### PR DESCRIPTION
https://bugs.r-project.org/show_bug.cgi?id=18994

Written by Gemini. I got the new regression test to fail in our testing system, e.g.

```
==9087==ERROR: AddressSanitizer: global-buffer-overflow on address 0x5574cda27572 at pc 0x5574cafa76ea bp 0x7fff9399eb30 sp 0x7fff9399eb28
WRITE of size 1 at 0x5574cda27572 thread T0
    #0 0x5574cafa76e9 in yylex <dir>/src/main/gram.c:6308:14
    #1 0x5574cafa76e9 in Rf_yyparse <dir>/src/main/gram.c:2186:16
    #2 0x5574cafadecc in R_Parse1 <dir>/src/main/gram.c:4043:12
    #3 0x5574cafaed1e in R_Parse <dir>/src/main/gram.c:4202:9
    #4 0x5574cafaf386 in R_ParseVector <dir>/src/main/gram.c:4290:12
    #5 0x5574cb0a5eb8 in do_parse <dir>/src/main/source.c:286:6
    #6 0x5574caf8e918 in bcEval_loop <dir>/src/main/eval.c:8118:14
    #7 0x5574caf6fc42 in bcEval <dir>/src/main/eval.c:7501:16
    #8 0x5574caf6f141 in Rf_eval <dir>/src/main/eval.c:1167:8
    #9 0x5574caf731bd in R_execClosure <dir>/src/main/eval.c:2393:39
    #10 0x5574caf7182d in applyClosure_core <dir>/src/main/eval.c:2306:16
    #11 0x5574caf6f713 in Rf_applyClosure <dir>/src/main/eval.c:2328:16
    #12 0x5574caf6f713 in Rf_eval <dir>/src/main/eval.c:1280:12
    #13 0x5574caf6ffad in forcePromise <dir>/src/main/eval.c:976:13
    #14 0x5574caf9bf08 in getvar <dir>/src/main/eval.c:5835:6
    #15 0x5574caf98afc in bcEval_loop <dir>/src/main/eval.c:7848:20
    #16 0x5574caf6fc42 in bcEval <dir>/src/main/eval.c:7501:16
    #17 0x5574caf6f141 in Rf_eval <dir>/src/main/eval.c:1167:8
    #18 0x5574caf731bd in R_execClosure <dir>/src/main/eval.c:2393:39
    #19 0x5574caf7182d in applyClosure_core <dir>/src/main/eval.c:2306:16
    #20 0x5574caf6f713 in Rf_applyClosure <dir>/src/main/eval.c:2328:16
    #21 0x5574caf6f713 in Rf_eval <dir>/src/main/eval.c:1280:12
    #22 0x5574cafe2bcc in Rf_ReplIteration <dir>/src/main/main.c:265:18
    #23 0x5574cafe5130 in R_ReplConsole <dir>/src/main/main.c:317:11
    #24 0x5574cafe4f7e in run_Rmainloop <dir>/src/main/main.c:1234:5
    #25 0x5574cafe51e2 in Rf_mainloop <dir>/src/main/main.c:1241:5
    #26 0x5574cd1aa8a1 in main <dir>/src/main/Rmain.c:32:5


 *** caught segfault ***
address 0x1, cause 'memory not mapped'

Traceback:
 1: parse(text = "{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{")
 2: doTryCatch(return(expr), name, parentenv, handler)
 3: tryCatchOne(expr, names, parentenv, handlers[[1L]])
 4: tryCatchList(expr, classes, parentenv, handlers)
 5: tryCatch(expr, error = function(e) conds <<- c(conds, list(e)))
 6: withCallingHandlers(tryCatch(expr, error = function(e) conds <<- c(conds,     list(e))), warning = function(w) {    conds <<- c(conds, list(w))    tryInvokeRestart("muffleWarning")}, condition = function(cond) conds <<- c(conds, list(cond)))
 7: getConds(expr)
 8: assertCondition(expr, classes, .exprString = d.expr)
 9: doTryCatch(return(expr), name, parentenv, handler)
10: tryCatchOne(expr, names, parentenv, handlers[[1L]])
11: tryCatchList(expr, classes, parentenv, handlers)
12: tryCatch(res <- assertCondition(expr, classes, .exprString = d.expr),     error = function(e) stop(gettextf("Failed to get error in evaluating %s",         d.expr), call. = FALSE, domain = NA))
13: tools::assertError(parse(text = "{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{{"))
```

@kevinushey are you able to test this readily? It's probably best to repro on r-devel...

---

model response:

The issue was indeed an off-by-one error (and off-by-two for [[) in the context stack overflow checks in gram.c.

The contextstack is a fixed-size array of size CONTEXTSTACK_SIZE (50). The pointer contextp points to the current top of the stack. When pushing a new item, contextp is incremented (*++contextp = ...).

For single character pushes (like {, [, (, and in IfPush), the code was checking if (index >= 50).

If contextp was at index 49 (the last valid index), 49 >= 50 is false.
The code would then increment contextp to 50 and write to contextstack[50], causing a buffer overflow.
Fix: Changed the check to if (index >= 49) (i.e., >= CONTEXTSTACK_SIZE - 1).
For [[ (LBB), which pushes two characters, the code was checking if (index >= 49).

If contextp was at index 48, 48 >= 49 is false.
The code would push the first [ (index 49) and then the second [ (index 50), causing a buffer overflow.
Fix: Changed the check to if (index >= 48) (i.e., >= CONTEXTSTACK_SIZE - 2).
I have applied these fixes to gram.c.