### PR TITLE
Update contrast.Rd to fix warnings in packages inheriting params

### DIFF
--- a/src/library/stats/man/contrast.Rd
+++ b/src/library/stats/man/contrast.Rd
@@ -25,7 +25,7 @@ contr.SAS(n, contrasts = TRUE, sparse = FALSE)
   \item{contrasts}{a logical indicating whether contrasts should be
     computed.}
   \item{sparse}{logical indicating if the result should be sparse
-    (of class \code{\linkS4class[Matrix]{dgCMatrix}}), using
+    (of class \code{\linkS4class{Matrix:dgCMatrix}}), using
     package \CRANpkg{Matrix}.}
   \item{scores}{the set of values over which orthogonal polynomials are
     to be computed.}


### PR DESCRIPTION
bugzilla #19088

Currently when a package inherits params from contr.sum() it generates an error for the package on the build check.

Version: 0.18.1
Check: whether package can be installed
Result: WARN 
  Found the following significant warnings:
    Warning: /Volumes/Builds/packages/big-sur-arm64/results/4.5/bayestestR.Rcheck/00_pkg_src/bayestestR/man/contr.equalprior.Rd:24: unexpected TEXT '[Matrix]', expecting '{'
Flavor: r-oldrel-macos-arm64