### PR TITLE
Fix `loadNamespace()` performance issues with `importFrom()`

### DIFF
--- a/src/library/base/R/namespace.R
+++ b/src/library/base/R/namespace.R
@@ -1170,9 +1170,13 @@ namespaceImportMethods <- function(self, ns, vars, from = NULL)
 }
 
 importIntoEnv <- function(impenv, impnames, expenv, expnames) {
+        ## Avoid computing `names(exports)` here. `exports` is an environment
+        ## so computing the names requires a full walk. This causes problematic
+        ## super-linear performance when there are many `importFrom()` directives.
     exports <- getNamespaceInfo(expenv, "exports")
-    ex <- names(exports)
-    if(!all(eie <- expnames %in% ex)) {
+    expvals <- mget(expnames, envir = exports, inherits = FALSE,
+                    ifnotfound = list(NULL))
+    if(!all(eie <- lengths(expvals) != 0L)) {
         miss <- expnames[!eie]
         ## if called (indirectly) for namespaceImportClasses
         ## these are all classes
@@ -1193,7 +1197,7 @@ importIntoEnv <- function(impenv, impnames, expenv, expnames) {
                  call. = FALSE, domain = NA)
         }
     }
-    expnames <- unlist(mget(expnames, envir = exports, inherits = FALSE), recursive=FALSE)
+    expnames <- unlist(expvals, recursive = FALSE)
     if (is.null(impnames)) impnames <- character()
     if (is.null(expnames)) expnames <- character()
     .Internal(importIntoEnv(impenv, impnames, expenv, expnames))

--- a/src/library/tools/R/admin.R
+++ b/src/library/tools/R/admin.R
@@ -786,6 +786,56 @@ function(dir, outDir, keep.source = TRUE)
     invisible()
 }
 
+### * mergeImportFroms
+
+## Merge adjacent `importFrom()` directives for the same package into a single
+## entry. This allows the import loop in `loadNamespace()` to process all these
+## imports in a single iteration, which is much more efficient.
+mergeImportFroms <- function(imports) {
+    n <- length(imports)
+    if (n <= 1L)
+        return(imports)
+
+    ## Three possibilities:
+    ## - `importFrom()`: `list("packageName", c("import1", "import2", ...))`
+    ## - `import()`: `"packageName"`
+    ## - `import(except = )`: `list("packageName", except = )`
+    isImportFrom <- vapply(imports, function(i) !is.character(i) && is.null(i$except), NA)
+    pkgs <- character(n)
+    pkgs[isImportFrom] <- vapply(imports[isImportFrom], \(x) x[[1]], "")
+
+    ## A group continues only between two importFrom()s of the same package
+    joins <- isImportFrom[-n] & isImportFrom[-1L] & pkgs[-n] == pkgs[-1L]
+    groups <- cumsum(c(TRUE, !joins))
+
+    merged <- lapply(split(seq_len(n), groups), function(index) {
+        ## A singleton group is a non-mergeable directive (`import()`,
+        ## `import(except = )`, or a lone `importFrom()`) and passes through.
+        if (length(index) == 1L)
+            return(imports[index])
+
+        sources <- unlist(lapply(imports[index], `[[`, 2L), recursive = FALSE)
+
+        targets <- names(sources)
+        if (is.null(targets))
+            targets <- sources
+        else
+            targets[!nzchar(targets)] <- sources[!nzchar(targets)]
+
+        ## Merge only when each local name is imported once. If a local name
+        ## repeats, leave the directives separate so `loadNamespace()` validates
+        ## and resolves at load-time.
+        if (anyDuplicated(targets))
+            imports[index]
+        else
+            list(list(pkgs[index[[1L]]], sources))
+    })
+
+    ## Each group yields a list of entries (one if merged, several if left
+    ## separate)
+    unlist(merged, recursive = FALSE, use.names = FALSE)
+}
+
 ### * .install_package_namespace_info
 
 .install_package_namespace_info <-
@@ -797,6 +847,7 @@ function(dir, outDir)
     nsInfoFilePath <- file.path(outDir, "Meta", "nsInfo.rds")
     if(file_test("-nt", nsInfoFilePath, nsFile)) return(invisible())
     nsInfo <- parseNamespaceFile(basename(dir), dirname(dir))
+    nsInfo$imports <- mergeImportFroms(nsInfo$imports)
     outMetaDir <- file.path(outDir, "Meta")
     if(!dir.exists(outMetaDir) && !dir.create(outMetaDir))
         stop(gettextf("cannot open directory '%s'", outMetaDir),


### PR DESCRIPTION
https://bugs.r-project.org/show_bug.cgi?id=19095

A single `importFrom(pkg, sym1, sym2, ...)` scales much better during namespace loading than consecutive `importFrom(pkg, sym1); importFrom(pkg, sym2); ...` directives. This PR makes a NAMESPACE with the consecutive style load as fast as the grouped style.

Current R (baseline):

```
N=10     many       2.0 ms
N=10     one        2.0 ms
N=100    many      10.0 ms
N=100    one        2.0 ms
N=1000   many     131.5 ms
N=1000   one        6.0 ms
N=10000  many    5756.0 ms
N=10000  one       48.0 ms
```

With the first commit of this PR which avoids computing the names of a big exports environment for each import-from iteration:

```
N=10     many       2.0 ms
N=10     one        2.0 ms
N=100    many       9.0 ms
N=100    one        2.0 ms
N=1000   many      96.0 ms
N=1000   one        5.0 ms
N=10000  many    2434.5 ms
N=10000  one       46.0 ms
```

With the second commit that merges adjacent import-from directives for the same package at install time:

```
N=10     many       2.0 ms
N=10     one        2.0 ms
N=100    many       2.0 ms
N=100    one        2.0 ms
N=1000   many       5.0 ms
N=1000   one        5.0 ms
N=10000  many      45.0 ms
N=10000  one       46.0 ms
```

While N=10k is extreme, a few 100s or even a 1000 imported symbols might occur with large packages.

- roxygen2 generates individual `importFrom()` expressions.

- We're considering expanding bulk imports to explicit `importFrom()` directives to pin the set of imported symbols and prevent package updates from creating user-visible conflicts at load-time.

The install-time merge implemented here benefits every package, hand-written or roxygen2-generated, with no author action needed. Separately we plan to have roxygen2 emit merged `importFrom()`s so older R versions benefit too.