### PR TITLE
Use zstd unconditionally

### DIFF
--- a/m4/R.m4
+++ b/m4/R.m4
@@ -3843,8 +3843,8 @@ if test "x${have_zstd}" = xyes; then
     AC_DEFINE(HAVE_ZSTD_DECOMPRESSBOUND, 1, [Define if zstd has ZSTD_decompressBound])
   fi
 # so far we don't require it, but we might
-#else
-#  AC_MSG_ERROR("libzstd library and headers are required")
+else
+  AC_MSG_ERROR("libzstd library and headers are required")
 fi
 ])# R_ZSTD
 

--- a/src/gnuwin32/fixed/h/config.h
+++ b/src/gnuwin32/fixed/h/config.h
@@ -1040,12 +1040,6 @@
 /* Define if you have the X11/Xmu headers and libraries. */
 /* #undef HAVE_X11_Xmu */
 
-/* Define if your system has zstd >= 1.3.3. */
-#define HAVE_ZSTD 1
-
-/* Define if zstd has ZSTD_decompressBound */
-#define HAVE_ZSTD_DECOMPRESSBOUND 1
-
 /* Define to 1 if you have the `__cospi' function. */
 /* #undef HAVE___COSPI */
 

--- a/src/include/config.h.in
+++ b/src/include/config.h.in
@@ -998,15 +998,6 @@
 /* Define if you have the X11/Xmu headers and libraries. */
 #undef HAVE_X11_Xmu
 
-/* Define if your system has zstd >= 1.3.3. */
-#undef HAVE_ZSTD
-
-/* Define if zstd has ZSTD_decompressBound */
-#undef HAVE_ZSTD_DECOMPRESSBOUND
-
-/* Define to 1 if you have the <zstd.h> header file. */
-#undef HAVE_ZSTD_H
-
 /* Define to 1 if you have the '__cospi' function. */
 #undef HAVE___COSPI
 

--- a/src/main/connections.c
+++ b/src/main/connections.c
@@ -2399,19 +2399,7 @@ newxzfile(const char *description, const char *mode, int type, int compress)
     return new;
 }
 
-
-#ifdef HAVE_ZSTD
-
-#ifndef HAVE_ZSTD_DECOMPRESSBOUND
-static unsigned long long ZSTD_decompressBound(const void* src, size_t srcSize) {
-    /* FIXME: it is stupid, but we could add a full streaming decompression pass as a fall-back */
-    error("The used zstd library does not include support for streaming decompression bounds so we cannot decompress streams in memory.");
-}
-#else
-/* seems silly, but this is needed to declare ZSTD_decompressBound */
 #define ZSTD_STATIC_LINKING_ONLY 1
-#endif
-
 #include <zstd.h>
 
 typedef struct zstdfileconn {
@@ -2660,15 +2648,6 @@ newzstdfile(const char *description, const char *mode, int compress)
     ((Rzstdfileconn) new->private)->compress = compress;
     return new;
 }
-
-#else
-static Rconnection
-newzstdfile(const char *description, const char *mode, int compress) {
-    error("Zstd compression support was not included in this R binary.");
-    /* unreachable */
-    return 0;
-}
-#endif
 
 typedef enum { COMP_UNKNOWN = 0, COMP_GZ, COMP_BZ, COMP_XZ, COMP_ZSTD } comp_type;
 
@@ -6999,7 +6978,6 @@ SEXP R_decompress3(SEXP in, Rboolean *err)
 	lzma_end(&strm);
 #if 0 /* not enabled - just ready if we ever want to allow zstd */
     } else if (type == 'S') {
-#ifdef HAVE_ZSTD
 	unsigned long long sz = ZSTD_getFrameContentSize(p + 5, inlen - 5);
 	if (sz == ZSTD_CONTENTSIZE_UNKNOWN) /* possible streaming so no size in the header */
 	    sz = ZSTD_decompressBound(p + 5, inlen - 5);
@@ -7009,9 +6987,6 @@ SEXP R_decompress3(SEXP in, Rboolean *err)
 	    *err = TRUE;
 	    return R_NilValue;
 	}
-#else
-	error("Zstd compression support was not included in this R binary.");
-#endif
 #endif
     } else if (type == '2') {
 	int res;
@@ -7146,7 +7121,6 @@ do_memCompress(SEXP call, SEXP op, SEXP args, SEXP env)
 	break;
     }
     case 5: /* zstd */
-#ifdef HAVE_ZSTD
     {
 	size_t inlen = XLENGTH(from);
 	size_t outlen = ZSTD_compressBound(inlen);
@@ -7159,9 +7133,6 @@ do_memCompress(SEXP call, SEXP op, SEXP args, SEXP env)
 	memcpy(RAW(ans), buf, res);
 	break;
     }
-#else
-    error("Zstd compression support was not included in this R binary.");
-#endif
     default:
 	break;
     }
@@ -7373,7 +7344,6 @@ do_memDecompress(SEXP call, SEXP op, SEXP args, SEXP env)
 	break;
     }
     case 6: /* zstd */
-#ifdef HAVE_ZSTD
     {
 	size_t inlen = XLENGTH(from), res;
 	unsigned long long outlen;
@@ -7393,9 +7363,6 @@ do_memDecompress(SEXP call, SEXP op, SEXP args, SEXP env)
 	    memcpy(RAW(ans), buf, res);
 	break;
     }
-#else
-    error("Zstd compression support was not included in this R binary.");
-#endif
     // case 5 is "unknown', covered above
     default:
 	break;

--- a/src/main/platform.c
+++ b/src/main/platform.c
@@ -3601,6 +3601,7 @@ attribute_hidden SEXP do_mkjunction(SEXP call, SEXP op, SEXP args, SEXP rho)
 #include <zlib.h>
 #include <bzlib.h>
 #include <lzma.h>
+#include <zstd.h>
 
 #ifdef HAVE_PCRE2
   /* PCRE2_CODE_UNIT_WIDTH is defined to 8 via config.h */
@@ -3685,13 +3686,7 @@ do_eSoftVersion(SEXP call, SEXP op, SEXP args, SEXP rho)
     SET_STRING_ELT(ans, i, mkChar(""));
 #endif
     SET_STRING_ELT(nms, i++, mkChar("libdeflate"));
-
-#ifdef HAVE_ZSTD
-#include <zstd.h>
     SET_STRING_ELT(ans, i, mkChar(ZSTD_versionString()));
-#else
-    SET_STRING_ELT(ans, i, mkChar(""));
-#endif
     SET_STRING_ELT(nms, i++, mkChar("zstd"));
 
 #ifdef HAVE_PCRE2


### PR DESCRIPTION
Remove conditioning of zstd, such that we can be sure this is available from R-4.6 onward on all platforms.