### PR TITLE
detect use of cmake/ctest via the PATH in R CMD check

### DIFF
--- a/doc/NEWS.Rd
+++ b/doc/NEWS.Rd
@@ -103,6 +103,13 @@
 
       \item \command{R CMD build} now excludes an obsolete
       \file{data/datalist} file when the package uses \samp{LazyData}.
+
+      \item For packages which declare \command{cmake} in the
+      \samp{SystemRequirements} field, \command{R CMD check --as-cran}
+      now gives a \samp{NOTE} if installation invokes \command{cmake} or
+      \command{ctest} via the bare command name rather than via the
+      \env{CMAKE}/\env{CTEST} variables, since these commonly fail on
+      macOS where \command{cmake} is often not on the path.
     }
   }
 

--- a/doc/NEWS.Rd
+++ b/doc/NEWS.Rd
@@ -106,10 +106,11 @@
 
       \item For packages which declare \command{cmake} in the
       \samp{SystemRequirements} field, \command{R CMD check --as-cran}
-      now gives a \samp{NOTE} if installation invokes \command{cmake} or
-      \command{ctest} via the bare command name rather than via the
-      \env{CMAKE}/\env{CTEST} variables, since these commonly fail on
-      macOS where \command{cmake} is often not on the path.
+      on a Unix-alike now gives a \samp{NOTE} if installation invokes
+      \command{cmake} or \command{ctest} via the bare command name
+      rather than via the \env{CMAKE}/\env{CTEST} variables, since these
+      commonly fail on macOS where \command{cmake} is often not on the
+      path.
     }
   }
 

--- a/doc/manual/R-exts.texi
+++ b/doc/manual/R-exts.texi
@@ -3355,12 +3355,19 @@ around this is for the package's @file{configure} script to include
 @example
 if test -z "$CMAKE"; then CMAKE="`which cmake`"; fi
 if test -z "$CMAKE"; then CMAKE=/Applications/CMake.app/Contents/bin/cmake; fi
-if test -f "$CMAKE"; then echo "no 'cmake' command found"; exit 1; fi
+if test ! -f "$CMAKE"; then echo "no 'cmake' command found"; exit 1; fi
 @end example
 @noindent
 and for the second approach to substitute @env{CMAKE} into
 @file{src/Makevars}.  This also applies to the ancillary command
 @command{ctest}, if used.
+
+For packages which declare @command{cmake} in the
+@samp{SystemRequirements} field, @command{R CMD check --as-cran} tries to
+detect uses of @command{cmake} (or @command{ctest}) via the bare command
+name rather than via the @env{CMAKE} (or @env{CTEST}) variable, and gives
+a @samp{NOTE} where it finds them: such uses commonly fail on macOS, where
+@command{cmake} is often not on the path.
 
 
 @node Checking and building packages

--- a/doc/manual/R-exts.texi
+++ b/doc/manual/R-exts.texi
@@ -3363,11 +3363,12 @@ and for the second approach to substitute @env{CMAKE} into
 @command{ctest}, if used.
 
 For packages which declare @command{cmake} in the
-@samp{SystemRequirements} field, @command{R CMD check --as-cran} tries to
-detect uses of @command{cmake} (or @command{ctest}) via the bare command
-name rather than via the @env{CMAKE} (or @env{CTEST}) variable, and gives
-a @samp{NOTE} where it finds them: such uses commonly fail on macOS, where
-@command{cmake} is often not on the path.
+@samp{SystemRequirements} field, @command{R CMD check --as-cran} on a
+Unix-alike (Linux or macOS) tries to detect uses of @command{cmake} (or
+@command{ctest}) via the bare command name rather than via the
+@env{CMAKE} (or @env{CTEST}) variable, and gives a @samp{NOTE} where it
+finds them: such uses commonly fail on macOS, where @command{cmake} is
+often not on the path.
 
 
 @node Checking and building packages

--- a/doc/manual/R-ints.texi
+++ b/doc/manual/R-ints.texi
@@ -4221,6 +4221,18 @@ It does so by putting scripts at the head of the path which print a
 message and fail.
 Default: false (but true for CRAN submission checks).
 
