### PR TITLE
proposal: writeChar should count supplementary chars once on windows

### DIFF
--- a/doc/NEWS.Rd
+++ b/doc/NEWS.Rd
@@ -279,6 +279,11 @@
       \item \code{writeChar()} in a multibyte locale counts characters and
       bytes consistently and no longer overflows, thanks to \I{Kevin
 	Ushey}'s report and patch in \PR{19112}.
+
+      \item On Windows, \code{writeChar()} now counts characters
+      consistently with \code{readChar()} and \code{nchar()}: previously,
+      \code{nchars} counted each supplementary (\I{non-BMP}) character
+      twice, as a UTF-16 surrogate pair.
     }
   }
 }

--- a/src/main/connections.c
+++ b/src/main/connections.c
@@ -5347,6 +5347,45 @@ attribute_hidden SEXP do_readchar(SEXP call, SEXP op, SEXP args, SEXP env)
     return ans;
 }
 
+/* Number of characters in 's': where wchar_t is 16-bit (Windows),
+   mbstowcs() returns the number of UTF-16 code units, counting each
+   supplementary ("non-BMP") character twice, so in a UTF-8 locale count
+   complete UTF-8 characters directly, as readChar() and nchar() do.
+   Returns (size_t)-1 for an invalid multibyte string. */
+static size_t mbCharCount(const char *s)
+{
+    size_t nc = mbstowcs(NULL, s, 0);
+
+    if(utf8locale && (int) nc >= 0) {
+	nc = 0;
+	for(const char *p = s; *p; p += utf8clen(*p))
+	    nc++;
+    }
+    return nc;
+}
+
+/* Byte length of the first 'nchars' characters of 's'.  For an invalid
+   multibyte string (valid = FALSE), Mbrtowc() signals an error when it
+   reaches the first invalid sequence. */
+static size_t mbBytesForChars(const char *s, R_xlen_t nchars, Rboolean valid)
+{
+    const char *p = s;
+
+    if(valid && utf8locale) {
+	for(R_xlen_t j = 0; j < nchars && *p; j++)
+	    p += utf8clen(*p);
+    } else {
+	mbstate_t mb_st;
+	mbs_init(&mb_st);
+	for(R_xlen_t j = 0; j < nchars; j++) {
+	    size_t used = Mbrtowc(NULL, p, R_MB_CUR_MAX, &mb_st);
+	    if(!used) break;
+	    p += used;
+	}
+    }
+    return (size_t)(p - s);
+}
+
 /* writeChar(object, con, nchars, sep, useBytes) */
 attribute_hidden SEXP do_writechar(SEXP call, SEXP op, SEXP args, SEXP env)
 {
@@ -5358,7 +5397,6 @@ attribute_hidden SEXP do_writechar(SEXP call, SEXP op, SEXP args, SEXP env)
     const char *s, *ssep = "";
     Rboolean wasopen = TRUE, usesep, isRaw = FALSE;
     Rconnection con = NULL;
-    mbstate_t mb_st;
     RCNTXT cntxt;
 
     checkArity(op, args);
@@ -5417,21 +5455,13 @@ attribute_hidden SEXP do_writechar(SEXP call, SEXP op, SEXP args, SEXP env)
 	else {
 	    const char *ss = useBytes ? CHAR(sii) : translateChar(sii);
 	    size_t nb = strlen(ss),
-		nc = mbcslocale ? mbstowcs(NULL, ss, 0) : nb;
+		nc = mbcslocale ? mbCharCount(ss) : nb;
 	    if((size_t) tt > nc)
 		nb += ((size_t) tt - nc); /* zero-padding, counted in bytes */
 	    else if((size_t) tt < nc) {
-		if(mbcslocale) {
-		    mbstate_t mb_st1;
-		    mbs_init(&mb_st1);
-		    const char *p = ss;
-		    nb = 0;
-		    for(int j = 0; j < tt; j++) {
-			size_t used = Mbrtowc(NULL, p, R_MB_CUR_MAX, &mb_st1);
-			p  += used;
-			nb += used;
-		    }
-		} else
+		if(mbcslocale)
+		    nb = mbBytesForChars(ss, tt, nc != (size_t)-1);
+		else
 		    nb = (size_t) tt;
 	    }
 	    nbytes[i] = nb;
@@ -5503,24 +5533,17 @@ attribute_hidden SEXP do_writechar(SEXP call, SEXP op, SEXP args, SEXP env)
 	    else
 		s = translateChar(si);
 	    lenb = lenc = strlen(s);
-	    if(mbcslocale) lenc = mbstowcs(NULL, s, 0);
+	    if(mbcslocale) lenc = mbCharCount(s);
 	    /* As from 1.8.1, zero-pad if too many chars are requested. */
 	    if(len > lenc) {
 		warning(_("writeChar: more characters requested than are in the string - will zero-pad"));
 		lenb += (len - lenc);
 	    }
 	    if(len < lenc) {
-		if(mbcslocale) {
+		if(mbcslocale)
 		    /* find out how many bytes we need to write */
-		    size_t i, used;
-		    const char *p = s;
-		    mbs_init(&mb_st);
-		    for(i = 0, lenb = 0; i < len; i++) {
-			used = Mbrtowc(NULL, p, R_MB_CUR_MAX, &mb_st);
-			p += used;
-			lenb += used;
-		    }
-		} else
+		    lenb = mbBytesForChars(s, len, lenc != (size_t)-1);
+		else
 		    lenb = len;
 	    }
 	    if (lenb + slen)

--- a/tests/reg-encodings.R
+++ b/tests/reg-encodings.R
@@ -465,3 +465,15 @@ for (k in 1:64) {
 ## or   Fatal glibc error: malloc.c:..(_int_malloc): assertion failed: (unsigned long) (size) >= (unsigned long)(nb)
 ## now, after fixing:
 stopifnot(all.equal(file.size(tf), 699))
+## file.size(tf) was 599 on Windows in R <= 4.6.x, counting each of these
+## supplementary ("non-BMP") characters as two UTF-16 code units
+## (d) truncation, which must also count characters, as readChar() does
+r2 <- writeChar(su, raw(), nchars = 50L, eos = NULL)
+tf2 <- tempfile(); f <- file(tf2, "wb")
+writeChar(su, f, nchars = 50L, eos = NULL)
+close(f)
+stopifnot(exprs = {
+    identical(r2, charToRaw(strrep("\U0001F600", 50L)))
+    file.size(tf2) == 200
+    identical(readBin(tf2, "raw", 300L), charToRaw(strrep("\U0001F600", 50L)))
+})


### PR DESCRIPTION
Alternative to #280 -- instead of adjusting the test expectation for Windows, this makes `writeChar()` count characters the same way on all platforms.

## Background

The Windows CI failure after r90334 (`file.size(tf)` of 599 rather than 699 in the new PR#19112 regression test) comes from `writeChar()` counting characters via `mbstowcs(NULL, s, 0)`. Where `wchar_t` is 16-bit (Windows), `mbstowcs()` returns the number of UTF-16 code units, so each supplementary ("non-BMP") character such as `"\U0001F600"` counts as 2. The test string of 100 such characters counts as 200, and `writeChar(su, f, nchars = 399L)` appends only `399 - 200 = 199` padding bytes instead of `399 - 100 = 299`.

This is inconsistent with the rest of R on Windows itself:

- `nchar(su, "chars")` returns 100 (R counts code points itself);
- `readChar()` already counts *characters* in a UTF-8 locale, walking the input with `utf8clen()` and never going through `wchar_t` (`readFixedString()` / `rawFixedString()`).

So on Windows, `writeChar(x, con, nchars = n)` and `readChar(con, nchars = n)` currently disagree about what a "char" is whenever `x` contains supplementary characters. The `?writeChar` documentation describes `nchars` as a number of characters, with no platform qualification.

## Change

Add `mbCharCount()` and `mbBytesForChars()` helpers used by both the buffer-sizing loop and the writing loop of `do_writechar()`: in a UTF-8 locale, count complete UTF-8 characters directly via `utf8clen()` (the same idiom `readChar()` uses); in other MBCS locales, keep the existing `mbstowcs()`/`Mbrtowc()` code (those encodings have no supplementary-plane characters, so counts agree).

Properties:

- On platforms with 32-bit `wchar_t` (Unix, macOS), behavior is unchanged: for valid strings, the `utf8clen()` walk returns exactly what `mbstowcs()`/`Mbrtowc()` returned.
- Invalid multibyte strings take the previous `Mbrtowc()` path unchanged, so the existing "invalid multibyte string at ..." error behavior is preserved.
- On Windows, `nchars` now counts supplementary characters once, consistently with `readChar()` and `nchar()`. The unconditional `file.size(tf) == 699` expectation in `tests/reg-encodings.R` then holds on Windows too (this branch deliberately does *not* include the #280 test tweak; if #280 is merged first, its `if(onWindows) 599` special-case should be reverted here).

Also adds a truncation test (`nchars` smaller than the number of characters) with supplementary characters, a path previously exercised on no platform for non-BMP input. Assertions use `readBin()`/raw comparisons rather than `readChar()` on purpose: whether UCRT's `mbrtowc()` (used in `readFixedString()`'s per-character validity check) accepts 4-byte UTF-8 sequences with a 16-bit `wchar_t` is a separate open question, and `readChar()` of non-BMP text on Windows deserves its own test/investigation.

## Compatibility

This changes what Windows writes for the (rare) case `nchars != number of characters` with non-BMP input: previously-written padded files effectively used UTF-16-unit counts. Given the padding/truncation path for non-BMP characters was inconsistent between `writeChar()` and `readChar()` and untested, treating the old Windows behavior as a bug seems right, but this is R-core's call -- hence a proposal PR.
