### PR TITLE
Implement `...(arg)` forwarding syntax

### DIFF
--- a/src/include/Defn.h
+++ b/src/include/Defn.h
@@ -2256,6 +2256,7 @@ void process_site_Renviron(void);
 void process_system_Renviron(void);
 void process_user_Renviron(void);
 SEXP promiseArgs(SEXP, SEXP);
+SEXP dotsForwardSym(SEXP);
 int Rcons_vprintf(const char *, va_list);
 int REvprintf_internal(const char *, va_list);
 SEXP R_data_class(SEXP , Rboolean);

--- a/src/library/base/man/dots.Rd
+++ b/src/library/base/man/dots.Rd
@@ -35,6 +35,13 @@
   \code{...elt(n)}, etc. propagates \link[=invisible]{visibility}. This
   is consistent with the evaluation of named arguments which also
   propagates visibility.
+
+  \code{\dots(\var{arg})} forwards \var{arg} to another function. This only
+  matters for non-standard evaluation, e.g. with \code{\link{substitute}()}.
+  Normally the inner function only sees the name of the variable the wrapper
+  handed it. With \code{\dots(\var{arg})} it sees the expression the user
+  originally wrote, exactly as if the wrapper were not there. \var{arg} must be
+  a single symbol that is in scope; anything else is an error.
 }
 \usage{
 ...length()
@@ -75,6 +82,19 @@ chk.n2 <- function(...) stopifnot(identical(print(...names()), names(list(...)))
 chk.n2(4, foo=5, 6, bar=7, sini = sin(1:10), "bar")
 chk.n2()
 chk.n2(1,2)
+
+## ...(arg): forward a single argument transparently.
+## The callee sees the original expression, not the wrapper's name.
+label <- function(x) deparse(substitute(x))
+with.forward <- function(value) label(...(value))
+without.forward <- function(value) label(value)
+with.forward(sin(1:10)) ## [1] "sin(1:10)"
+without.forward(sin(1:10)) ## [1] "value"
+
+## A real use: a wrapper around plot() keeps the axis labels that
+## plot() builds from the expressions passed to it.
+bare.plot <- function(x, y) plot(...(x), ...(y), axes = FALSE)
+bare.plot(sin(1:10), cos(1:10)) ## labels "sin(1:10)" and "cos(1:10)", not "x"/"y"
 }
 \keyword{programming}
 \keyword{documentation}

--- a/src/library/compiler/R/cmp.R
+++ b/src/library/compiler/R/cmp.R
@@ -654,7 +654,8 @@ INCLNK.OP = 0,
 DECLNK.OP = 0,
 DECLNK_N.OP = 1,
 INCLNKSTK.OP = 0,
-DECLNKSTK.OP = 0
+DECLNKSTK.OP = 0,
+DOTSFWD.OP = 1
 )
 
 Opcodes.names <- names(Opcodes.argc)
@@ -788,6 +789,7 @@ DECLNK.OP <- 125
 DECLNK_N.OP <- 126
 INCLNKSTK.OP <- 127
 DECLNKSTK.OP <- 128
+DOTSFWD.OP <- 129
 
 
 ##