+@item _R_CHECK_CMAKE_ON_PATH_
+For packages which declare @command{cmake} in the
+@samp{SystemRequirements} field (and which are not restricted to a
+non-Unix @samp{OS_type}), this checks if the package uses
+@command{cmake} or @command{ctest} from the path rather than via the
+@env{CMAKE}/@env{CTEST} variables recommended in @file{Writing R
+Extensions}.  It does so by putting wrappers at the head of the path
+which record a diagnostic and then run the real command, and reporting a
+@samp{NOTE} if the diagnostic appears in the install log.  Such uses
+commonly fail on macOS, where @command{cmake} is often not on the path.
+Default: false (but true for CRAN submission checks).
+
 @item _R_CHECK_RD_ALLOW_EMPTY_ITEM_IN_DESCRIBE_
 Control whether empty items inside @code{\describe} are allowed without
 a warning. This is a temporary stop gap measure meant to support legacy

--- a/doc/manual/R-ints.texi
+++ b/doc/manual/R-ints.texi
@@ -4231,7 +4231,9 @@ Extensions}.  It does so by putting wrappers at the head of the path
 which record a diagnostic and then run the real command, and reporting a
 @samp{NOTE} if the diagnostic appears in the install log.  Such uses
 commonly fail on macOS, where @command{cmake} is often not on the path.
-Default: false (but true for CRAN submission checks).
+Run only on Unix-alikes (Linux and macOS), which is sufficient to catch
+the problem in the pre-flight checks on the CRAN Linux machines.
+Default: false (but true for CRAN submission checks, except on Windows).
 
 @item _R_CHECK_RD_ALLOW_EMPTY_ITEM_IN_DESCRIBE_
 Control whether empty items inside @code{\describe} are allowed without

--- a/src/library/tools/R/check.R
+++ b/src/library/tools/R/check.R
@@ -312,6 +312,89 @@ add_dummies <- function(dir, Log)
    }
 }
 
+## Whether a package might use 'cmake'/'ctest' on macOS, and hence be
+## affected by them commonly not being on the PATH there.  We only
+## consider packages that declare 'cmake' in SystemRequirements, and skip
+## those that do not target a Unix-alike (e.g. Windows-only packages), for
+## which the macOS PATH issue cannot apply.
+pkg_uses_cmake <- function(desc)
+{
+    sr <- desc["SystemRequirements"]
+    if (is.na(sr) || !grepl("cmake", sr, ignore.case = TRUE))
+        return(FALSE)
+
+    ostype <- desc["OS_type"]
+    if (!is.na(ostype) && tolower(ostype) != "unix")
+        return(FALSE)
+
+    TRUE
+}
+
+## The diagnostic emitted by the cmake/ctest wrappers created in
+## add_cmake_dummies() and detected later by check_src().
+cmake_on_path_message <- function(cmd)
+    sprintf(paste0("R CMD check: '%s' was invoked via the PATH; use the '%s' ",
+                   "variable instead -- see 'Using cmake' in 'Writing R Extensions'"),
+            cmd, toupper(cmd))
+
+## On the PATH used for installation, replace 'cmake'/'ctest' with wrappers
+## that record a diagnostic and then run the real command.  This lets us
+## flag packages that invoke these commands via the bare name (which is
+## commonly not on the PATH on macOS) rather than via the CMAKE/CTEST
+## variables recommended in 'Writing R Extensions'.  We also export a
+## working CMAKE/CTEST so that packages following the manual keep working.
+add_cmake_dummies <- function(dir, Log)
+{
+    dir1 <- file.path(dir, "R_check_bin")
+    if (!dir.exists(dir1)) {
+        dir.create(dir1)
+        if (!dir.exists(dir1)) {
+            messageLog(Log, "creation of directory ", sQuote(dir1), " failed")
+            return()
+        }
+        Sys.setenv(PATH = env_path(dir1, Sys.getenv("PATH")))
+    }
+
+    for (cmd in c("cmake", "ctest")) {
+        VAR <- toupper(cmd)
+
+        ## a 'good' command: honour CMAKE/CTEST, else the PATH, else the
+        ## usual macOS application location.
+        real <- Sys.getenv(VAR)
+        if (!nzchar(real))
+            real <- Sys.which(cmd)
+        if (!nzchar(real)) {
+            mac <- file.path("/Applications/CMake.app/Contents/bin", cmd)
+            if (file.exists(mac))
+                real <- mac
+        }
+
+        ## nothing to intercept if no real command is available: a package
+        ## following the manual would then fail anyway, which is correct.
+        if (!nzchar(real) || !file.exists(real))
+            next
+        real <- normalizePath(real, mustWork = FALSE)
+
+        ## avoid pointing a wrapper at itself (should not happen, but be safe)
+        if (identical(normalizePath(dirname(real), mustWork = FALSE),
+                      normalizePath(dir1, mustWork = FALSE)))
+            next
+
+        ## export CMAKE/CTEST for packages following the manual ...
+        args <- list(real)
+        names(args) <- VAR
+        do.call(Sys.setenv, args)
+
+        ## ... and intercept uses of the bare command name on the PATH.
+        wrapper <- file.path(dir1, cmd)
+        writeLines(c("#!/bin/sh",
+                     sprintf('echo "%s" 1>&2', cmake_on_path_message(cmd)),
+                     sprintf('exec "%s" "$@"', real)),
+                   wrapper)
+        Sys.chmod(wrapper, "0755")
+    }
+}
+
 ###- The main function for "R CMD check"
 .check_packages <- function(args = NULL, no.q = interactive(), warnOption = 1)
 {
@@ -4044,6 +4127,35 @@ add_dummies <- function(dir, Log)
                     resultLog(Log, "OK")
             }
         }
