### PR TITLE
Harmonize with tools::file_ext()

### DIFF
--- a/src/library/tools/R/utils.R
+++ b/src/library/tools/R/utils.R
@@ -91,7 +91,7 @@ function(x, compression = FALSE)
     ## (Only purely alphanumeric extensions are recognized.)
     if(compression)
         x <- sub("[.](gz|bz2|xz)$", "", x)
-    sub("([^.]+)\\.[[:alnum:]]+$", "\\1", x)
+    sub("\\.[[:alnum:]]+$", "\\1", x)
 }
 
 ### ** file_test


### PR DESCRIPTION
Harmonize with tools::file_ext() to recognise the extension of file names that end in a dot.