### PR TITLE
Bail in `wgl_histadd()` if initialization has not occurred

### DIFF
--- a/src/gnuwin32/getline/wc_history.c
+++ b/src/gnuwin32/getline/wc_history.c
@@ -73,7 +73,7 @@ void wgl_histadd(const wchar_t *buf)
 {
     const wchar_t *p = buf;
 
-    if(wgl_init_done > 0) return;
+    if(wgl_init_done) return;
     while (*p == ' ' || *p == '\t' || *p == '\n') p++;
     if (*p) {
 	hist_buf[hist_last] = hist_save(buf);


### PR DESCRIPTION
With the following combination, you can currently crash R:

- Windows
- `CharacterMode = RGui` (What RStudio and Positron do)
- Start R in such a way that `wgl_hist_init()` does not get called
    - It is only called via `AppMain -> setupui -> wgl_hist_init`, which I'm somewhat certain means that any embedder of R won't end up calling `wgl_hist_init`, because we don't call `AppMain`.
- Call `utils::timestamp()`, crash!

---

When `wgl_hist_init()` is not called on startup, this leaves `static wchar_t  **hist_buf;` unset, and also leaves `static int      wgl_init_done = -1;`, which is the "guard" to check before accessing `hist_buf`.

All `wgl_*()` functions in `wc_history.c` check `wgl_init_done` in some way before proceeding, with:

- `wgl_init_done = -1` meaning unset
- `wgl_init_done = 0` meaning set
- `wgl_init_done = 1` meaning there was an error and history is disabled

But `wgl_histadd()` is a noticeable outlier. Rather than doing `if(wgl_init_done) return;`, which catches `-1` and `1` cases, it does `if(wgl_init_done > 1) return;`, which allows the default unset case of `-1` to slip through, and then it tries to write to an unset `hist_buf`, causing a crash.

You can cause this to crash R via the following:

- R call to `utils::timestamp()`
- Which calls the C level `addhistory()`
- Which calls `wgl_histadd()` when `CharacterMode == RGui`
- Then you get a crash

With this PR, I'm expecting that `wgl_histadd()` now just silently exits since `hist_buf` hasn't been initialized. Users on Windows will still see an emitted `utils::timestamp()`, it just won't save to any history buffer.

---

Notably, RStudio currently works around this by [overloading](https://github.com/rstudio/rstudio/blob/fbc9a8b899048759fffe5c4a9e7581913c5797e7/src/cpp/r/R/Tools.R#L946-L951) the R level `savehistory()`, `loadhistory()`, and `timestamp()` on Windows. In Positron we have not done this, which has resulted in this bug report https://github.com/posit-dev/positron/issues/13261.

In Positron, we will probably override `timestamp()` at the very least (for old R compatibility), since it seems to be the only way to get directly at this unsafe `wgl_histadd()` call.

But it still seems worth fixing in general.