+
+        Check_cmake <- Sys.getenv("_R_CHECK_CMAKE_ON_PATH_", "FALSE")
+        if(config_val_to_logical(Check_cmake) && pkg_uses_cmake(desc) &&
+           dir.exists('src')) {
+            instlog <- if (startsWith(install, "check"))
+                           install_log_path
+                       else
+                           file.path(pkgoutdir, "00install.out")
+            if (file.exists(instlog)) {
+                checkingLog(Log, "use of 'cmake'/'ctest' via the PATH")
+                lines <- readLines(instlog, warn = FALSE)
+                hits <- grep("was invoked via the PATH; use the",
+                             lines, value = TRUE, useBytes = TRUE)
+                if (length(hits)) {
+                    cmds <- unique(sub(".*'([^']+)' was invoked via the PATH.*",
+                                       "\\1", hits))
+                    noteLog(Log)
+                    msg <- c(
+                        sprintf("Package installation invoked %s via the PATH.",
+                                paste(sQuote(cmds), collapse = " and ")),
+                        "Such commands are often not on the PATH, notably on macOS where",
+                        "'cmake' is commonly installed only as",
+                        "'/Applications/CMake.app/Contents/bin/cmake'; discover them via",
+                        "the 'CMAKE'/'CTEST' variables as described in 'Using cmake' in",
+                        "the 'Writing R Extensions' manual.")
+                    printLog0(Log, paste(c(msg, ""), collapse = "\n"))
+                } else resultLog(Log, "OK")
+            }
+        }
     }
 
     check_sos <- function() {
@@ -7658,6 +7770,7 @@ add_dummies <- function(dir, Log)
         Sys.setenv1("_R_CHECK_R_DEPENDS_", "warn")
         ## until this is tested on Windows
         Sys.setenv("_R_CHECK_R_ON_PATH_" = if(WINDOWS) "FALSE" else "TRUE")
+        Sys.setenv("_R_CHECK_CMAKE_ON_PATH_" = if(WINDOWS) "FALSE" else "TRUE")
         Sys.setenv("_R_CHECK_PACKAGES_USED_IN_TESTS_USE_SUBDIRS_" = "TRUE")
         Sys.setenv("_R_CHECK_CONNECTIONS_LEFT_OPEN_" = "TRUE")
         Sys.setenv("_R_CHECK_SHLIB_OPENMP_FLAGS_" = "TRUE")
@@ -8085,6 +8198,9 @@ add_dummies <- function(dir, Log)
             makevars <- basename(makevars)
 
             if (do_install) {
+                if(config_val_to_logical(Sys.getenv("_R_CHECK_CMAKE_ON_PATH_", "FALSE")) &&
+                   pkg_uses_cmake(desc))
+                    add_cmake_dummies(file_path_as_absolute(pkgoutdir), Log)
                 check_install()
                 if(R_check_pkg_sizes) check_install_sizes()
             }

--- a/src/library/tools/R/check.R
+++ b/src/library/tools/R/check.R
@@ -345,6 +345,12 @@ cmake_on_path_message <- function(cmd)
 ## working CMAKE/CTEST so that packages following the manual keep working.
 add_cmake_dummies <- function(dir, Log)
 {
+    ## Unix-only for now: the wrapper is a /bin/sh script, and the macOS
+    ## PATH problem this targets does not arise on Windows (which uses
+    ## configure.win/Makevars.win, not exercised by a Unix check anyway).
+    if (.Platform$OS.type == "windows")
+        return()
+
     dir1 <- file.path(dir, "R_check_bin")
     if (!dir.exists(dir1)) {
         dir.create(dir1)
@@ -4129,7 +4135,7 @@ add_cmake_dummies <- function(dir, Log)
         }
 
         Check_cmake <- Sys.getenv("_R_CHECK_CMAKE_ON_PATH_", "FALSE")
-        if(config_val_to_logical(Check_cmake) && pkg_uses_cmake(desc) &&
+        if(!WINDOWS && config_val_to_logical(Check_cmake) && pkg_uses_cmake(desc) &&
            dir.exists('src')) {
             instlog <- if (startsWith(install, "check"))
                            install_log_path


### PR DESCRIPTION
## Motivation

`Writing R Extensions` recommends that packages using `cmake` discover it via a `CMAKE` variable, because on macOS `cmake` is commonly installed only at `/Applications/CMake.app/Contents/bin/cmake` and is not on the `PATH`. Packages that invoke a bare `cmake`/`ctest` instead build fine on the maintainer's machine (and on Linux CRAN builders) but fail on the CRAN macOS builders, where the problem is discovered late.

This adds a check that catches the mistake earlier.

## What it does

For packages that declare `cmake` in `SystemRequirements` (and are not restricted to a non-Unix `OS_type`), `R CMD check --as-cran`:

- discovers a working `cmake`/`ctest` (honouring `CMAKE`/`CTEST`, then the `PATH`, then the usual macOS application location) and exports `CMAKE`/`CTEST`, so packages following the manual keep working;
- places `cmake`/`ctest` wrappers at the head of the install `PATH` that record a diagnostic to stderr and then `exec` the real command;
- scans the install log for that diagnostic in `check_src()` and emits a `NOTE` naming the offending command(s).

This is a warn-and-forward design rather than a hard failure: packages that invoke the bare command still build (so the check does not change install outcomes), but the use is surfaced. It is gated by a new `_R_CHECK_CMAKE_ON_PATH_` environment variable (true under `--as-cran` on non-Windows), mirroring the existing `_R_CHECK_R_ON_PATH_` mechanism and its `add_dummies()` machinery.

Because the interception works on any platform with a real `cmake`, the mistake is caught on the maintainer's Linux/macOS machine or on CRAN incoming checks, before it reaches the macOS builder.

## Also included

Fixes an inverted test in the `Using cmake` example in `Writing R Extensions`:

```diff
-if test -f "$CMAKE"; then echo "no 'cmake' command found"; exit 1; fi
+if test ! -f "$CMAKE"; then echo "no 'cmake' command found"; exit 1; fi
```

As written it aborts precisely when `cmake` *is* found.

## Notes / limitations

- Windows-only packages (`OS_type: windows`) are skipped. There is no machine-readable way to detect a Linux-only package, so a Linux-only package that uses a bare `cmake` would still get the `NOTE`; in practice `cmake` is normally on the `PATH` on Linux, so this degrades to a harmless style nudge.
- Docs added: `NEWS.Rd`, and the new environment variable is documented in `R-ints`; the check is mentioned in the `Using cmake` section of `R-exts`.

Given r-svn is a read-only mirror of the R Subversion repository, this PR is intended for discussion/review; the change would ultimately need to land via the usual SVN workflow.
