### PR TITLE
Fix buffer overread in R_is_redirection_tty

### DIFF
--- a/src/main/sysutils.c
+++ b/src/main/sysutils.c
@@ -3058,6 +3058,8 @@ attribute_hidden int R_is_redirection_tty(int fd)
     fnInfo->FileNameLength = fnLength;
     r = GetFileInformationByHandleEx(h, FileNameInfo, fnInfo, size);
     int res = 0;
+    /* defensively check that the name did not grow between calls and that its
+       byte length contains an integral number of WCHARs */
     if (r && fnInfo->FileNameLength <= fnLength &&
 	fnInfo->FileNameLength % sizeof(WCHAR) == 0) {
 	/* FileNameLength is in bytes and excludes the null terminator.  The

--- a/src/main/sysutils.c
+++ b/src/main/sysutils.c
@@ -3058,14 +3058,18 @@ attribute_hidden int R_is_redirection_tty(int fd)
     fnInfo->FileNameLength = fnLength;
     r = GetFileInformationByHandleEx(h, FileNameInfo, fnInfo, size);
     int res = 0;
-    if (r)
-	/* note that fnInfo->FileName is not null terminated */
+    if (r && fnInfo->FileNameLength <= fnLength &&
+	fnInfo->FileNameLength % sizeof(WCHAR) == 0) {
+	/* FileNameLength is in bytes and excludes the null terminator.  The
+	   allocation has room for it because FILE_NAME_INFO includes FileName[1]. */
+	fnInfo->FileName[fnInfo->FileNameLength / sizeof(WCHAR)] = L'\0';
 	/* e.g. msys-1888ae32e00d56aa-pty0-from-master,
 	        cygwin-e022582115c10879-pty0-from-master */
 	/* test borrowed from git */
 	res = ((wcsstr(fnInfo->FileName, L"msys-") ||
 	        wcsstr(fnInfo->FileName, L"cygwin-")) &&
 		wcsstr(fnInfo->FileName, L"-pty"));
+    }
     free(fnInfo);
     return res;
 }
@@ -3079,4 +3083,3 @@ attribute_hidden int R_isatty(int fd)
 #endif
     return isatty(fd);
 }
-


### PR DESCRIPTION
`FILE_NAME_INFO::FileName` is not null-terminated, so `wcsstr()` can read into unmapped memory. Validate `FileNameLength` and append a null terminator before searching the name.

Fixes https://github.com/r-lib/testthat/issues/2284