### PR TITLE
asan: poison free small-node data to catch use of collected objects

### DIFF
--- a/doc/manual/R-exts.texi
+++ b/doc/manual/R-exts.texi
@@ -10083,6 +10083,19 @@ By comparison with @command{valgrind}, @abbr{ASan} can
 detect misuse of stack and global variables but not the use of
 uninitialized memory.
 
+When @R{} itself is built with @option{-fsanitize=address}, the memory
+manager additionally poisons the data regions of vector nodes in its
+internal small-node pages whenever they are free, so use of a vector's
+data after the vector has been garbage collected is reported by
+@abbr{ASan} even though the underlying pages are recycled by @R{}
+rather than returned to @code{malloc} (this parallels what
+@option{--with-valgrind-instrumentation=2} provides under
+@command{valgrind}).  Such reports are labelled
+@samp{use-after-poison}.  Together with @code{gctorture} this can
+detect the use of unprotected objects whose memory has been reclaimed.
+Node headers and cons cells are not poisoned, so misuse of those is
+still not detected.
+
 Recent versions return symbolic addresses for the location of the error
 provided @command{llvm-symbolizer}@footnote{part of the @I{LLVM} project and
 distributed in @code{llvm} @acronym{RPM}s and @file{.deb}s on Linux.  It is not

--- a/src/main/memory.c
+++ b/src/main/memory.c
@@ -76,6 +76,55 @@
 # include "valgrind/memcheck.h"
 #endif
 
+/* Declarations for the Address Sanitizer.
+
+   When R itself is compiled with -fsanitize=address, the data regions
+   of free nodes in the small-node pages are manually poisoned, so
+   that use of a node's data after the node has been collected is
+   reported by ASan even though the underlying pages are recycled by
+   R's allocator and never returned to malloc.  This parallels what
+   --with-valgrind-instrumentation=2 provides under valgrind, at a
+   much smaller run-time cost.
+
+   Large vector nodes need no manual handling: they are individually
+   malloc'd and freed, so ASan tracks them natively.  Node headers are
+   never poisoned, since the collector traverses free nodes via their
+   header fields; consequently misuse of the header of a collected
+   node (or of a collected cons cell, which has no separate data
+   region) is still not detected.
+*/
+#if defined(__has_feature)
+# if __has_feature(address_sanitizer)
+#  define HAVE_ADDRESS_SANITIZER 1
+# endif
+#endif
+#if !defined(HAVE_ADDRESS_SANITIZER) && defined(__SANITIZE_ADDRESS__)
+# define HAVE_ADDRESS_SANITIZER 1
+#endif
+
+#ifdef HAVE_ADDRESS_SANITIZER
+# include <sanitizer/asan_interface.h>
+# define ASAN_POISON_FREE_NODE(c, n) \
+    do { \
+	if (NodeClassSize[c] > 0) \
+	    ASAN_POISON_MEMORY_REGION(STDVEC_DATAPTR(n), \
+				      NodeClassSize[c]*sizeof(VECREC)); \
+    } while (0)
+# define ASAN_UNPOISON_FREE_NODE(c, n) \
+    do { \
+	if (NodeClassSize[c] > 0) \
+	    ASAN_UNPOISON_MEMORY_REGION(STDVEC_DATAPTR(n), \
+					NodeClassSize[c]*sizeof(VECREC)); \
+    } while (0)
+/* memory manually poisoned must be unpoisoned before it is returned
+   to malloc */
+# define ASAN_UNPOISON_PAGE(p) ASAN_UNPOISON_MEMORY_REGION(p, R_PAGE_SIZE)
+#else
+# define ASAN_POISON_FREE_NODE(c, n) do { } while (0)
+# define ASAN_UNPOISON_FREE_NODE(c, n) do { } while (0)
+# define ASAN_UNPOISON_PAGE(p) do { } while (0)
+#endif
+
 /* For speed in cases when the argument is known to not be an ALTREP list. */
 #define VECTOR_ELT_0(x,i)        ((SEXP *) STDVEC_DATAPTR(x))[i]
 #define SET_VECTOR_ELT_0(x,i, v) (((SEXP *) STDVEC_DATAPTR(x))[i] = (v))
@@ -846,6 +895,7 @@ static R_size_t R_NodesInUse = 0;
   } \
   R_GenHeap[c].Free = NEXT_NODE(__n__); \
   R_NodesInUse++; \
+  ASAN_UNPOISON_FREE_NODE(c, __n__); \
   (s) = __n__; \
 } while (0)
 
@@ -859,6 +909,7 @@ static R_size_t R_NodesInUse = 0;
 	    error("need new page - should not happen");	\
 	R_GenHeap[c].Free = NEXT_NODE(__n__);		\
 	R_NodesInUse++;					\