@@ -1195,6 +1197,14 @@ cmpCallArgs <- function(args, cb, cntxt, nse = FALSE) {
         n <- names[[i]]
         if (missing(a)) { ## better test for missing??
             cb$putcode(DOMISSING.OP)
+            cmpTag(n, cb)
+        }
+        else if (is.call(a) && identical(a[[1L]], quote(`...`)) &&
+                 length(a) == 2L && is.symbol(a[[2L]]) &&
+                 is.null(names(a)[-1L])) {
+            ## ...(sym): forward the promise bound to sym
+            ci <- cb$putconst(a[[2L]])
+            cb$putcode(DOTSFWD.OP, ci)
             cmpTag(n, cb)
         }
         else if (identical(a, quote(`...`))) {

--- a/src/main/eval.c
+++ b/src/main/eval.c
@@ -3612,6 +3612,47 @@ attribute_hidden SEXP do_set(SEXP call, SEXP op, SEXP args, SEXP rho)
   if (__tag__ != R_NilValue) SET_TAG(to, __tag__); \
 } while (0)
 
+/* Is `expr` a call to `...`? i.e. a LANGSXP whose CAR is R_DotsSymbol. */
+static R_INLINE Rboolean isDotsCall(SEXP expr)
+{
+    return TYPEOF(expr) == LANGSXP && CAR(expr) == R_DotsSymbol;
+}
+
+/* ...(sym) forwarding: detect a call of the form `...(sym)` in the
+   AST, i.e. a LANGSXP whose CAR is R_DotsSymbol and whose single
+   unnamed argument is a symbol.  Returns the symbol, or R_NilValue. */
+attribute_hidden SEXP dotsForwardSym(SEXP expr)
+{
+    if (isDotsCall(expr) &&
+	CDR(expr) != R_NilValue &&
+	CDDR(expr) == R_NilValue &&
+	TAG(CDR(expr)) == R_NilValue &&
+	TYPEOF(CADR(expr)) == SYMSXP)
+	return CADR(expr);
+    return R_NilValue;
+}
+
+/* Look up a forwarded symbol binding, erroring if unbound. */
+static SEXP findForwardVar(SEXP sym, SEXP rho)
+{
+    SEXP val = R_findVar(sym, rho);
+    if (val == R_UnboundValue)
+	error(_("object '%s' not found"), CHAR(PRINTNAME(sym)));
+    return val;
+}
+
+/* Validate a ...(sym) form and look up the forwarded binding.
+   Errors if the form is invalid or the symbol is unbound.
+   Returns the binding value (a PROMSXP, R_MissingArg, or a value). */
+static SEXP dotsForwardVal(SEXP expr, SEXP rho)
+{
+    SEXP fwd = dotsForwardSym(expr);
+    if (fwd == R_NilValue)
+	error(_("...(arg) requires a single symbol argument"));
+    return findForwardVar(fwd, rho);
+}
+
+
 /* Used in eval and applyMethod (object.c) for builtin primitives,
    do_internal (names.c) for builtin .Internals
    and in evalArgs.
@@ -3680,7 +3721,14 @@ attribute_hidden SEXP evalList(SEXP el, SEXP rho, SEXP call, int n)
 	                  EncodeChar(PRINTNAME(CAR(el))));
 #endif
 	} else {
-	    val = eval(CAR(el), rho);
+	    if (isDotsCall(CAR(el))) {
+		val = dotsForwardVal(CAR(el), rho);
+		if (val == R_MissingArg)
+		    errorcall(call, _("argument %d is empty"), n);
+		val = eval(val, rho);
+	    } else {
+		val = eval(CAR(el), rho);
+	    }
 	    INCREMENT_LINKS(val);
 	    ev = CONS_NR(val, R_NilValue);
 	    if (head == R_NilValue)
@@ -3822,6 +3870,16 @@ static SEXP promiseArgsEx(SEXP el, SEXP rho, Rboolean forward)
 	}
 	else if (CAR(el) == R_MissingArg) {
 	    SETCDR(tail, CONS(R_MissingArg, R_NilValue));
+	    tail = CDR(tail);
+	    COPY_TAG(tail, el);
+	}
+	/* ...(sym): forward the promise bound to sym */
+	else if (isDotsCall(CAR(el))) {
+	    SEXP val = dotsForwardVal(CAR(el), rho);
+	    if (val == R_MissingArg)
+		SETCDR(tail, CONS(R_MissingArg, R_NilValue));
+	    else
+		SETCDR(tail, CONS(mkPROMISE(val, rho), R_NilValue));
 	    tail = CDR(tail);
 	    COPY_TAG(tail, el);
 	}
@@ -4749,6 +4807,7 @@ enum {
   DECLNK_N_OP,
   INCLNKSTK_OP,
   DECLNKSTK_OP,
+  DOTSFWD_OP,
   OPCOUNT
 };
 
@@ -8054,6 +8113,23 @@ static SEXP bcEval_loop(struct bcEval_locals *ploc)
 	  else if (h != R_MissingArg)
 	    error(_("'...' used in an incorrect context"));
 	}
