### PR TITLE
Fix memory blowup in .Rd_get_text() since r90045 (73f7cc2)

### DIFF
--- a/src/library/tools/R/Rd.R
+++ b/src/library/tools/R/Rd.R
@@ -901,10 +901,12 @@ function(x) {
     rval <- NULL
     file <- textConnection("rval", "w", local = TRUE)
 
-    Rdsave <- Rd2txt_options(underline_titles = FALSE, unicode_symbols = FALSE)
+    save <- options(useFancyQuotes = FALSE)
+    Rdsave <- Rd2txt_options(underline_titles = FALSE)
     sink(file)
     tryCatch(Rd2txt(x, fragment=TRUE),
              finally = {sink()
+                        options(save)
                         Rd2txt_options(Rdsave)
                         close(file)})
 


### PR DESCRIPTION
`.Rd_get_text()` (src/library/tools/R/Rd.R) is called once per Rd file by `Rd_contents()` -> `Rd_info()` -> `.Rd_get_title()` during `R CMD INSTALL`'s "installing help indices" / "building package indices" steps, converting each file's \title fragment to plain text via Rd2txt().

Commit 73f7cc2 (2026-05-11, r90045, "Rd2txt(): use Unicode dashes") replaced `options(useFancyQuotes = FALSE)` (restored afterward via options(save)) with `Rd2txt_options(underline_titles = FALSE, unicode_symbols = FALSE)`, and dropped the `options(save)` restore in the finally block.

Since then, every call to `.Rd_get_text()` leaks memory, and it is not proportional to the size of the content being converted. Benchmarked both versions converting tiny \title fragments (a few words each), 2000 calls in a single R session:

- Pre-73f7cc2 (fixed): +0.5 MB total after 2000 calls -- no measurable leak.
- Post-73f7cc2 (current): +653 MB after just 25 calls (~26 MB/call), then a hard crash (cannot allocate vector of size 2.0 Gb) shortly after.

This is a fixed-ish leak per call, independent of content size, so the multiplier is simply the number of Rd files in the package -- `Rd_contents()` calls it once per file. For a package with a few hundred Rd files (e.g. one with ~320, as we hit in practice), that is roughly 320 x 26MB ~= 8GB from title-processing alone during a single `R CMD INSTALL`, consistent with the 20GB+ RSS blowups and crashes we observed installing such a package -- this affects any package with enough Rd files, regardless of content.

This reverts just the one hunk to the pre-73f7cc2 implementation -- a pure revert, no new behavior, restoring the option save/restore that got dropped alongside the (presumably intentional) Unicode-dashes change.

Noticed while working on a separate `R CMD INSTALL` parallelization patch (PR #278); not included there since it is an unrelated correctness fix.