### PR TITLE
name missing modules in windows dll load errors

### DIFF
--- a/doc/NEWS.Rd
+++ b/doc/NEWS.Rd
@@ -67,6 +67,11 @@
 
       \item New low-level function \code{.OBJSXP()} enables deparsing of
       non-S4 \code{"object"} type objects.
+
+      \item On Windows, when loading a DLL fails because a module it
+      requires (directly or indirectly) could not be found, the error
+      message now attempts to name the missing modules, determined by
+      examining the import tables of the DLL and its dependencies.
     }
   }
 

--- a/src/gnuwin32/dynload.c
+++ b/src/gnuwin32/dynload.c
@@ -26,6 +26,7 @@
 #endif
 
 #include <string.h>
+#include <stdio.h>
 #include <stdlib.h>
 #include <Defn.h>
 #include <Rmath.h>
@@ -99,6 +100,226 @@ _CRTIMP unsigned int __cdecl _clearfp (void);
 #define	_MCW_PC		0x00030000	/* Precision */
 #endif
 
+/* When LoadLibrary() fails with ERROR_MOD_NOT_FOUND, Windows does not
+   report which module could not be found: it may be the DLL itself, one
+   of the DLLs it imports, or a DLL imported indirectly.  To give a more
+   useful error message, we walk the import table of the DLL on disk and
+   probe each imported module the way the loader would, recursing into
+   dependencies which do resolve, and record the names of modules which
+   cannot be found.
+
+   The probes run while any DLLpath directory is still in effect, so
+   they see the same search path as the failed LoadLibrary() call.
+   Delay-loaded DLLs are not needed at load time and are not checked.
+
+   The error code and the results are stashed here because the getError
+   hook (R_getDLLError) is only given a buffer, and because probing
+   would otherwise clobber GetLastError(). */
+
+#define DEPS_MAX_VISITED 100
+#define DEPS_MAX_DEPTH 10
+#define DEPS_MAX_IMPORTS 1024
+#define DEPS_MAX_PENDING 32
+#define DEPS_NAME_MAX 64
+
+static DWORD loadError = 0;
+static char missingDeps[1024] = "";
+
+static int depsVisited = 0;
+static char depsSeen[DEPS_MAX_VISITED][DEPS_NAME_MAX];
+
+/* Translate an RVA in an on-disk PE image to a file offset.  Returns
+   the number of contiguous bytes available at *offset, or 0 if the RVA
+   does not map into the file. */
+static DWORD rvaToOffset(const IMAGE_NT_HEADERS *nt, DWORD fsize,
+			 DWORD rva, DWORD *offset)
+{
+    const IMAGE_SECTION_HEADER *sec = IMAGE_FIRST_SECTION(nt);
+
+    for (int i = 0; i < nt->FileHeader.NumberOfSections; i++, sec++) {
+	DWORD va = sec->VirtualAddress, raw = sec->SizeOfRawData;
+	if (rva < va || rva - va >= raw)
+	    continue;
+
+	ULONGLONG off = (ULONGLONG) sec->PointerToRawData + (rva - va);
+	if (off >= fsize)
+	    return 0;
+
+	DWORD avail = raw - (rva - va);
+	if (avail > fsize - (DWORD) off)
+	    avail = (DWORD) (fsize - off);
+	*offset = (DWORD) off;
+	return avail;
+    }
+
+    return 0;
+}
+
+/* Returns a NUL-terminated string at the given RVA, or NULL if it does
+   not map into the file or is not terminated within its section. */
+static const char *rvaToCString(const BYTE *base, DWORD fsize,
+				const IMAGE_NT_HEADERS *nt, DWORD rva)
+{
+    DWORD offset = 0;
+    DWORD avail = rvaToOffset(nt, fsize, rva, &offset);
+
+    if (avail == 0 || !memchr(base + offset, '\0', avail))
+	return NULL;
+    return (const char *) (base + offset);
+}
+
+/* Returns 1 if the module has already been probed (or the table is
+   full, to bound the walk), and records it otherwise. */
+static int sawModule(const char *name)
+{
+    for (int i = 0; i < depsVisited; i++)
+	if (_stricmp(depsSeen[i], name) == 0)
+	    return 1;
+
+    if (depsVisited == DEPS_MAX_VISITED)
+	return 1;
+
+    strncpy(depsSeen[depsVisited], name, DEPS_NAME_MAX - 1);
+    depsSeen[depsVisited][DEPS_NAME_MAX - 1] = '\0';
+    depsVisited++;
+    return 0;
+}
+
+static int isSystemModule(const char *path)
+{
+    char windir[MAX_PATH];
+    UINT n = GetWindowsDirectory(windir, MAX_PATH);
+
+    return n > 0 && n < MAX_PATH && _strnicmp(path, windir, n) == 0;
+}
+
+static void reportMissingModule(const char *name, const char *importer)
+{
+    size_t used = strlen(missingDeps);
+    snprintf(missingDeps + used, sizeof(missingDeps) - used,
+	     "\n  missing module '%s' required by '%s'", name, importer);
+}
+
+static void probeImports(const char *path, int depth);
+
+static void walkImports(const BYTE *base, DWORD fsize, const char *path,
+			int depth)
+{
+    /* validate the PE headers; they must describe an image of the same
+       architecture as this build of R */
+    if (fsize < sizeof(IMAGE_DOS_HEADER))
+	return;
+    const IMAGE_DOS_HEADER *dos = (const IMAGE_DOS_HEADER *) base;
+    if (dos->e_magic != IMAGE_DOS_SIGNATURE || dos->e_lfanew < 0)
+	return;
+    DWORD ntoff = (DWORD) dos->e_lfanew;
+    if (ntoff >= fsize || fsize - ntoff < sizeof(IMAGE_NT_HEADERS))
+	return;
+
+    const IMAGE_NT_HEADERS *nt = (const IMAGE_NT_HEADERS *) (base + ntoff);
+    if (nt->Signature != IMAGE_NT_SIGNATURE ||
+	nt->OptionalHeader.Magic != IMAGE_NT_OPTIONAL_HDR_MAGIC)
+	return;
+
+    const BYTE *sec = (const BYTE *) IMAGE_FIRST_SECTION(nt);
+    ULONGLONG secend = (ULONGLONG) (sec - base) +
+	(ULONGLONG) nt->FileHeader.NumberOfSections *
+	sizeof(IMAGE_SECTION_HEADER);
+    if (secend > fsize)
+	return;
+
+    if (nt->OptionalHeader.NumberOfRvaAndSizes <= IMAGE_DIRECTORY_ENTRY_IMPORT)
+	return;
+    const IMAGE_DATA_DIRECTORY *dir =
+	&nt->OptionalHeader.DataDirectory[IMAGE_DIRECTORY_ENTRY_IMPORT];
+    if (dir->VirtualAddress == 0 || dir->Size == 0)
+	return;
+
+    const char *name = path;
+    for (const char *p = path; *p; p++)
+	if (*p == '/' || *p == '\\')
+	    name = p + 1;
+
+    /* probe all direct imports before recursing, so that a missing
+       module is attributed to its shallowest importer */
+    char pending[DEPS_MAX_PENDING][MAX_PATH];
+    int npending = 0;
+
+    for (DWORD i = 0; i < DEPS_MAX_IMPORTS; i++) {
+	DWORD rva = dir->VirtualAddress +
+	    i * (DWORD) sizeof(IMAGE_IMPORT_DESCRIPTOR);
+	DWORD offset = 0;
+	if (rvaToOffset(nt, fsize, rva, &offset) <
+	    sizeof(IMAGE_IMPORT_DESCRIPTOR))
+	    break;
+
+	const IMAGE_IMPORT_DESCRIPTOR *imp =
+	    (const IMAGE_IMPORT_DESCRIPTOR *) (base + offset);
+	if (imp->Name == 0)
+	    break;
+
+	const char *dep = rvaToCString(base, fsize, nt, imp->Name);
+	if (dep == NULL)
+	    break;
+
+	/* API set names ("virtual DLLs") are resolved specially */
+	if (_strnicmp(dep, "api-ms-", 7) == 0 ||
+	    _strnicmp(dep, "ext-ms-", 7) == 0)
+	    continue;
+
+	if (sawModule(dep))
+	    continue;
+
+	/* checks resolvability without running any initializers */
+	HMODULE mod = LoadLibraryEx(dep, NULL, DONT_RESOLVE_DLL_REFERENCES);
+	if (mod == NULL) {
+	    reportMissingModule(dep, name);
+	    continue;
+	}
+
+	char full[MAX_PATH];
+	DWORD n = GetModuleFileName(mod, full, MAX_PATH);
+	FreeLibrary(mod);
+
+	/* the missing module may be an indirect dependency, but there
+	   is no point descending into system DLLs */
+	if (n > 0 && n < MAX_PATH && !isSystemModule(full) &&
+	    npending < DEPS_MAX_PENDING)
+	    strcpy(pending[npending++], full);
+    }
+
+    for (int i = 0; i < npending; i++)
+	probeImports(pending[i], depth + 1);
+}
+
+static void probeImports(const char *path, int depth)
+{
+    if (depth >= DEPS_MAX_DEPTH)
+	return;
+
+    HANDLE file = CreateFile(path, GENERIC_READ, FILE_SHARE_READ, NULL,
+			     OPEN_EXISTING, 0, NULL);
+    if (file == INVALID_HANDLE_VALUE)
+	return;
+
+    DWORD fsize = GetFileSize(file, NULL);
+    HANDLE map = NULL;
+    const BYTE *base = NULL;
+    if (fsize != INVALID_FILE_SIZE && fsize > 0)
+	map = CreateFileMapping(file, NULL, PAGE_READONLY, 0, 0, NULL);
+    if (map)
+	base = (const BYTE *) MapViewOfFile(map, FILE_MAP_READ, 0, 0, 0);
+
+    if (base) {
+	walkImports(base, fsize, path, depth);
+	UnmapViewOfFile((LPCVOID) base);
+    }
+
+    if (map)
+	CloseHandle(map);
+    CloseHandle(file);
+}
+
 HINSTANCE R_loadLibrary(const char *path, int asLocal, int now,
 			const char *search)
 {
@@ -110,6 +331,16 @@ HINSTANCE R_loadLibrary(const char *path, int asLocal, int now,
     _clearfp();
     if(useSearch) setDLLSearchPath(search);
     tdlh = LoadLibrary(path);
+    loadError = tdlh ? 0 : GetLastError();
+
+    /* try to identify missing dependencies, while the DLLpath
+       directory is still in effect */
+    missingDeps[0] = '\0';
+    if (tdlh == NULL && loadError == ERROR_MOD_NOT_FOUND) {
+	depsVisited = 0;
+	probeImports(path, 0);
+    }
+
     if(useSearch) setDLLSearchPath(NULL);
     dllcw = _controlfp(0,0) & ~_MCW_IC;
     if (dllcw != rcw) {
@@ -136,7 +367,7 @@ static void R_getDLLError(char *buf, int len)
 	FORMAT_MESSAGE_FROM_SYSTEM |
 	FORMAT_MESSAGE_IGNORE_INSERTS,
 	NULL,
-	GetLastError(),
+	loadError,
 	MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
 	(LPSTR) &lpMsgBuf,
 	0,
@@ -149,7 +380,15 @@ static void R_getDLLError(char *buf, int len)
     /* It seems that Win 7 returns error messages with CRLF terminators */
     for (LPSTR p = lpMsgBuf; *p && q < e; p++) if (*p != '\r') *q++ = *p;
     LocalFree(lpMsgBuf);
-    *e = '\0';
+
+    if (missingDeps[0]) {
+	/* trim trailing whitespace before appending the module names */
+	while (q > buf && (q[-1] == '\n' || q[-1] == ' '))
+	    q--;
+	for (const char *p = missingDeps; *p && q < e; p++)
+	    *q++ = *p;
+    }
+    *q = '\0';
 }
 
 /* Returns the number of bytes (excluding the terminator) needed in buf.

--- a/src/library/base/man/dynload.Rd
+++ b/src/library/base/man/dynload.Rd
@@ -234,6 +234,13 @@ is.loaded(symbol, PACKAGE = "", type = "")
   that could not be found is not \file{rJava.dll} but something else
   Windows is looking for (here most likely Java DLLs): if you are lucky
   there will be a dialog box with more details.
+
+  Windows does not report which module could not be found, so when this
+  happens \R examines the imports of the DLL (and, recursively, of the
+  DLLs it depends on) and appends lines of the form
+  \preformatted{    missing module 'jvm.dll' required by 'rJava.dll'}
+  naming the modules it was unable to find, where they can be
+  determined.
 }
 #endif
 \section{Warning}{

--- a/tests/reg-win.R
+++ b/tests/reg-win.R
@@ -32,3 +32,40 @@ writeBin(d, src)
 download.file(url, dst, method = "wininet", mode = "wb")
 dstbin <- readBin(dst, "raw")
 stopifnot(identical(d, dstbin))
+
+
+## dyn.load() failing because a dependent DLL cannot be found should
+## name the missing module (needs a toolchain, as when building R)
+if (nzchar(Sys.which("make")) && nzchar(Sys.which("gcc"))) {
+    owd <- setwd(tempdir())
+    dir.create("dll-deps-test")
+    setwd("dll-deps-test")
+    rcmd <- file.path(R.home("bin"), "Rcmd.exe")
+
+    ## a helper DLL, moved into a directory not on the DLL search path
+    writeLines("void dep_fn(void) {}", "fakedep.c")
+    stopifnot(system2(rcmd, c("SHLIB", "-o", "fakedep.dll",
+                              "fakedep.c")) == 0L)
+    dir.create("deps")
+    stopifnot(file.rename("fakedep.dll", "deps/fakedep.dll"))
+
+    ## a DLL linked against the helper
+    writeLines(c("extern void dep_fn(void);",
+                 "void use_dep(void) { dep_fn(); }"),
+               "needsdep.c")
+    stopifnot(system2(rcmd, c("SHLIB", "-o", "needsdep.dll", "needsdep.c",
+                              "-Ldeps", "-lfakedep")) == 0L)
+
+    ## the dependency cannot be found, so loading must fail, and the
+    ## error message should identify the missing module
+    msg <- tryCatch(dyn.load("needsdep.dll"), error = conditionMessage)
+    stopifnot(is.character(msg),
+              grepl("missing module 'fakedep.dll' required by 'needsdep.dll'",
+                    msg, fixed = TRUE))
+
+    ## sanity check: with DLLpath the dependency is found and loading works
+    dll <- dyn.load("needsdep.dll", DLLpath = file.path(getwd(), "deps"))
+    dyn.unload(dll[["path"]])
+
+    setwd(owd)
+}


### PR DESCRIPTION
When `LoadLibrary()` fails with `ERROR_MOD_NOT_FOUND`, Windows does not report which module could not be found, leading to the famously unhelpful:

```
unable to load shared object 'D:/.../WSPsignal.dll':
  LoadLibrary failure:  The specified module could not be found.
```

This patch makes R identify the culprit itself: on `ERROR_MOD_NOT_FOUND`, walk the import table of the DLL on disk, probe each imported module with `LoadLibraryEx(..., DONT_RESOLVE_DLL_REFERENCES)`, and recurse into dependencies that do resolve. Modules that cannot be found are appended to the error message:

```
unable to load shared object 'D:/.../WSPsignal.dll':
  LoadLibrary failure:  The specified module could not be found.
  missing module 'libgsl-25.dll' required by 'WSPsignal.dll'
```

Notes:

- Probing runs while any `DLLpath` directory (`SetDllDirectory`) is still in effect, so it sees the same search path as the failed load.
- API set names (`api-ms-*`, `ext-ms-*`) are skipped; system DLLs are not descended into; the walk is bounded (depth 10, 100 modules). Delay-loaded DLLs are not needed at load time and are not checked.
- The error code is now captured immediately after `LoadLibrary()` returns, where previously `GetLastError()` was not read until after `SetDllDirectory(NULL)` and `_controlfp()` calls.
- Includes a regression test in `tests/reg-win.R`: builds a helper DLL, moves it to a `deps/` directory off the DLL search path, links a second DLL against it, and checks both that loading fails with the new message and that loading with `DLLpath` pointing at `deps/` succeeds. Skipped when no toolchain is available.

Also updates `?dyn.load` (the section discussing this message) and adds a NEWS entry.