+	NEXT();
+      }
+    OP(DOTSFWD, 1):
+      {
+	SEXP sym = GETCONST(constants, GETOP());
+	SEXP val = findForwardVar(sym, rho);
+	SEXPTYPE ftype = CALL_FRAME_FTYPE();
+	if (ftype == CLOSXP) {
+	    if (val != R_MissingArg)
+		val = mkPROMISE(val, rho);
+	} else if (ftype == BUILTINSXP) {
+	    if (val == R_MissingArg)
+		error(_("argument is empty"));
+	    val = eval(val, rho);
+	}
+	/* SPECIALSXP: push forwarded arg as-is, specials handle their own args */
+	PUSHCALLARG(val);
 	NEXT();
       }
     OP(PUSHARG, 0): PUSHCALLARG(BCNPOP()); NEXT();

--- a/src/main/unique.c
+++ b/src/main/unique.c
@@ -1863,6 +1863,18 @@ static SEXP subDots(SEXP rho)
     return rval;
 }
 
+/* Resolve a ...(sym) forwarding form: look up sym in rho and chase
+   through the promise chain to recover the original expression.
+   Parallel to subDots() which does the same for ... elements. */
+static SEXP subArg(SEXP sym, SEXP rho)
+{
+    SEXP val = R_findVar(sym, rho);
+    if (val == R_UnboundValue)
+	error(_("object '%s' not found"), CHAR(PRINTNAME(sym)));
+    while (TYPEOF(val) == PROMSXP)
+	val = PREXPR(val);
+    return val;
+}
 
 attribute_hidden SEXP do_matchcall(SEXP call, SEXP op, SEXP args, SEXP env)
 {
@@ -1944,6 +1956,15 @@ attribute_hidden SEXP do_matchcall(SEXP call, SEXP op, SEXP args, SEXP env)
 	    }
 	}
     }
+
+    /* Resolve ...(sym) forwarding forms via subArg(), consistent with
+       how subDots() resolves ... elements above. */
+    for (t1 = actuals; t1 != R_NilValue; t1 = CDR(t1)) {
+	SEXP fwd = dotsForwardSym(CAR(t1));
+	if (fwd != R_NilValue)
+	    SETCAR(t1, subArg(fwd, sysp));
+    }
+
     rlist = matchArgs_RC(formals, actuals, call);
 
     /* Attach the argument names as tags */

