### PR TITLE
enforce UTF-8 encoding for DCF read/write

### DIFF
--- a/doc/NEWS.Rd
+++ b/doc/NEWS.Rd
@@ -8,7 +8,18 @@
 \section{\Rlogo Changes in R-devel}{
   \subsection{Significant User-Visible Changes}{
     \itemize{
-      \item .
+      \item \code{read.dcf()} and \code{write.dcf()} now treat \abbr{DCF}
+      files (such as package \file{DESCRIPTION} and repository
+      \file{PACKAGES} files) as \abbr{UTF-8}, as required by the Debian
+      control file format.  \code{read.dcf()} returns values in
+      \abbr{UTF-8} and \code{write.dcf()} always writes \abbr{UTF-8}
+      regardless of the session locale; bytes which are not valid
+      \abbr{UTF-8} are preserved by escaping them as \samp{<xx>} rather
+      than being re-encoded via a \samp{Encoding} field.  As a
+      consequence, the \code{useBytes} argument of \code{write.dcf()} is
+      ignored, and non-\abbr{UTF-8} \file{DESCRIPTION} files (e.g. those
+      declaring \samp{Encoding: latin1}) are no longer re-encoded on
+      reading.
     }
   }
 

--- a/src/library/base/R/dcf.R
+++ b/src/library/base/R/dcf.R
@@ -16,6 +16,23 @@
 #  A copy of the GNU General Public License is available at
 #  https://www.R-project.org/Licenses/
 
+## Canonicalize 's' to valid UTF-8: honour any declared encoding via
+## enc2utf8(), then escape bytes that are still invalid as <xx>, as
+## iconv(sub = "byte") does.  DCF files are required to be UTF-8.  This is
+## the same canonicalization strwrap() does inline; non-character input
+## (which carries no encoding) is returned unchanged.
+.enc2utf8_sub <-
+function(s)
+{
+    if(!is.character(s))
+        return(s)
+    s <- enc2utf8(s)
+    bad <- which(!is.na(s) & !validUTF8(s))
+    if(length(bad))
+        s[bad] <- iconv(s[bad], from = "UTF-8", to = "UTF-8", sub = "byte")
+    s
+}
+
 read.dcf <-
 function(file, fields = NULL, all = FALSE, keep.white = NULL)
 {
@@ -74,15 +91,10 @@ function(file, fields = NULL, all = FALSE, keep.white = NULL)
     ascii_space <- " \f\n\r\t\v"
 
     ## DCF files must be encoded in UTF-8.  Read as UTF-8 and repair any
-    ## invalid byte sequences by escaping them as <xx>, mirroring
-    ## iconv(..., sub = "byte"), so that invalid input is preserved
-    ## visually rather than silently dropped.
-    lines <- readLines(file, skipNul = TRUE, encoding = "UTF-8",
-                       warn = FALSE)
-    bad <- which(!validUTF8(lines))
-    if(length(bad))
-        lines[bad] <- iconv(lines[bad], from = "UTF-8", to = "UTF-8",
-                            sub = "byte")
+    ## invalid byte sequences (escaping them as <xx>) so that invalid input
+    ## is preserved visually rather than silently dropped.
+    lines <- readLines(file, skipNul = TRUE, encoding = "UTF-8", warn = FALSE)
+    lines <- .enc2utf8_sub(lines)
 
     ## Ignore comment lines.
     lines <- lines[!startsWith(lines, "#")]
@@ -176,25 +188,10 @@ function(x, file = "", append = FALSE, useBytes = FALSE,
 	gsub("\n \\.([^\n])","\n  .\\1",
 	     gsub("\n[ \t]*\n", "\n .\n ", s, perl = TRUE, useBytes = TRUE),
              perl = TRUE, useBytes = TRUE)
-    ## DCF files must be encoded in UTF-8.  Convert values with a declared
-    ## encoding to UTF-8 and escape any remaining invalid bytes as <xx>
-    ## (cf. iconv(..., sub = "byte")).  This must happen before the values
-    ## are reformatted below.
-    to_utf8 <- function(s) {
-        ## Non-character values (logical, integer, ...) carry no encoding
-        ## and are coerced to character by the formatting below, so leave
-        ## them untouched here.
-        if(!is.character(s))
-            return(s)
-        s <- enc2utf8(s)
-        bad <- which(!is.na(s) & !validUTF8(s))
-        if(length(bad))
-            s[bad] <- iconv(s[bad], from = "UTF-8", to = "UTF-8",
-                            sub = "byte")
-        s
-    }
     fmt <- function(tag, val, fold = TRUE) {
-        val <- to_utf8(val)
+        ## DCF files must be encoded in UTF-8: canonicalize values to UTF-8
+        ## (escaping invalid bytes) before they are reformatted below.
+        val <- .enc2utf8_sub(val)
         s <- if(fold)
             formatDL(rep.int(tag, length(val)), val, style = "list",
                      width = width, indent = indent)

--- a/src/library/base/R/dcf.R
+++ b/src/library/base/R/dcf.R
@@ -73,7 +73,16 @@ function(file, fields = NULL, all = FALSE, keep.white = NULL)
     ascii_blank <- " \t"
     ascii_space <- " \f\n\r\t\v"
 
-    lines <- readLines(file, skipNul = TRUE, encoding = "bytes")
+    ## DCF files must be encoded in UTF-8.  Read as UTF-8 and repair any
+    ## invalid byte sequences by escaping them as <xx>, mirroring
+    ## iconv(..., sub = "byte"), so that invalid input is preserved
+    ## visually rather than silently dropped.
+    lines <- readLines(file, skipNul = TRUE, encoding = "UTF-8",
+                       warn = FALSE)
+    bad <- which(!validUTF8(lines))
+    if(length(bad))
+        lines[bad] <- iconv(lines[bad], from = "UTF-8", to = "UTF-8",
+                            sub = "byte")
 
     ## Ignore comment lines.
     lines <- lines[!startsWith(lines, "#")]
@@ -131,10 +140,6 @@ function(file, fields = NULL, all = FALSE, keep.white = NULL)
                    c(1L, pos[-length(pos)] + 1L), pos)
     vals[fold] <- trimws(vals[fold])
 
-    ## for back-compatibility, but creates invalid strings
-    Encoding(vals) <- "unknown"
-    Encoding(tags) <- "unknown"
-
     out <- .assemble_things_into_a_data_frame(tags, vals, nums[pos])
 
     if(!is.null(fields))
@@ -149,6 +154,10 @@ function(x, file = "", append = FALSE, useBytes = FALSE,
          width = 0.9 * getOption("width"),
          keep.white = NULL)
 {
+    ## DCF files must be encoded in UTF-8, so output is always written as
+    ## UTF-8 (see the value conversion in fmt() below).  The 'useBytes'
+    ## argument is therefore ignored.
+
     if(file == "")
         file <- stdout()
     else if(is.character(file)) {
@@ -167,7 +176,25 @@ function(x, file = "", append = FALSE, useBytes = FALSE,
 	gsub("\n \\.([^\n])","\n  .\\1",
 	     gsub("\n[ \t]*\n", "\n .\n ", s, perl = TRUE, useBytes = TRUE),
              perl = TRUE, useBytes = TRUE)
+    ## DCF files must be encoded in UTF-8.  Convert values with a declared
+    ## encoding to UTF-8 and escape any remaining invalid bytes as <xx>
+    ## (cf. iconv(..., sub = "byte")).  This must happen before the values
+    ## are reformatted below.
+    to_utf8 <- function(s) {
+        ## Non-character values (logical, integer, ...) carry no encoding
+        ## and are coerced to character by the formatting below, so leave
+        ## them untouched here.
+        if(!is.character(s))
+            return(s)
+        s <- enc2utf8(s)
+        bad <- which(!is.na(s) & !validUTF8(s))
+        if(length(bad))
+            s[bad] <- iconv(s[bad], from = "UTF-8", to = "UTF-8",
+                            sub = "byte")
+        s
+    }
     fmt <- function(tag, val, fold = TRUE) {
+        val <- to_utf8(val)
         s <- if(fold)
             formatDL(rep.int(tag, length(val)), val, style = "list",
                      width = width, indent = indent)
@@ -215,5 +242,9 @@ function(x, file = "", append = FALSE, useBytes = FALSE,
         ## Note that we do not write a trailing blank line.
         eor[ which(diff(c(col(out))[is_not_empty]) >= 1L) ] <- "\n"
     }
-    writeLines(paste0(c(out[is_not_empty]), eor), file, useBytes=useBytes)
+    ## The values were converted to UTF-8 above, so write the bytes
+    ## verbatim (useBytes = TRUE) rather than re-encoding to the session's
+    ## native encoding.  A connection opened with an explicit encoding may
+    ## still re-encode the output, but the default is always UTF-8.
+    writeLines(paste0(c(out[is_not_empty]), eor), file, useBytes = TRUE)
 }

--- a/src/library/base/man/dcf.Rd
+++ b/src/library/base/man/dcf.Rd
@@ -40,8 +40,9 @@ write.dcf(x, file = "", append = FALSE, useBytes = FALSE,
     is attempted to coerce \code{x} to a data frame.}
   \item{append}{logical.  If \code{TRUE}, the output is appended to the
     file.  If \code{FALSE}, any existing file of the name is destroyed.}
-  \item{useBytes}{logical to be passed to \code{\link{writeLines}()},
-    see there: \dQuote{for expert use}.}
+  \item{useBytes}{ignored, and retained only for back-compatibility.
+    Since \code{write.dcf} now always writes UTF-8 (see \sQuote{Details}),
+    the output is no longer re-encoded to the session's native encoding.}
   \item{indent}{a positive integer specifying the indentation for
     continuation lines in output entries.}
   \item{width}{a positive integer giving the target column for wrapping
@@ -73,10 +74,16 @@ write.dcf(x, file = "", append = FALSE, useBytes = FALSE,
     length limit was approximately 8191 bytes per line.
   }
 
-  Note that \code{read.dcf(all = FALSE)} reads the file byte-by-byte.
-  This allows a \file{DESCRIPTION} file to be read and only its ASCII
-  fields used, or its \samp{Encoding} field used to re-encode the
-  remaining fields.
+  DCF files are required to be encoded in UTF-8.  \code{read.dcf}
+  therefore returns values in UTF-8 (non-ASCII values being marked as
+  such), and \code{write.dcf} converts values with a declared encoding
+  (such as \code{"latin1"}) to UTF-8 and always writes UTF-8, regardless
+  of the session's locale.  Any bytes which are not valid UTF-8 are not
+  dropped but preserved visually by escaping them as \samp{<xx>} (where
+  \code{xx} is the byte in hexadecimal), as done by
+  \code{\link{iconv}(sub = "byte")}.  As a consequence, the
+  \samp{Encoding} field of a \file{DESCRIPTION} file is no longer used to
+  re-encode the other fields.
 
   \code{write.dcf} does not write \code{NA} fields.
 }
@@ -103,10 +110,8 @@ write.dcf(x, file = "", append = FALSE, useBytes = FALSE,
 }
 
 \references{
-  \url{https://www.debian.org/doc/debian-policy/ch-controlfields.html}.
-
-  Note that \R does not require encoding in UTF-8, which is a recent
-  Debian requirement.
+  \url{https://www.debian.org/doc/debian-policy/ch-controlfields.html},
+  which requires control files to be encoded in UTF-8.
 }
 
 \note{

--- a/src/library/tools/R/utils.R
+++ b/src/library/tools/R/utils.R
@@ -2358,82 +2358,22 @@ function(dfile, keep.white = .keep_white_description_fields)
     if (nrow(out) != 1L)
         stop("contains a blank line", call. = FALSE)
     out <- out[1L, ]
-    if(!is.na(encoding <- out["Encoding"])) {
-        ## could convert everything (valid) to UTF-8
-        if(encoding == "UTF-8") {
-            Encoding(out) <- "UTF-8"
-            ind <- validUTF8(out)
-            if(!all(ind)) {
-                pos <- which(!ind)
-                ## Be as nice as for the other cases ...
-                ## Could also throw an error along the lines of
-                ##   stop(sprintf(ngettext(length(pos),
-                ##                         "field %s is not valid UTF-8",
-                ##                         "fields %s are not valid UTF-8"),
-                ##                paste(sQuote(names(out)[pos]),
-                ##                             collapse = ", ")),
-                ##        call. = FALSE, domain = NA)
-                out[pos] <-
-                    iconv(out[pos], "UTF-8", "UTF-8", sub = "byte")
-            }
-        }
-        else if(encoding == "latin1")
-            Encoding(out) <- "latin1"
-        else
-            out <- iconv(out, encoding, "", sub = "byte")
-    }
+    ## read.dcf() now always returns UTF-8 (repairing any invalid bytes),
+    ## so the legacy Encoding-field post-processing is no longer needed.
     out
 }
 
 .write_description <-
 function(x, dfile, keep.white = .keep_white_description_fields)
 {
-    ## Invert how .read_description() handles package encodings.
-    if(!is.na(encoding <- x["Encoding"])) {
-        ## For UTF-8 or latin1 encodings, .read_description() would
-        ## simply have marked the encoding.  But we might have added
-        ## fields encoded differently ...
-        ind <- is.na(match(Encoding(x), c(encoding, "unknown")))
-        if(any(ind))
-            x[ind] <- mapply(iconv, x[ind], Encoding(x)[ind], encoding,
-                             sub = "byte")
-    } else {
-        ## If there is no declared encoding, we cannot have non-ASCII
-        ## content.
-        ## Cf. tools::showNonASCII():
-        asc <- iconv(x, "latin1", "ASCII")
-        ## fields might have been NA to start with, so use identical.
-        if(!identical(asc, x)) {
-            warning("Unknown encoding with non-ASCII data: converting to ASCII")
-	    ind <- is.na(asc) | (asc != x)
-            x[ind] <- iconv(x[ind], "latin1", "ASCII", sub = "byte")
-        }
-    }
+    ## write.dcf() now always writes valid UTF-8 (converting values with a
+    ## declared encoding and repairing any invalid bytes), so there is no
+    ## need to handle the declared Encoding field here.
     ## Avoid folding for fields where we keep whitespace when reading,
     ## plus two more fields where legacy code does not strip whitespace
     ## and so we should not wrap.
-    ## Unfortunately, wrapping may destroy declared encodings: for the
-    ## fields where we do not keep whitespace, write.dcf() calls
-    ## formatDL() which in turn calls paste() on the results of
-    ## strwrap(), and paste() may change the (common) encoding.
-    ## In particular, pasting a latin1 string comes out in UTF-8 in a
-    ## UTF-8 locale, and with unknown encoding in a C locale.
-    ## Hence, when we have a declared non-UTF-8 encoding, we convert
-    ## to UTF-8 before formatting, and convert back to the declared
-    ## encoding when writing out.
     keep.white <- unique(c(keep.white, "Maintainer", "BugReports"))
-    if(!is.na(encoding) && (encoding != "UTF-8")) {
-        x <- iconv(x, from = encoding, to = "UTF-8")
-        tfile <- tempfile()
-        write.dcf(rbind(x), tfile, keep.white = keep.white,
-                  useBytes = TRUE)
-        writeLines(iconv(readLines(tfile),
-                         from = "UTF-8", to = encoding),
-                   dfile, useBytes = TRUE)
-    } else {
-        write.dcf(rbind(x), dfile, keep.white = keep.white,
-                  useBytes = TRUE)
-    }
+    write.dcf(rbind(x), dfile, keep.white = keep.white)
 }
 
 .expand_package_description_db_R_fields <-

--- a/src/main/dcf.c
+++ b/src/main/dcf.c
@@ -31,87 +31,25 @@
 static SEXP allocMatrixNA(SEXPTYPE, int, int);
 static void transferVector(SEXP s, SEXP t);
 
-/* Inspect the byte sequence of at most 'length' bytes starting at 'p'.
-   Return the number of bytes in the next valid UTF-8 character, or 0 if
-   'p' does not start a valid UTF-8 sequence.  The validation logic is
-   adapted from valid_utf8() in valid_utf8.h, restricted to RFC 3629
-   (characters 0 to 0x10FFFF, at most 4 bytes, no surrogates). */
-static int utf8_char_len(const unsigned char *p, size_t length)
-{
-    unsigned int ab, c, d;
-
-    c = p[0];
-    if (c < 128) return 1;		/* ASCII character */
-    if (c < 0xc0) return 0;		/* isolated 10xx xxxx byte */
-    if (c >= 0xfe) return 0;		/* invalid 0xfe or 0xff byte */
-
-    /* Number of additional bytes implied by the leading byte. */
-    if (c < 0xe0)	ab = 1;		/* 110x xxxx */
-    else if (c < 0xf0)	ab = 2;		/* 1110 xxxx */
-    else		ab = 3;		/* 1111 0xxx (and 5/6-byte forms,
-					   rejected as overlong below) */
-
-    if (length <= ab) return 0;		/* truncated sequence */
-
-    d = p[1];
-    if ((d & 0xc0) != 0x80) return 0;	/* bad continuation byte */
-
-    switch (ab) {
-    case 1:
-	/* 2-byte character: check for an overlong sequence. */
-	if ((c & 0x3e) == 0) return 0;
-	break;
-    case 2:
-	/* 3-byte character: check the third byte, then guard against
-	   overlong sequences and the surrogate range 0xd800-0xdfff. */
-	if ((p[2] & 0xc0) != 0x80) return 0;
-	if (c == 0xe0 && (d & 0x20) == 0) return 0;
-	if (c == 0xed && d >= 0xa0) return 0;
-	break;
-    default:
-	/* 4-byte character: check the 3rd and 4th bytes, then guard
-	   against overlong sequences and code points above 0x10FFFF.
-	   Leading bytes >= 0xf8 land here too and are rejected, since
-	   5/6-byte forms are not valid under RFC 3629. */
-	if (c >= 0xf8) return 0;
-	if ((p[2] & 0xc0) != 0x80) return 0;
-	if ((p[3] & 0xc0) != 0x80) return 0;
-	if (c == 0xf0 && (d & 0x30) == 0) return 0;
-	if (c > 0xf4 || (c == 0xf4 && d > 0x8f)) return 0;
-	break;
-    }
-
-    return (int) ab + 1;
-}
-
-/* Build a CHARSXP marked as UTF-8 from the NUL-terminated string 's',
-   replacing each invalid byte with a "<xx>" escape (cf. the substitution
-   done by iconv(..., sub = "byte"); see do_iconv() in sysutils.c).  When
-   's' is already valid UTF-8 (the common case) no copy is made. */
+/* Build a CHARSXP marked as UTF-8 from the NUL-terminated string 's'.
+   DCF files are required to be UTF-8, so 's' is interpreted as UTF-8
+   regardless of its actual encoding; any invalid byte sequences are
+   repaired by escaping them as "<xx>", exactly as
+   iconv(from = "UTF-8", to = "UTF-8", sub = "byte") does (which the R
+   code paths in read.dcf()/write.dcf() also use).  The common case of
+   already-valid input is handled without conversion. */
 static SEXP mkCharUTF8sub(const char *s)
 {
     if (utf8Valid(s))
 	return mkCharCE(s, CE_UTF8);
 
-    size_t len = strlen(s);
-    /* Worst case each byte becomes a 4-character "<xx>" escape. */
-    char *out = R_alloc(4 * len + 1, sizeof(char));
-    const unsigned char *p = (const unsigned char *) s;
-    char *o = out;
-    size_t rem = len;
-    while (rem > 0) {
-	int n = utf8_char_len(p, rem);
-	if (n > 0) {
-	    memcpy(o, p, (size_t) n);
-	    o += n; p += n; rem -= (size_t) n;
-	} else {
-	    snprintf(o, 5, "<%02x>", (unsigned int) *p);
-	    o += 4; p += 1; rem -= 1;
-	}
-    }
-    *o = '\0';
-
-    return mkCharCE(out, CE_UTF8);
+    /* reEnc3() performs the iconv() repair via Riconv(); subst = 1 selects
+       the "<xx>" hexadecimal substitution for invalid bytes.  It returns a
+       string allocated with R_alloc() (and freed at the vmaxset() in
+       do_readDCF()), or 's' itself if iconv is unavailable.  Either way
+       mkCharCE() copies the bytes into the CHARSXP below. */
+    const char *repaired = reEnc3(s, "UTF-8", "UTF-8", 1);
+    return mkCharCE(repaired, CE_UTF8);
 }
 
 static void con_cleanup(void *data)

--- a/src/main/dcf.c
+++ b/src/main/dcf.c
@@ -31,6 +31,89 @@
 static SEXP allocMatrixNA(SEXPTYPE, int, int);
 static void transferVector(SEXP s, SEXP t);
 
+/* Inspect the byte sequence of at most 'length' bytes starting at 'p'.
+   Return the number of bytes in the next valid UTF-8 character, or 0 if
+   'p' does not start a valid UTF-8 sequence.  The validation logic is
+   adapted from valid_utf8() in valid_utf8.h, restricted to RFC 3629
+   (characters 0 to 0x10FFFF, at most 4 bytes, no surrogates). */
+static int utf8_char_len(const unsigned char *p, size_t length)
+{
+    unsigned int ab, c, d;
+
+    c = p[0];
+    if (c < 128) return 1;		/* ASCII character */
+    if (c < 0xc0) return 0;		/* isolated 10xx xxxx byte */
+    if (c >= 0xfe) return 0;		/* invalid 0xfe or 0xff byte */
+
+    /* Number of additional bytes implied by the leading byte. */
+    if (c < 0xe0)	ab = 1;		/* 110x xxxx */
+    else if (c < 0xf0)	ab = 2;		/* 1110 xxxx */
+    else		ab = 3;		/* 1111 0xxx (and 5/6-byte forms,
+					   rejected as overlong below) */
+
+    if (length <= ab) return 0;		/* truncated sequence */
+
+    d = p[1];
+    if ((d & 0xc0) != 0x80) return 0;	/* bad continuation byte */
+
+    switch (ab) {
+    case 1:
+	/* 2-byte character: check for an overlong sequence. */
+	if ((c & 0x3e) == 0) return 0;
+	break;
+    case 2:
+	/* 3-byte character: check the third byte, then guard against
+	   overlong sequences and the surrogate range 0xd800-0xdfff. */
+	if ((p[2] & 0xc0) != 0x80) return 0;
+	if (c == 0xe0 && (d & 0x20) == 0) return 0;
+	if (c == 0xed && d >= 0xa0) return 0;
+	break;
+    default:
+	/* 4-byte character: check the 3rd and 4th bytes, then guard
+	   against overlong sequences and code points above 0x10FFFF.
+	   Leading bytes >= 0xf8 land here too and are rejected, since
+	   5/6-byte forms are not valid under RFC 3629. */
+	if (c >= 0xf8) return 0;
+	if ((p[2] & 0xc0) != 0x80) return 0;
+	if ((p[3] & 0xc0) != 0x80) return 0;
+	if (c == 0xf0 && (d & 0x30) == 0) return 0;
+	if (c > 0xf4 || (c == 0xf4 && d > 0x8f)) return 0;
+	break;
+    }
+
+    return (int) ab + 1;
+}
+
+/* Build a CHARSXP marked as UTF-8 from the NUL-terminated string 's',
+   replacing each invalid byte with a "<xx>" escape (cf. the substitution
+   done by iconv(..., sub = "byte"); see do_iconv() in sysutils.c).  When
+   's' is already valid UTF-8 (the common case) no copy is made. */
+static SEXP mkCharUTF8sub(const char *s)
+{
+    if (utf8Valid(s))
+	return mkCharCE(s, CE_UTF8);
+
+    size_t len = strlen(s);
+    /* Worst case each byte becomes a 4-character "<xx>" escape. */
+    char *out = R_alloc(4 * len + 1, sizeof(char));
+    const unsigned char *p = (const unsigned char *) s;
+    char *o = out;
+    size_t rem = len;
+    while (rem > 0) {
+	int n = utf8_char_len(p, rem);
+	if (n > 0) {
+	    memcpy(o, p, (size_t) n);
+	    o += n; p += n; rem -= (size_t) n;
+	} else {
+	    snprintf(o, 5, "<%02x>", (unsigned int) *p);
+	    o += 4; p += 1; rem -= 1;
+	}
+    }
+    *o = '\0';
+
+    return mkCharCE(out, CE_UTF8);
+}
+
 static void con_cleanup(void *data)
 {
     Rconnection con = data;
@@ -203,7 +286,7 @@ attribute_hidden SEXP do_readDCF(SEXP call, SEXP op, SEXP args, SEXP env)
 			}
 			strcat(buf, line + offset);
 		    }
-		    SET_STRING_ELT(retval, lastm + nwhat * k, mkChar(buf));
+		    SET_STRING_ELT(retval, lastm + nwhat * k, mkCharUTF8sub(buf));
 		}
 	    } else {
 		if(tre_regexecb(&regline, line, 1, regmatch, 0) == 0) {
@@ -230,7 +313,7 @@ attribute_hidden SEXP do_readDCF(SEXP call, SEXP op, SEXP args, SEXP env)
 				    line[regmatch[0].rm_so] = '\0';
 			    }
 			    SET_STRING_ELT(retval, m + nwhat * k,
-					   mkChar(line + offset));
+					   mkCharUTF8sub(line + offset));
 			    break;
 			} else {
 			    /* This is a field, but not one prespecified */
@@ -274,7 +357,7 @@ attribute_hidden SEXP do_readDCF(SEXP call, SEXP op, SEXP args, SEXP env)
 			}
 			strncpy(buf, line, Rf_strchr(line, ':') - line);
 			buf[Rf_strchr(line, ':') - line] = '\0';
-			SET_STRING_ELT(what, nwhat, mkChar(buf));
+			SET_STRING_ELT(what, nwhat, mkCharUTF8sub(buf));
 			nwhat++;
 			/* lastm uses C indexing, hence nwhat - 1 */
 			lastm = nwhat - 1;
@@ -292,7 +375,7 @@ attribute_hidden SEXP do_readDCF(SEXP call, SEXP op, SEXP args, SEXP env)
 				line[regmatch[0].rm_so] = '\0';
 			}
 			SET_STRING_ELT(retval, lastm + nwhat * k,
-				       mkChar(line + offset));
+				       mkCharUTF8sub(line + offset));
 		    }
 		} else {
 		    /* Must be a regular line with no tag ... */

--- a/tests/reg-tests-1e.R
+++ b/tests/reg-tests-1e.R
@@ -3449,6 +3449,108 @@ km <- merge(k, m, all.x = TRUE, all.y = TRUE)
 stopifnot(identical(names(km), c(names(k), names(m))))
 ## previously `y[FALSE, ]` instead of `z` (in R <= 4.6.0)
 
+## read.dcf() and write.dcf() always use UTF-8 (r-dev-day issue 156)
+local({
+    eacute <- intToUtf8(0xe9) # small e with acute, UTF-8
+    ccedil <- intToUtf8(0xe7) # small c with cedilla, UTF-8
+    ## A DCF file with a valid UTF-8 field and a field with an invalid byte.
+    tf <- tempfile()
+    con <- file(tf, "wb")
+    writeBin(charToRaw("Package: testpkg\nTitle: caf\xc3\xa9\nAuthor: Fran\xffois\n"),
+             con)
+    close(con)
+    ## Both the C path (all = FALSE) and the R path (all = TRUE) must agree:
+    ## valid UTF-8 is marked as such, invalid bytes are escaped as <xx>.
+    dC <- read.dcf(tf)
+    dR <- read.dcf(tf, all = TRUE)
+    stopifnot(
+        dC[1, "Title"] == paste0("caf", eacute),
+        Encoding(dC[1, "Title"]) == "UTF-8",
+        dC[1, "Author"] == "Fran<ff>ois",
+        identical(unname(dC[1, "Title"]),  dR$Title),
+        identical(unname(dC[1, "Author"]), dR$Author)
+    )
+    ## write.dcf() converts a declared encoding to UTF-8 and escapes any
+    ## invalid bytes; the output must be valid UTF-8.
+    x <- data.frame(Package = "testpkg",
+                    Author  = "Fran\xe7ois",
+                    Note    = "bad\xffbyte",
+                    stringsAsFactors = FALSE)
+    Encoding(x$Author) <- "latin1"
+    tf2 <- tempfile()
+    write.dcf(x, tf2)            # always UTF-8, regardless of locale
+    stopifnot(validUTF8(rawToChar(readBin(tf2, "raw", file.size(tf2)))))
+    y <- read.dcf(tf2)
+    stopifnot(
+        y[1, "Author"] == paste0("Fran", ccedil, "ois"),
+        Encoding(y[1, "Author"]) == "UTF-8",
+        y[1, "Note"] == "bad<ff>byte"
+    )
+    ## An invalid byte on a continuation line is escaped, while a valid
+    ## UTF-8 character on the same field is preserved.
+    tf3 <- tempfile()
+    con <- file(tf3, "wb")
+    writeBin(charToRaw("Package: p\nDescription: one \xff bad\n  caf\xc3\xa9 line\n"),
+             con)
+    close(con)
+    d3C <- read.dcf(tf3)
+    d3R <- read.dcf(tf3, all = TRUE)
+    stopifnot(
+        grepl("<ff>", d3C[1, "Description"], fixed = TRUE),
+        grepl(eacute, d3C[1, "Description"], fixed = TRUE),
+        Encoding(d3C[1, "Description"]) == "UTF-8",
+        identical(unname(d3C[1, "Description"]), d3R$Description)
+    )
+    ## Valid 3- and 4-byte characters are preserved; the various kinds of
+    ## invalid sequence (truncated, overlong, surrogate) are each escaped
+    ## per byte, and a literal "<ff>" is not re-escaped.  C and R agree.
+    euro  <- intToUtf8(0x20AC)   # 3-byte UTF-8
+    emoji <- intToUtf8(0x1F600)  # 4-byte UTF-8
+    rdb <- function(bytes) {
+        f <- tempfile(); cc <- file(f, "wb"); writeBin(as.raw(bytes), cc); close(cc)
+        on.exit(unlink(f))
+        list(C = read.dcf(f)[1, "X"], R = read.dcf(f, all = TRUE)$X)
+    }
+    cases <- list(
+        list(b = c(charToRaw("Package: p\nX: "), charToRaw(euro),
+                   charToRaw(emoji), charToRaw("\n")),    want = paste0(euro, emoji)),
+        list(b = c(charToRaw("Package: p\nX: a"), as.raw(0xc3),
+                   charToRaw("\n")),                       want = "a<c3>"),
+        list(b = c(charToRaw("Package: p\nX: "), as.raw(c(0xc0, 0x80)),
+                   charToRaw("\n")),                       want = "<c0><80>"),
+        list(b = c(charToRaw("Package: p\nX: "), as.raw(c(0xed, 0xa0, 0x80)),
+                   charToRaw("\n")),                       want = "<ed><a0><80>"),
+        list(b = charToRaw("Package: p\nX: a<ff>b\n"),     want = "a<ff>b")
+    )
+    for (cs in cases) {
+        got <- rdb(cs$b)
+        stopifnot(got$C == cs$want, identical(unname(got$C), got$R))
+    }
+    ## An invalid byte in a field name (tag) is escaped; C and R agree.
+    tf4 <- tempfile()
+    con <- file(tf4, "wb")
+    writeBin(c(charToRaw("Package: p\nX"), as.raw(0xff), charToRaw("Y: v\n")), con)
+    close(con)
+    stopifnot("X<ff>Y" %in% colnames(read.dcf(tf4)),
+              identical(colnames(read.dcf(tf4)), names(read.dcf(tf4, all = TRUE))))
+    ## A repeated field with an invalid byte: all = TRUE gives a list column.
+    con <- file(tf4, "wb")
+    writeBin(c(charToRaw("Package: p\nX: a\nX: "), as.raw(0xff), charToRaw("\n")), con)
+    close(con)
+    stopifnot(identical(unlist(read.dcf(tf4, all = TRUE)$X), c("a", "<ff>")))
+    ## A keep.white field uses the non-folding branch of write.dcf();
+    ## a latin1 value is still written as valid UTF-8.
+    v <- "Fran\xe7ois"; Encoding(v) <- "latin1"
+    write.dcf(data.frame(Package = "p", Maintainer = v, stringsAsFactors = FALSE),
+              tf4, keep.white = "Maintainer")
+    stopifnot(validUTF8(rawToChar(readBin(tf4, "raw", file.size(tf4)))),
+              read.dcf(tf4)[1, "Maintainer"] == paste0("Fran", ccedil, "ois"))
+    unlink(c(tf, tf2, tf3, tf4))
+})
+## read.dcf() previously returned values with encoding "unknown", and
+## write.dcf() relied on the Encoding field (in R <= 4.6.0)
+
+
 ## keep at end
 rbind(last =  proc.time() - .pt,
       total = proc.time())

--- a/tests/reg-tests-1e.R
+++ b/tests/reg-tests-1e.R
@@ -3457,11 +3457,15 @@ local({
     ## convert to UTF-8 honouring the declared encoding, escape invalid
     ## bytes, and pass non-character input through unchanged.
     lat <- "Fran\xe7ois"; Encoding(lat) <- "latin1"
+    ## A string declared UTF-8 but containing a stray invalid byte: must be
+    ## escaped regardless of the native encoding (an undeclared literal would
+    ## be reinterpreted via the locale codepage on non-UTF-8 platforms).
+    inv <- "a\xffb"; Encoding(inv) <- "UTF-8"
     stopifnot(
         identical(.enc2utf8_sub("abc"), "abc"),
         .enc2utf8_sub(lat) == paste0("Fran", ccedil, "ois"),
         Encoding(.enc2utf8_sub(lat)) == "UTF-8",
-        .enc2utf8_sub("a\xffb") == "a<ff>b",
+        .enc2utf8_sub(inv) == "a<ff>b",
         identical(.enc2utf8_sub(c("a", NA)), c("a", NA)),
         identical(.enc2utf8_sub(1:3), 1:3)
     )
@@ -3489,6 +3493,7 @@ local({
                     Note    = "bad\xffbyte",
                     stringsAsFactors = FALSE)
     Encoding(x$Author) <- "latin1"
+    Encoding(x$Note)   <- "UTF-8"   # stray invalid byte, must be escaped
     tf2 <- tempfile()
     write.dcf(x, tf2)            # always UTF-8, regardless of locale
     stopifnot(validUTF8(rawToChar(readBin(tf2, "raw", file.size(tf2)))))

--- a/tests/reg-tests-1e.R
+++ b/tests/reg-tests-1e.R
@@ -3453,6 +3453,18 @@ stopifnot(identical(names(km), c(names(k), names(m))))
 local({
     eacute <- intToUtf8(0xe9) # small e with acute, UTF-8
     ccedil <- intToUtf8(0xe7) # small c with cedilla, UTF-8
+    ## The shared base:::.enc2utf8_sub() helper used by read/write.dcf():
+    ## convert to UTF-8 honouring the declared encoding, escape invalid
+    ## bytes, and pass non-character input through unchanged.
+    lat <- "Fran\xe7ois"; Encoding(lat) <- "latin1"
+    stopifnot(
+        identical(.enc2utf8_sub("abc"), "abc"),
+        .enc2utf8_sub(lat) == paste0("Fran", ccedil, "ois"),
+        Encoding(.enc2utf8_sub(lat)) == "UTF-8",
+        .enc2utf8_sub("a\xffb") == "a<ff>b",
+        identical(.enc2utf8_sub(c("a", NA)), c("a", NA)),
+        identical(.enc2utf8_sub(1:3), 1:3)
+    )
     ## A DCF file with a valid UTF-8 field and a field with an invalid byte.
     tf <- tempfile()
     con <- file(tf, "wb")


### PR DESCRIPTION
This implements [r-devel/r-dev-day#156](https://github.com/r-devel/r-dev-day/issues/156) (proposed by @kurthornik, building on #86): bring R's DCF read/write functions into compliance with the Debian Control File requirement that control files be encoded in UTF-8.

### Changes

- **`read.dcf()` now returns UTF-8** in both code paths:
  - `all = TRUE` (R, `src/library/base/R/dcf.R`): reads as UTF-8 and repairs invalid byte sequences with `iconv(sub = "byte")`; drops the old `Encoding <- "unknown"` marking.
  - `all = FALSE` (C, `src/main/dcf.c`, `do_readDCF`): new helpers `utf8_char_len()` (a streaming single-character validator adapted from `valid_utf8()`) and `mkCharUTF8sub()`, which escape invalid bytes as `<xx>` and mark the result UTF-8. Fast-path (no copy) when the string is already valid.
- **`write.dcf()` always writes UTF-8** regardless of the session locale: values with a declared encoding are converted, invalid bytes escaped, and the output written byte-verbatim. The `useBytes` argument is now ignored (kept for back-compatibility, documented as such).
- **`tools:::.read_description()` / `.write_description()`** no longer special-case the `Encoding` field.
- Docs (`dcf.Rd`), a NEWS entry, and regression tests (`reg-tests-1e.R`).

Invalid bytes are escaped (`<xx>`), not dropped, so the C and R paths produce identical output.

### Notable behavior change

The `Encoding` field of a `DESCRIPTION` is no longer used to re-encode the other fields. A non-UTF-8 (e.g. `Encoding: latin1`) `DESCRIPTION` now reads with its high bytes escaped rather than transcoded. This is the intended effect of enforcing UTF-8 (issue Task 2) and is noted in NEWS. Repository index generation (`PACKAGES` / `PACKAGES.gz`) is now UTF-8 regardless of the build locale.

### Testing

Built R trunk and verified in both `LC_ALL=C` and a UTF-8 locale. The new `reg-tests-1e.R` block covers: C/R-path agreement; 2-, 3-, and 4-byte valid characters; invalid sequences (truncated lead byte, overlong, UTF-16 surrogate, isolated byte); literal `<ff>` not double-escaped; invalid byte in a field name; repeated-field list columns; continuation-line escaping; latin1 -> UTF-8 on write; and the `keep.white` (non-folding) write path. The regression suite (`reg-tests-1*`, `reg-IO`, `reg-IO2`, `reg-packages`, `reg-encodings`, `reg-examples*`, `reg-S4`, `test-Iconv`) and the `base`/`tools`/`utils` examples all pass.