+	ASAN_UNPOISON_FREE_NODE(c, __n__);		\
 	(s) = __n__;					\
     } while (0)
 
@@ -1019,6 +1070,7 @@ static void GetNewPage(int node_class)
 	if (NodeClassSize[node_class] > 0)
 	    VALGRIND_MAKE_MEM_NOACCESS(STDVEC_DATAPTR(s), NodeClassSize[node_class]*sizeof(VECREC));
 #endif
+	ASAN_POISON_FREE_NODE(node_class, s);
 	s->sxpinfo = UnmarkedNodeTemplate.sxpinfo;
 	INIT_REFCNT(s);
 	SET_NODE_CLASS(s, node_class);
@@ -1046,6 +1098,7 @@ static void ReleasePage(PAGE_HEADER *page, int node_class)
 	R_GenHeap[node_class].AllocCount--;
     }
     R_GenHeap[node_class].PageCount--;
+    ASAN_UNPOISON_PAGE(page);
     free(page);
 }
 
@@ -1962,6 +2015,17 @@ static int RunGenCollect(R_size_t size_needed)
 				       NodeClassSize[i]*sizeof(VECREC));
 	}
     }
+#endif
+
+#ifdef HAVE_ADDRESS_SANITIZER
+    /* Poison the data of everything left in New space: only free and
+       newly collected nodes remain there at this point.  Nodes handed
+       back out are unpoisoned in CLASS_GET_FREE_NODE. */
+    for (i = 1; i < NUM_SMALL_NODE_CLASSES; i++)
+	for (s = NEXT_NODE(R_GenHeap[i].New);
+	     s != R_GenHeap[i].New;
+	     s = NEXT_NODE(s))
+	    ASAN_POISON_FREE_NODE(i, s);
 #endif
 
     /* reset Free pointers */


### PR DESCRIPTION
## Motivation

R's small-node allocator recycles pages internally and never returns individual nodes to `malloc`, so a stock AddressSanitizer build of R cannot detect use of a vector's data after the vector has been garbage collected -- the memory is simply reused. Under `valgrind` this gap is covered by `--with-valgrind-instrumentation=2`, which marks free node data as inaccessible, but valgrind costs ~20x at runtime.

This PR adds the ASan equivalent, active only when R itself is compiled with `-fsanitize=address` (macro no-ops otherwise, so regular builds are unchanged):

* free-node data regions in the small-node pages are poisoned with `ASAN_POISON_MEMORY_REGION`: at page creation, and for everything left in New space at the end of a collection (only free and newly collected nodes remain there at that point);
* data is unpoisoned when a node is handed back out in `CLASS_GET_FREE_NODE` / `CLASS_QUICK_GET_FREE_NODE`;
* page memory is unpoisoned before being returned to `malloc` in `ReleasePage`.

Large and custom vectors need no manual handling (individually malloc'd/freed, so ASan tracks them natively). Node headers are not poisoned since the collector traverses free nodes via header fields; consequently misuse of a collected cons cell (which has no separate data region) is still not detected -- the same limitation as the valgrind level 2 instrumentation.

## Example

With R configured as `CC="clang -fsanitize=address" CFLAGS="-fno-omit-frame-pointer -g -O2" MAIN_LDFLAGS=-fsanitize=address` (no strict barrier needed), running this under `gctorture(TRUE)`:

```c
SEXP C_uaf(void)
{
    SEXP x = allocVector(REALSXP, 3);
    REAL(x)[0] = 42.0;
    SEXP y = PROTECT(allocVector(REALSXP, 100)); /* x not protected */
    double d = REAL(x)[0];  /* use after collection */
    REAL(y)[0] = d;
    UNPROTECT(1);
    return y;
}
```

produces an immediate report with the exact faulting access:

```
==13131==ERROR: AddressSanitizer: use-after-poison on address 0x625001a5b938 ...
    #0 0x000101d7d2f4 in C_uaf uaf.c:13
    #1 0x00010105ec10 in R_doDotCall dotcode.c:751
    #2 0x00010106feb0 in do_dotcall dotcode.c:1437
    #3 0x0001010f1ab0 in Rf_eval eval.c:1258
    ...
```

## Notes

* The poisoning survived a full build (including byte-compilation of all base packages under the instrumented allocator) and gctorture smoke tests on macOS arm64.
* If this lands together with #282, the corpse "data preview" added there would read poisoned memory in a combined strict-barrier + ASan build; whichever lands second should add an `ASAN_UNPOISON_MEMORY_REGION` of the corpse data in `report_unprotected()` (happy to follow up).
* R-exts "Using the Address Sanitizer" gained a paragraph describing the new behavior.
