### PR TITLE
Disallow `|` commands in `postscript()` (and hence `pdf()`)

### DIFF
--- a/doc/NEWS.Rd
+++ b/doc/NEWS.Rd
@@ -8,7 +8,12 @@
 \section{\Rlogo Changes in R-devel}{
   \subsection{Significant User-Visible Changes}{
     \itemize{
-      \item .
+      \item \code{pdf()} and \code{postscript()} no longer interpret a
+      \code{file} argument of the form \code{"|cmd"} as a command to
+      pipe the output to, and now signal an error: this was a
+      potential security risk.  To print PostScript output, use
+      \code{postscript(file = "", command = ...)} or
+      \code{print.it = TRUE}.
     }
   }
 

--- a/src/library/grDevices/R/unix/dev2bitmap.R
+++ b/src/library/grDevices/R/unix/dev2bitmap.R
@@ -77,14 +77,14 @@ bitmap <- function(file, type = "png16m", height = 7, width = 7, res = 72,
     extra <- ""
     if (!is.na(taa)) extra <- paste0(" -dTextAlphaBits=", taa)
     if (!is.na(gaa)) extra <- paste0(extra, " -dGraphicsAlphaBits=", gaa)
-    cmd <- paste0("|", shQuote(gsexe),
+    cmd <- paste0(shQuote(gsexe),
                   " -dNOPAUSE -dBATCH -q -sDEVICE=", type,
                   " -r", res,
                   " -dAutoRotatePages=/None",
                   " -g", ceiling(res*width), "x", ceiling(res*height),
                   extra,
                   " -sOutputFile=", shQuote(file), " -")
-    postscript(file = cmd, width = width, height = height,
+    postscript(file = "", command = cmd, width = width, height = height,
                pointsize = pointsize, paper = "special", horizontal = FALSE, ...)
     invisible()
 }

--- a/src/library/grDevices/man/pdf.Rd
+++ b/src/library/grDevices/man/pdf.Rd
@@ -27,8 +27,7 @@ pdf(file = if(onefile) "Rplots.pdf" else "Rplot\%03d.pdf",
     inches.  The default values are \code{7}.}
   \item{onefile}{logical: if true (the default) allow multiple figures
     in one file.  If false, generate a file with name containing the page
-    number for each page.  Defaults to \code{TRUE}, and forced to true
-    if \code{file} is a pipe.}
+    number for each page.  Defaults to \code{TRUE}.}
   \item{family}{the initial font family to be used, normally as a
     character string.  See the section \sQuote{Families}.  Defaults to
     \code{"Helvetica"}.}
@@ -360,12 +359,6 @@ pdf(file = if(onefile) "Rplots.pdf" else "Rplot\%03d.pdf",
   At very small line widths, the line type may be forced to solid.
 }
 
-\section{Printing}{
-  Except on Windows it is possible to print directly from \code{pdf} by
-  something like (this is appropriate for a CUPS printing system):
-\preformatted{    pdf("|lp -o landscape", paper = "a4r")}
-  This forces \code{onefile = TRUE}.
-}
 \note{
   If you have drawn any typeset glyphs (see \code{\link{glyphInfo}})
   then it is \emph{highly} recommended that you use

--- a/src/library/grDevices/man/postscript.Rd
+++ b/src/library/grDevices/man/postscript.Rd
@@ -25,8 +25,6 @@ postscript(file = if(onefile) "Rplots.ps" else "Rplot\%03d.ps",
   \item{file}{a character string giving the file path.  If it is
     \code{""}, the output is piped to the command given by the argument
     \code{command}.
-    If it is of the form \code{"|cmd"}, the output is piped to the
-    command given by \command{cmd}.
 
     For use with \code{onefile = FALSE}, give a C integer format such as
     \code{"Rplot\%03d.ps"} (the default in that case).  The string
@@ -211,7 +209,7 @@ postscript(file = if(onefile) "Rplots.ps" else "Rplot\%03d.ps",
     when the device is closed.  Note that the plot file is not deleted
     unless \code{command} arranges to delete it.
 
-    \item \code{file = ""} or \code{file = "|cmd"} can be used to print
+    \item \code{file = ""} can be used to print
     using a pipe.  Failure to open the command will probably be reported
     to the terminal but not to \R, in which case close the
     device by \code{dev.off} immediately.
@@ -296,7 +294,7 @@ postscript("foo.ps")
 dev.off()              # turn off the postscript device
 
 ## On Unix-alikes only:
-postscript("|lp -dlw")
+postscript(file = "", command = "lp -dlw")
 # produce the desired graph(s)
 dev.off()              # plot will appear on printer
 

--- a/src/library/grDevices/src/devPS.c
+++ b/src/library/grDevices/src/devPS.c
@@ -3751,17 +3751,9 @@ static void PS_Open(pDevDesc dd, PostScriptDesc *pd)
 	    return;
 	}
     } else if (pd->filename[0] == '|') {
-	errno = 0;
-	pd->psfp = R_popen(pd->filename + 1, "w");
-	pd->open_type = 1;
-	if (!pd->psfp || errno != 0) {
-	    char errbuf[strlen(pd->filename + 1) + 1];
-	    strcpy(errbuf, pd->filename + 1);
-	    PS_cleanup(4, dd, pd);
-	    error(_("cannot open 'postscript' pipe to '%s'"),
-		     errbuf);
-	    return;
-	}
+	PS_cleanup(4, dd, pd);
+	error(_("file names starting with '|' are no longer supported"));
+	return;
     } else {
 	snprintf(buf, 512, pd->filename, pd->fileno + 1); /* file 1 to start */
 	pd->psfp = R_fopen(R_ExpandFileName(buf), "w");
@@ -4914,8 +4906,6 @@ typedef struct {
 
 typedef struct {
     char filename[R_PATH_MAX];
-    int open_type;
-    char cmd[R_PATH_MAX];
 
     char papername[64];	/* paper name */
     int paperwidth;	/* paper width in big points (1/72 in) */
@@ -4934,7 +4924,6 @@ typedef struct {
 
     FILE *pdffp;        /* output file */
     FILE *mainfp;
-    FILE *pipefp;
 
     /* This group of variables track the current device status.
      * They should only be set by routines that emit PDF. */
@@ -8171,19 +8160,6 @@ static void PDF_endfile(PDFDesc *pd)
     rewind(pd->pdffp);
     fprintf(pd->pdffp, "%%PDF-%i.%i\n", pd->versionMajor, pd->versionMinor);
     fclose(pd->pdffp);
-    if (pd->open_type == 1) {
-	char buf[APPENDBUFSIZE];
-	size_t nc;
-	pd->pdffp = R_fopen(pd->filename, "rb"); 
-	while((nc = fread(buf, 1, APPENDBUFSIZE, pd->pdffp))) {
-	    if(nc != fwrite(buf, 1, nc, pd->pipefp))
-		error("write error");
-	    if (nc < APPENDBUFSIZE) break;
-	}
-	fclose(pd->pdffp);
-	pclose(pd->pipefp);
-	unlink(pd->filename);
-    }
 }
 
 
@@ -8195,27 +8171,10 @@ static void PDF_Open(pDevDesc dd, PDFDesc *pd)
         return;
     
     if (pd->filename[0] == '|') {
-	strncpy(pd->cmd, pd->filename + 1, R_PATH_MAX - 1);
-	pd->cmd[R_PATH_MAX - 1] = '\0';
-	char *tmp = R_tmpnam("Rpdf", R_TempDir);
-	strncpy(pd->filename, tmp, R_PATH_MAX - 1);
-	pd->filename[R_PATH_MAX - 1] = '\0';
-	free(tmp);
-	errno = 0;
-	pd->pipefp = R_popen(pd->cmd, "w");
-	if (!pd->pipefp || errno != 0) {
-	    char errbuf[strlen(pd->cmd) + 1];
-	    strcpy(errbuf, pd->cmd);
-	    PDFcleanup(7, pd);
-	    error(_("cannot open 'pdf' pipe to '%s'"), errbuf);
-	    return;
-	}
-	pd->open_type = 1;
-	if (!pd->onefile) {
-	    pd->onefile = TRUE;
-	    warning(_("file = \"|cmd\" implies 'onefile = TRUE'"));
-	}
-    } else pd->open_type = 0;
+	PDFcleanup(7, pd);
+	error(_("file names starting with '|' are no longer supported"));
+	return;
+    }
     snprintf(buf, 512, pd->filename, pd->fileno + 1); /* file 1 to start */
     /* NB: this must be binary to get tell positions and line endings right,
        as well as allowing binary streams */


### PR DESCRIPTION
`file` is, in the vast majority of cases, a path — inert data naming where bytes should land. But when its first character is `|`, the remainder is handed to `R_popen()`, i.e. executed by `/bin/sh -c`. So `pdf(file = x)` is a write-to-disk operation for almost all values of `x` and an arbitrary-command-execution operation for a small, invisible subset of them. Nothing at the call site signals that the second mode exists, and it requires a close read of the documentation to discover it exists.

It's reasonable to expect that a careful R programmer will know that `system()` is potentially dangerous when given unsanitized user inputs; I don't think they have any particular reason to suspect that `pdf()` is just as bad. This matters because filenames are routinely derived from untrusted input. R is now deployed in Shiny, plumber, OpenCPU and batch report-generation services where it's reasonable for the filename to be a user-specified parameter.

The cost of removing this functionality is very small because the legitimate capability of piping device output to a program remains fully available through `postscript(file = "", command = …)` and `print.it = TRUE`.