### PR TITLE
[Bugzilla#19083] Allow standardGeneric to result from setGeneric even if '{' is used in def=

### DIFF
--- a/src/library/methods/R/Methods.R
+++ b/src/library/methods/R/Methods.R
@@ -114,13 +114,18 @@ setGeneric <-
         if(is.primitive(def) || !is.function(def))
             stop(gettextf("if the 'def' argument is supplied, it must be a function that calls standardGeneric(\"%s\") or is the default",
                           name), domain = NA)
-        nonstandardCase <- .NonstandardGenericTest(body(def), name, stdGenericBody)
+        fbody <- body(def)
+        attributes(fbody) <- NULL
+        bracedGenericBody <- call("{", stdGenericBody)
+        nonstandardCase <- .NonstandardGenericTest(fbody, name, stdGenericBody, bracedGenericBody)
         if(is.na(nonstandardCase)) {
             if(is.null(useAsDefault)) {# take this as the default
                 useAsDefault <- def
             }
             body(def, envir = as.environment(where)) <- stdGenericBody
             nonstandardCase <- FALSE
+        } else if (!nonstandardCase && identical(fbody, bracedGenericBody)) {
+            body(def, envir = as.environment(where)) <- stdGenericBody
         }
         fdef <- def
         if(is.null(genericFunction) && nonstandardCase)

--- a/src/library/methods/R/RMethodUtils.R
+++ b/src/library/methods/R/RMethodUtils.R
@@ -1213,9 +1213,11 @@ metaNameUndo <- function(strings, prefix, searchForm = FALSE)
         FALSE
 }
 
-.NonstandardGenericTest <- function(body, fname, stdBody)
+.NonstandardGenericTest <- function(body, fname, stdBody, bracedBody)
 {
     if(identical(body, stdBody))
+        FALSE
+    else if(identical(body, bracedBody))
         FALSE
     else if(.recursiveCallTest(body, fname))
         TRUE

--- a/tests/reg-S4.R
+++ b/tests/reg-S4.R
@@ -878,6 +878,16 @@ setClass("foo", slots = c(y = "numeric"))
 setClass("bar", contains = "foo")
 body(getClass("bar")@contains[[1]]@coerce)[[2]]
 
+## setGeneric def can be in '{' for convenience
+setGeneric("BracedGenericDef", function(obj) {
+    standardGeneric("BracedGenericDef")
+})
+g <- getGeneric("BracedGenericDef")
+## assert correct class and `{` is stripped from result
+stopifnot(exprs = {
+    is(g, "standardGeneric")
+    identical(body(g), substitute(standardGeneric("BracedGenericDef")))
+})
 
 
 ## ----- from here on, keep at EOF -----

--- a/tests/reg-S4.Rout.save
+++ b/tests/reg-S4.Rout.save
@@ -1,11 +1,13 @@
 
-R Under development (unstable) (2024-08-27 r87063) -- "Unsuffered Consequences"
-Copyright (C) 2024 The R Foundation for Statistical Computing
+R Under development (unstable) (2026-06-04 r90104) -- "Unsuffered Consequences"
+Copyright (C) 2026 The R Foundation for Statistical Computing
 Platform: x86_64-pc-linux-gnu
 
 R is free software and comes with ABSOLUTELY NO WARRANTY.
 You are welcome to redistribute it under certain conditions.
 Type 'license()' or 'licence()' for distribution details.
+
+  Natural language support but running in an English locale
 
 R is a collaborative project with many contributors.
 Type 'contributors()' for more information and
@@ -1176,12 +1178,23 @@ value <- methods::new("A")
 > body(getClass("bar")@contains[[1]]@coerce)[[2]]
 class(from) <- "foo"
 > 
+> ## setGeneric def can be in '{' for convenience
+> setGeneric("BracedGenericDef", function(obj) {
++     standardGeneric("BracedGenericDef")
++ })
+[1] "BracedGenericDef"
+> g <- getGeneric("BracedGenericDef")
+> ## assert correct class and `{` is stripped from result
+> stopifnot(exprs = {
++     is(g, "standardGeneric")
++     identical(body(g), substitute(standardGeneric("BracedGenericDef")))
++ })
 > 
 > 
 > ## ----- from here on, keep at EOF -----
 > 
 > cat('Time elapsed: ', proc.time(),'\n')
-Time elapsed:  0.869 0.169 1.642 0.001 0.003 
+Time elapsed:  0.853 0.096 0.95 0.012 0.003 
 > 
 > ### NB: Only add new tests here _IF_   checking output,
 > ### --  otherwise use ./classes-methods.R


### PR DESCRIPTION
https://bugs.r-project.org/show_bug.cgi?id=19083