### PR TITLE
Fix build on macOS

### DIFF
--- a/src/main/sysutils.c
+++ b/src/main/sysutils.c
@@ -58,7 +58,7 @@
 attribute_hidden int R_isWriteableDir(char *path);
 
 #ifdef HAVE_AQUA
-int (*ptr_CocoaSystem)(const char*);
+extern int (*ptr_CocoaSystem)(const char*);
 #endif
 
 #ifdef Win32


### PR DESCRIPTION
Follow-up to https://github.com/r-devel/r-svn/commit/826fe63263, cc @ltierney 

Submitted at https://bugs.r-project.org/show_bug.cgi?id=19044

On macOS I'm getting:

```
duplicate symbol '_ptr_CocoaSystem' in:
    /Users/lionel/Sync/Projects/R/r-core/r-svn/build/src/main/sysutils.o
    /Users/lionel/Sync/Projects/R/r-core/r-svn/build/src/unix/system.o
ld: 1 duplicate symbols
```

Why do r-devel/r-svn CI checks on macOS build successfully (e.g. https://github.com/r-devel/r-svn/actions/runs/23922541311/job/69772084184)? Not sure, but the CI is using "Apple clang version 17.0.0", whereas I'm using "Homebrew clang version 20.1.2". The linker might be more tolerant on CI.

In any case that's because of this new declaration in `Rinterface.h`:

```c
#ifdef HAVE_AQUA
extern int (*ptr_CocoaSystem)(const char*);
#endif
```

that conflicts with a definition in `sysutils.c`:

```c
int (*ptr_CocoaSystem)(const char*);
```

Note that the `Rinterface.h` header is included from `system.c` like this:

```c
#define __SYSTEM__
#define R_INTERFACE_PTRS 1
#include <Rinterface.h>
#undef __SYSTEM__
```

And in `Rinterface.h` we have:

```c
#ifdef __SYSTEM__
# define extern
#endif
```

Which turns the declaration into an actual definition, hence the duplicate symbol error.