### PR TITLE
Fix `debugonce()` and `undebug()` issues with primitive generics

### DIFF
--- a/src/main/debug.c
+++ b/src/main/debug.c
@@ -49,9 +49,10 @@ attribute_hidden SEXP do_debug(SEXP call, SEXP op, SEXP args, SEXP rho)
 	SET_RDEBUG(CAR(args), 1);
 	break;
     case 1: // undebug()
-	if( RDEBUG(CAR(args)) != 1 )
+	if( RDEBUG(CAR(args)) != 1 && RSTEP(CAR(args)) != 1 )
 	    warning("argument is not being debugged");
 	SET_RDEBUG(CAR(args), 0);
+	SET_RSTEP(CAR(args), 0);
 	break;
     case 2: // isdebugged()
 	ans = ScalarLogical(RDEBUG(CAR(args)));

--- a/src/main/objects.c
+++ b/src/main/objects.c
@@ -466,6 +466,12 @@ SEXP dispatchMethod(SEXP op, SEXP sxp, SEXP dotClass, RCNTXT *cptr, SEXP method,
     if ((RDEBUG(op) && R_current_debug_state()) || RSTEP(op) || RDEBUG(rho))
 	SET_RSTEP(sxp, 1);
 
+    /* For primitives, RSTEP is not cleared by applyClosure (since the
+       primitive itself is never processed there). Clear it here to
+       honor debugonce() semantics. */
+    if (RSTEP(op) && (TYPEOF(op) == BUILTINSXP || TYPEOF(op) == SPECIALSXP))
+	SET_RSTEP(op, 0);
+
     SEXP newcall =  PROTECT(shallow_duplicate(cptr->call));
     SETCAR(newcall, method);
     R_GlobalContext->callflag = CTXT_GENERIC;

--- a/tests/reg-tests-1e.R
+++ b/tests/reg-tests-1e.R
@@ -2615,6 +2615,43 @@ stopifnot(identical(strX2 , strX2. ), noListof(strX2. ),
 ## strXs?2. did have 'List of' in R <= 4.5.z
 
 
+## debugonce() on primitive generics should fire only once
+## and undebug() should be able to cancel it
+Sys.setenv("_R_CHECK_BROWSER_NONINTERACTIVE_" = "true")
+##
+debugonce(`[`)
+stopifnot(grepl("non-interactive browser", tryCmsg(mtcars[1])))
+x <- mtcars[1]                        # must NOT enter debugger
+stopifnot(identical(x, mtcars[1]))
+##
+debugonce(`[`)
+undebug(`[`)
+x <- mtcars[1] # must NOT enter debugger
+stopifnot(identical(x, mtcars[1]))
+##
+## undebug() after debugonce() on a primitive should not warn
+debugonce(`[`)
+op <- options(warn = 2)
+undebug(`[`)  # warned spuriously in R <= 4.5.z
+options(op)
+##
+## debug() + undebug() on a primitive must still work
+debug(`[`)
+stopifnot(grepl("non-interactive browser", tryCmsg(mtcars[1])))
+undebug(`[`)
+x <- mtcars[1] # must NOT enter debugger
+stopifnot(identical(x, mtcars[1]))
+##
+## undebug() should cancel debugonce() on closures too
+f <- function(x) x + 1
+debugonce(f)
+undebug(f)
+stopifnot(identical(f(1), 2)) # must NOT enter debugger
+##
+Sys.unsetenv("_R_CHECK_BROWSER_NONINTERACTIVE_")
+## debugonce() on primitives was permanent in R <= 4.5.z
+## undebug() after debugonce() never worked in R <= 4.5.z
+
 
 ## keep at end
 rbind(last =  proc.time() - .pt,


### PR DESCRIPTION
This patch fixes two bugs:

1. `debugonce()` on a primitive generic like `[` does not respect "once" semantics. It debugs every subsequent S3 dispatch indefinitely.

2. `undebug()` cannot cancel a pending `debugonce()` on any function type, including closures:

```r
> debugonce(identity)
> undebug(identity)
Warning message:
In undebug(identity) : argument is not being debugged
> identity(1)
debugging in: identity(1)
debug: x
Browse[1]>
```

R uses two flags for debugging: `RDEBUG` (set by `debug()`) and `RSTEP` (set by `debugonce()`). For closures, `debugonce()` works because `applyClosure` checks `RSTEP`, enters the debugger, and clears the flag. The next call sees `RSTEP = 0`.

Primitive generics (primitives that perform S3 dispatch, such as `[`, `[[`, `$`) never go through `applyClosure`. They call `dispatchMethod()` via `usemethod()` directly. `dispatchMethod()` propagates the debug state to the method but never clears `RSTEP` on the primitive, so it persists across all subsequent dispatches.

The `undebug()` bug is simpler: it only cleared `RDEBUG`, not `RSTEP`. For closures this went unnoticed probably because the "once" clearing in `applyClosure` works. After one call the flag is gone anyway.

Fixes:

- `dispatchMethod()`: after propagating debug state from a primitive generic to the method, clear `RSTEP` on the primitive.

- `undebug()`: clear both `RDEBUG` and `RSTEP`, and check both flags for the "not being debugged" warning.
