### PR TITLE
[Bugzilla#19096] Consider alternative implementations for R_integer_times

### DIFF
--- a/src/main/arithmetic.c
+++ b/src/main/arithmetic.c
@@ -351,17 +351,15 @@ static R_INLINE int R_integer_minus(int x, int y, bool *pnaflag)
 static R_INLINE int R_integer_times(int x, int y, bool *pnaflag)
 {
     if (x == NA_INTEGER || y == NA_INTEGER)
-	return NA_INTEGER;
-    else {
-	int_fast64_t z = (int_fast64_t)x * (int_fast64_t)y;
-        if (z <= R_INT_MAX && z >= R_INT_MIN)
-	    return (int)z;
-	else {
-	    if (pnaflag != NULL)
-		*pnaflag = true;
-	    return NA_INTEGER;
-	}
-    }
+	  return NA_INTEGER;
+
+    int z;
+    if (!__builtin_mul_overflow(x, y, &z) && z != NA_INTEGER)
+	  return z;
+
+    if (pnaflag != NULL)
+	  *pnaflag = true;
+    return NA_INTEGER;
 }
 
 static R_INLINE double R_integer_divide(int x, int y)

--- a/src/main/arithmetic.c
+++ b/src/main/arithmetic.c
@@ -353,7 +353,7 @@ static R_INLINE int R_integer_times(int x, int y, bool *pnaflag)
     if (x == NA_INTEGER || y == NA_INTEGER)
 	return NA_INTEGER;
     else {
-	int64_t z = (int64_t)x * (int64_t)y;
+	int_fast64_t z = (int_fast64_t)x * (int_fast64_t)y;
         if (z <= R_INT_MAX && z >= R_INT_MIN)
 	    return (int)z;
 	else {

--- a/src/main/arithmetic.c
+++ b/src/main/arithmetic.c
@@ -348,15 +348,14 @@ static R_INLINE int R_integer_minus(int x, int y, bool *pnaflag)
     return x - y;
 }
 
-#define GOODIPROD(x, y, z) ((double) (x) * (double) (y) == (z))
 static R_INLINE int R_integer_times(int x, int y, bool *pnaflag)
 {
     if (x == NA_INTEGER || y == NA_INTEGER)
 	return NA_INTEGER;
     else {
-	int z = x * y;  // UBSAN will warn if this overflows (happens in bda)
-	if (GOODIPROD(x, y, z) && z != NA_INTEGER)
-	    return z;
+	int64_t z = (int64_t)x * (int64_t)y;
+        if (z <= R_INT_MAX && z >= R_INT_MIN)
+	    return (int)z;
 	else {
 	    if (pnaflag != NULL)
 		*pnaflag = true;

--- a/src/main/arithmetic.c
+++ b/src/main/arithmetic.c
@@ -325,13 +325,14 @@ static R_INLINE int R_integer_plus(int x, int y, bool *pnaflag)
     if (x == NA_INTEGER || y == NA_INTEGER)
 	return NA_INTEGER;
 
-    if (((y > 0) && (x > (R_INT_MAX - y))) ||
-	((y < 0) && (x < (R_INT_MIN - y)))) {
-	if (pnaflag != NULL)
-	    *pnaflag = true;
-	return NA_INTEGER;
-    }
-    return x + y;
+    int z;
+    if (!__builtin_add_overflow(x, y, &z) && z != NA_INTEGER)
+      return z;
+
+    if (pnaflag != NULL)
+      *pnaflag = true;
+
+    return NA_INTEGER;
 }
 
 static R_INLINE int R_integer_minus(int x, int y, bool *pnaflag)
@@ -339,13 +340,14 @@ static R_INLINE int R_integer_minus(int x, int y, bool *pnaflag)
     if (x == NA_INTEGER || y == NA_INTEGER)
 	return NA_INTEGER;
 
-    if (((y < 0) && (x > (R_INT_MAX + y))) ||
-	((y > 0) && (x < (R_INT_MIN + y)))) {
-	if (pnaflag != NULL)
-	    *pnaflag = true;
-	return NA_INTEGER;
-    }
-    return x - y;
+    int z;
+    if (!__builtin_sub_overflow(x, y, &z) && z != NA_INTEGER)
+      return z;
+
+    if (pnaflag != NULL)
+      *pnaflag = true;
+
+    return NA_INTEGER;
 }
 
 static R_INLINE int R_integer_times(int x, int y, bool *pnaflag)

--- a/tests/reg-tests-1e.R
+++ b/tests/reg-tests-1e.R
@@ -3449,9 +3449,6 @@ km <- merge(k, m, all.x = TRUE, all.y = TRUE)
 stopifnot(identical(names(km), c(names(k), names(m))))
 ## previously `y[FALSE, ]` instead of `z` (in R <= 4.6.0)
 
-x <- y <- rep(10000L, 5e7)
-print(system.time(for(i in 1:100) x * y))
-
 ## keep at end
 rbind(last =  proc.time() - .pt,
       total = proc.time())

--- a/tests/reg-tests-1e.R
+++ b/tests/reg-tests-1e.R
@@ -3449,6 +3449,9 @@ km <- merge(k, m, all.x = TRUE, all.y = TRUE)
 stopifnot(identical(names(km), c(names(k), names(m))))
 ## previously `y[FALSE, ]` instead of `z` (in R <= 4.6.0)
 
+x <- y <- rep(10000L, 5e7)
+print(system.time(for(i in 1:100) x * y))
+
 ## keep at end
 rbind(last =  proc.time() - .pt,
       total = proc.time())

--- a/tests/reg-tests-2.R
+++ b/tests/reg-tests-2.R
@@ -3401,6 +3401,8 @@ withAutoprint({
 })
 ## temporarily wrongly showed " withAutoprint({ "
 
+x <- y <- rep(10000L, 5e7)
+print(system.time(for(i in 1:100) x * y))
 
 # ----- Last line -------------
 cat('Time elapsed: ', proc.time(),'\n')


### PR DESCRIPTION
Follows https://github.com/r-devel/r-dev-day/issues/163

 - Initial commit just to get a baseline of timings on the various GHA platforms
 - Next comit uses the `int64_t` proposal from the e-mail
 - Following commit uses Luke's suggested `__builtin_mul_overflow`

Also linked on Bugzilla: https://bugs.r-project.org/show_bug.cgi?id=19096