--- a/tests/reg-tests-1e.R
+++ b/tests/reg-tests-1e.R
@@ -3411,6 +3411,220 @@ stopifnot(exprs = {
 if(is.character(ans)) detach("package:cluster", unload = TRUE)
 
 
+## ...(arg) transparent argument forwarding
+local({
+    ## Here we test the interpreted paths only
+    oldJIT <- compiler::enableJIT(0)
+    on.exit(compiler::enableJIT(oldJIT))
+    getBindingType <- function(sym, env = parent.frame()) {
+        if (is.character(sym)) sym <- as.name(sym)
+        .Internal(getBindingType(sym, env))
+    }
+    delayedExpr <- function(sym, env = parent.frame()) {
+        if (is.character(sym)) sym <- as.name(sym)
+        .Internal(delayedBindingExpression(sym, env))
+    }
+    delayedEnv <- function(sym, env = parent.frame()) {
+        if (is.character(sym)) sym <- as.name(sym)
+        .Internal(delayedBindingEnvironment(sym, env))
+    }
+    forcedExpr <- function(sym, env = parent.frame()) {
+        if (is.character(sym)) sym <- as.name(sym)
+        .Internal(forcedBindingExpression(sym, env))
+    }
+    inner_sub <- function(x) substitute(x)
+    ## substitute() sees the original expression, not the intermediate name
+    wrapper <- function(x) inner_sub(...(x))
+    stopifnot(identical(wrapper(1 + 2), quote(1 + 2)))
+    ## without forwarding, substitute() sees `x`
+    wrapper_plain <- function(x) inner_sub(x)
+    stopifnot(identical(wrapper_plain(1 + 2), quote(x)))
+    ## forwarding an already-forced promise preserves the expression
+    wrapper_forced <- function(x) { force(x); inner_sub(...(x)) }
+    stopifnot(identical(wrapper_forced(1 + 2), quote(1 + 2)))
+    ## missing argument forwarding
+    inner_miss <- function(x) missing(x)
+    wrapper_miss <- function(x) inner_miss(...(x))
+    stopifnot(wrapper_miss())
+    stopifnot(!wrapper_miss(1))
+    ## callee default kicks in when missing is forwarded
+    inner_default <- function(x = 42) x
+    wrapper_default <- function(x) inner_default(...(x))
+    stopifnot(identical(wrapper_default(), 42))
+    ## multiple forwarded args
+    inner2 <- function(x, y) list(substitute(x), substitute(y))
+    wrapper2 <- function(x, y) inner2(...(x), ...(y))
+    stopifnot(identical(wrapper2(quote(a + b), quote(c * d)),
+                        list(quote(quote(a + b)), quote(quote(c * d)))))
+    ## named argument at call site
+    inner_named <- function(y) substitute(y)
+    wrapper_named <- function(x) inner_named(y = ...(x))
+    stopifnot(identical(wrapper_named(1 + 2), quote(1 + 2)))
+    ## mix forwarded and regular args
+    inner_mix <- function(x, y, z) list(substitute(x), substitute(y), substitute(z))
+    wrapper_mix <- function(a, b) inner_mix(...(a), y = 42, z = ...(b))
+    r <- wrapper_mix(quote(hello), quote(world))
+    stopifnot(identical(r[[1]], quote(quote(hello))),
+              identical(r[[2]], 42),
+              identical(r[[3]], quote(quote(world))))
+    ## shared forcing side effect
+    env <- environment()
+    env$counter <- 0L
+    inner_force <- function(x) x
+    wrapper_shared <- function(x) {
+        v <- inner_force(...(x))
+        list(callee = v, caller = x)
+    }
+    r <- wrapper_shared({ env$counter <- env$counter + 1L; 99 })
+    stopifnot(identical(r$callee, 99),
+              identical(r$caller, 99),
+              identical(env$counter, 1L))
+    ## sys.call() shows ...(x) literally
+    inner_sc <- function(x) sys.call()
+    wrapper_sc <- function(x) inner_sc(...(x))
+    stopifnot(identical(deparse(wrapper_sc(1 + 2)), "inner_sc(...(x))"))
+    ## match.call() resolves ...(x) to the original expression
+    inner_mc <- function(x) match.call()
+    wrapper_mc <- function(x) inner_mc(...(x))
+    stopifnot(identical(deparse(wrapper_mc(1 + 2)), "inner_mc(x = 1 + 2)"))
+    ## double forwarding (chain of wrappers)
+    mid <- function(x) inner_sub(...(x))
+    outer_fn <- function(x) mid(...(x))
+    stopifnot(identical(outer_fn(1 + 2), quote(1 + 2)))
+    ## ...(x) combined with ... forwarding
+    inner_dots <- function(x, ...) list(substitute(x), substitute(list(...)))
+    wrapper_dots <- function(x, ...) inner_dots(...(x), ...)
+    r <- wrapper_dots(1 + 2, 3 + 4, 5 + 6)
+    stopifnot(identical(r[[1]], quote(1 + 2)),
+              identical(r[[2]], quote(list(3 + 4, 5 + 6))))
+    ## ...(x) landing in callee's ...
+    inner_dots2 <- function(...) substitute(list(...))
+    wrapper_dots2 <- function(x, y) inner_dots2(...(x), ...(y))
+    stopifnot(identical(wrapper_dots2(1 + 2, 3 + 4),
+                        quote(list(1 + 2, 3 + 4))))
+    ## evalq(...(x))
+    wrapper_evalq <- function(x) evalq(inner_sub(...(x)))
+    stopifnot(identical(wrapper_evalq(1 + 2), quote(1 + 2)))
+    ## ...(non-symbol) is an error
+    eMsg <- "...(arg) requires a single symbol argument"
+    stopifnot(identical(tryCmsg(inner_sub(...(1 + 2))), eMsg))
+    stopifnot(identical(tryCmsg(inner_sub(...())), eMsg))
+    stopifnot(identical(tryCmsg(inner_sub(...(x, y))), eMsg))
+    ## ...(x) where x is unbound is an error
+    wrapper_unbound <- function() inner_sub(...(no_such_var))
+    stopifnot(identical(tryCmsg(wrapper_unbound()),
+                        "object 'no_such_var' not found"))
+    ## binding type: forwarded promise is "delayed", becomes "forced"
+    e <- environment()
+    x <- 1
+    get_type <- function(x) getBindingType("x")
+    fwd_type <- function(x) get_type(...(x))
+    stopifnot(fwd_type(x) == "delayed")
+    get_type_forced <- function(x) { force(x); getBindingType("x") }
+    fwd_type_forced <- function(x) get_type_forced(...(x))
+    stopifnot(fwd_type_forced(x) == "forced")
+    ## forcing in callee marks the forwarded promise as forced in the wrapper too
+    fwd_type_after <- function(x) {
+        inner <- function(x) { force(x); "done" }
+        inner(...(x))
+        getBindingType("x")
+    }
+    stopifnot(fwd_type_after(x) == "forced")
+    ## delayedBindingExpression sees the original expression
+    get_expr <- function(x) delayedExpr("x")
+    fwd_expr <- function(x) get_expr(...(x))
+    stopifnot(identical(fwd_expr(x), quote(x)))
+    stopifnot(identical(fwd_expr(1 + 2), quote(1 + 2)))
+    ## delayedBindingEnvironment sees the original caller's environment
+    get_env <- function(x) delayedEnv("x")
+    fwd_env <- function(x) get_env(...(x))
+    stopifnot(identical(fwd_env(x), e))
+    ## forcedBindingExpression works through ...(x) forwarding
+    get_fexpr <- function(x) { force(x); forcedExpr("x") }
+    fwd_fexpr <- function(x) get_fexpr(...(x))
+    stopifnot(identical(fwd_fexpr(x), quote(x)))
+    stopifnot(identical(fwd_fexpr(1 + 2), quote(1 + 2)))
+    ## double forwarding with binding accessors
+    mid_expr <- function(x) get_expr(...(x))
+    deep_expr <- function(x) mid_expr(...(x))
+    stopifnot(identical(deep_expr(x), quote(x)))
+    mid_env <- function(x) get_env(...(x))
+    deep_env <- function(x) mid_env(...(x))
+    stopifnot(identical(deep_env(x), e))
+})
+
+
+## ...(arg) forwarding with bytecode-compiled functions
+local({
+    inner_sub <- compiler::cmpfun(function(x) substitute(x))
+    wrapper <- compiler::cmpfun(function(x) inner_sub(...(x)))
+    stopifnot(identical(wrapper(1 + 2), quote(1 + 2)))
+    ## without forwarding, substitute() sees `x`
+    wrapper_plain <- compiler::cmpfun(function(x) inner_sub(x))
+    stopifnot(identical(wrapper_plain(1 + 2), quote(x)))
+    ## forwarding an already-forced promise preserves the expression
+    wrapper_forced <- compiler::cmpfun(function(x) { force(x); inner_sub(...(x)) })
+    stopifnot(identical(wrapper_forced(1 + 2), quote(1 + 2)))
+    ## missing argument forwarding
+    inner_miss <- compiler::cmpfun(function(x) missing(x))
+    wrapper_miss <- compiler::cmpfun(function(x) inner_miss(...(x)))
+    stopifnot(wrapper_miss())
+    stopifnot(!wrapper_miss(1))
+    ## callee default kicks in when missing is forwarded
+    inner_default <- compiler::cmpfun(function(x = 42) x)
+    wrapper_default <- compiler::cmpfun(function(x) inner_default(...(x)))
+    stopifnot(identical(wrapper_default(), 42))
+    ## named argument at call site
+    inner_named <- compiler::cmpfun(function(y) substitute(y))
+    wrapper_named <- compiler::cmpfun(function(x) inner_named(y = ...(x)))
+    stopifnot(identical(wrapper_named(1 + 2), quote(1 + 2)))
+    ## double forwarding
+    mid <- compiler::cmpfun(function(x) inner_sub(...(x)))
+    outer_fn <- compiler::cmpfun(function(x) mid(...(x)))
+    stopifnot(identical(outer_fn(1 + 2), quote(1 + 2)))
+    ## ...(x) combined with ... forwarding
+    inner_dots <- compiler::cmpfun(function(x, ...) list(substitute(x), substitute(list(...))))
+    wrapper_dots <- compiler::cmpfun(function(x, ...) inner_dots(...(x), ...))
+    r <- wrapper_dots(1 + 2, 3 + 4, 5 + 6)
+    stopifnot(identical(r[[1]], quote(1 + 2)),
+              identical(r[[2]], quote(list(3 + 4, 5 + 6))))
+    ## ...(x) landing in callee's ...
+    inner_dots2 <- compiler::cmpfun(function(...) substitute(list(...)))
+    wrapper_dots2 <- compiler::cmpfun(function(x, y) inner_dots2(...(x), ...(y)))
+    stopifnot(identical(wrapper_dots2(1 + 2, 3 + 4),
+                        quote(list(1 + 2, 3 + 4))))
+    ## shared forcing side effect
+    env <- environment()
+    env$counter <- 0L
+    inner_force <- compiler::cmpfun(function(x) x)
+    wrapper_shared <- compiler::cmpfun(function(x) {
+        v <- inner_force(...(x))
+        list(callee = v, caller = x)
+    })
+    r <- wrapper_shared({ env$counter <- env$counter + 1L; 99 })
+    stopifnot(identical(r$callee, 99),
+              identical(r$caller, 99),
+              identical(env$counter, 1L))
+    ## sys.call() shows ...(x) literally
+    inner_sc <- compiler::cmpfun(function(x) sys.call())
+    wrapper_sc <- compiler::cmpfun(function(x) inner_sc(...(x)))
+    stopifnot(identical(deparse(wrapper_sc(1 + 2)), "inner_sc(...(x))"))
+    ## match.call() resolves ...(x) to the original expression
+    inner_mc <- compiler::cmpfun(function(x) match.call())
+    wrapper_mc <- compiler::cmpfun(function(x) inner_mc(...(x)))
+    stopifnot(identical(deparse(wrapper_mc(1 + 2)), "inner_mc(x = 1 + 2)"))
+    ## ...(non-symbol) is an error in compiled code too
+    eMsg <- "...(arg) requires a single symbol argument"
+    stopifnot(identical(tryCmsg(inner_sub(...(1 + 2))), eMsg))
+    stopifnot(identical(tryCmsg(inner_sub(...())), eMsg))
+    stopifnot(identical(tryCmsg(inner_sub(...(x, y))), eMsg))
+    ## ...(x) where x is unbound is an error in compiled code
+    wrapper_unbound <- compiler::cmpfun(function() inner_sub(...(no_such_var)))
+    stopifnot(identical(tryCmsg(wrapper_unbound()),
+                        "object 'no_such_var' not found"))
+})
+
+
 
 ## keep at end
 rbind(last =  proc.time() - .pt,


### PR DESCRIPTION
POC for https://github.com/RConsortium/S7/issues/592

This adds a `...(arg)` syntax that forwards a named argument (here `arg`) across layers of function calls using the same mechanism as `...`. This allows wrapping NSE functions that inspect their arguments with `substitute()`, and have expression capture work transparently across the wrapper:

```r
label <- function(x) deparse(substitute(x))

with_forward <- function(value) label(...(value))
without_forward <- function(value) label(value)

with_forward(sin(1:10))
#> [1] "sin(1:10)"

without_forward(sin(1:10))
#> [1] "value"
```

For instance, this makes it possible to wrap `plot()` and have the internal labeling of dimensions work as expected:

```r
# Wrapper that changes some arguments
bare_plot <- function(x, y) plot(...(x), ...(y), axes = FALSE)

# labels "sin(1:10)" and "cos(1:10)", not "x" and "y"
bare_plot(sin(1:10), cos(1:10))
```

As a bonus, this syntax can be a full base R replacement for `{{` in tidyeval, without any changes to rlang. The capture side `enquo()` is implemented on top of the new environment accessors, and would be immediately compatible with arguments forwarded with `...()`, capturing both the relevant expression and its environment.

Finally, that mechanism would also solve the forwarding issue for S7, which is the motivating case for this POC:

```r
gen <- function(x, y, ...) {
  method <- find_method(class_of(x))
  method(...(x), ...(y), ...)
}
```