### PR TITLE
adjust writeChar test expectation for windows

### DIFF
--- a/tests/reg-encodings.R
+++ b/tests/reg-encodings.R
@@ -464,4 +464,7 @@ for (k in 1:64) {
 ## or   malloc(): invalid size (unsorted)
 ## or   Fatal glibc error: malloc.c:..(_int_malloc): assertion failed: (unsigned long) (size) >= (unsigned long)(nb)
 ## now, after fixing:
-stopifnot(all.equal(file.size(tf), 699))
+## (writeChar() counts chars via mbstowcs(); on Windows, 16-bit wchar_t means
+##  each non-BMP char counts as a UTF-16 surrogate pair, i.e., as 2, so only
+##  399 - 200 zero bytes are appended there)
+stopifnot(all.equal(file.size(tf), if(onWindows) 599 else 699))


### PR DESCRIPTION
The Windows (x86_64) job fails in the regression test added in r90334 ("counting chars & bytes consistently, notably in mbcslocale", the PR#19112 writeChar() overflow fix):

```
> stopifnot(all.equal(file.size(tf), 699))
Error: file.size(tf) and 699 are not equal:
  Mean relative difference: 0.1669449
```

The reported relative difference is exactly 100/599: the file is 599 bytes on Windows rather than the expected 699.

## Cause

`writeChar()` counts characters via `mbstowcs(NULL, s, 0)`, both in the long-standing writing loop and in the new buffer-sizing loop from r90334. On Windows, `wchar_t` is 16-bit UTF-16, so `mbstowcs()` returns the number of UTF-16 code units, not characters. `su <- strrep("\U0001F600", 100L)` consists of supplementary-plane characters (surrogate pairs in UTF-16), so it counts as 200 rather than 100. The zero padding is then `399 - 200 = 199` bytes instead of `399 - 100 = 299`, giving a 599-byte file (`400 + 199`) instead of 699.

Parts (a)/(b) of the test use "é", a BMP character that counts as 1 UTF-16 unit, so they pass on Windows as well; only the non-BMP case in part (c) diverges.

Note this is not a resurfacing of the heap corruption fixed by r90334: the sizing loop and the writing loop count the same way, so the buffer size and bytes written agree on Windows. Only the test's hard-coded 699 bakes in the Unix (32-bit `wchar_t`) character count.

## Change

Make the expected file size platform-aware (`599` on Windows), matching the `onWindows` special-casing used earlier in this test file.

An alternative would be to make `writeChar()` count real characters (consistently with `nchar(su, "chars") == 100`) on Windows, i.e. treat a surrogate pair as one character, but that changes long-standing Windows padding semantics and seems like a decision for R-core.
