### PR TITLE
reject re-entrant parse_Rd instead of corrupting the outer parse

### DIFF
--- a/src/library/tools/src/gramRd.c
+++ b/src/library/tools/src/gramRd.c
@@ -4463,6 +4463,7 @@ static void PutState(ParseState *state) {
     state->Value = parseState.Value;
     state->xxinitvalue = parseState.xxinitvalue;
     state->xxMacroList = parseState.xxMacroList;
+    state->mset = parseState.mset;
     state->prevState = parseState.prevState;
 }
 
@@ -4483,6 +4484,7 @@ static void UseState(ParseState *state) {
     parseState.Value = state->Value;
     parseState.xxinitvalue = state->xxinitvalue;
     parseState.xxMacroList = state->xxMacroList;
+    parseState.mset = state->mset;
     parseState.prevState = state->prevState;
 }
 
@@ -4506,6 +4508,11 @@ static void PopState(void) {
     	busy = false;
 }
 
+static void PopStateOnError(void *dummy)
+{
+    PopState();
+}
+
 /* "do_parseRd" 
 
  .External2(C_parseRd,file, srcfile, encoding, verbose, basename, warningCalls, macros, warndups)
@@ -4521,7 +4528,8 @@ SEXP parseRd(SEXP call, SEXP op, SEXP args, SEXP env)
     bool wasopen, fragment;
     int ifile, wcall;
     ParseStatus status;
-    RCNTXT cntxt;
+    RCNTXT conn_cntxt;
+    RCNTXT state_cntxt;
     SEXP macros;
 
 #if DEBUGMODE
@@ -4531,7 +4539,14 @@ SEXP parseRd(SEXP call, SEXP op, SEXP args, SEXP env)
     R_ParseError = 0;
     R_ParseErrorMsg[0] = '\0';
     
+    if (busy)
+	error(_("'parse_Rd' is not re-entrant"));
+
     PushState();
+    begincontext(&state_cntxt, CTXT_CCODE, R_NilValue, R_BaseEnv, R_BaseEnv,
+                 R_NilValue, R_NilValue);
+    state_cntxt.cend = &PopStateOnError;
+    state_cntxt.cenddata = NULL;
 
     ifile = asInteger(CAR(args));                       args = CDR(args);
 
@@ -4556,19 +4571,21 @@ SEXP parseRd(SEXP call, SEXP op, SEXP args, SEXP env)
 	if(!wasopen) {
 	    if(!con->open(con)) error(_("cannot open the connection"));
 	    /* Set up a context which will close the connection on error */
-	    begincontext(&cntxt, CTXT_CCODE, R_NilValue, R_BaseEnv, R_BaseEnv,
+	    begincontext(&conn_cntxt, CTXT_CCODE, R_NilValue, R_BaseEnv, R_BaseEnv,
 			 R_NilValue, R_NilValue);
-	    cntxt.cend = &con_cleanup;
-	    cntxt.cenddata = con;
+	    conn_cntxt.cend = &con_cleanup;
+	    conn_cntxt.cenddata = con;
 	}
 	if(!con->canread) error(_("cannot read from this connection"));
 	s = R_ParseRd(con, &status, source, fragment, macros);
-	if(!wasopen) endcontext(&cntxt);
+	if(!wasopen) endcontext(&conn_cntxt);
 	PopState();
+	endcontext(&state_cntxt);
 	if (status != PARSE_OK) parseError(call, R_ParseError);
     }
     else {
       PopState();
+      endcontext(&state_cntxt);
       error(_("invalid Rd file"));
     }
     return s;

--- a/src/library/tools/src/gramRd.y
+++ b/src/library/tools/src/gramRd.y
@@ -1928,6 +1928,7 @@ static void PutState(ParseState *state) {
     state->Value = parseState.Value;
     state->xxinitvalue = parseState.xxinitvalue;
     state->xxMacroList = parseState.xxMacroList;
+    state->mset = parseState.mset;
     state->prevState = parseState.prevState;
 }
 
@@ -1948,6 +1949,7 @@ static void UseState(ParseState *state) {
     parseState.Value = state->Value;
     parseState.xxinitvalue = state->xxinitvalue;
     parseState.xxMacroList = state->xxMacroList;
+    parseState.mset = state->mset;
     parseState.prevState = state->prevState;
 }
 
@@ -1971,6 +1973,11 @@ static void PopState(void) {
     	busy = false;
 }
 
+static void PopStateOnError(void *dummy)
+{
+    PopState();
+}
+
 /* "do_parseRd" 
 
  .External2(C_parseRd,file, srcfile, encoding, verbose, basename, warningCalls, macros, warndups)
@@ -1986,7 +1993,8 @@ SEXP parseRd(SEXP call, SEXP op, SEXP args, SEXP env)
     bool wasopen, fragment;
     int ifile, wcall;
     ParseStatus status;
-    RCNTXT cntxt;
+    RCNTXT conn_cntxt;
+    RCNTXT state_cntxt;
     SEXP macros;
 
 #if DEBUGMODE
@@ -1996,7 +2004,14 @@ SEXP parseRd(SEXP call, SEXP op, SEXP args, SEXP env)
     R_ParseError = 0;
     R_ParseErrorMsg[0] = '\0';
     
+    if (busy)
+	error(_("'parse_Rd' is not re-entrant"));
+
     PushState();
+    begincontext(&state_cntxt, CTXT_CCODE, R_NilValue, R_BaseEnv, R_BaseEnv,
+                 R_NilValue, R_NilValue);
+    state_cntxt.cend = &PopStateOnError;
+    state_cntxt.cenddata = NULL;
 
     ifile = asInteger(CAR(args));                       args = CDR(args);
 
@@ -2021,19 +2036,21 @@ SEXP parseRd(SEXP call, SEXP op, SEXP args, SEXP env)
 	if(!wasopen) {
 	    if(!con->open(con)) error(_("cannot open the connection"));
 	    /* Set up a context which will close the connection on error */
-	    begincontext(&cntxt, CTXT_CCODE, R_NilValue, R_BaseEnv, R_BaseEnv,
+	    begincontext(&conn_cntxt, CTXT_CCODE, R_NilValue, R_BaseEnv, R_BaseEnv,
 			 R_NilValue, R_NilValue);
-	    cntxt.cend = &con_cleanup;
-	    cntxt.cenddata = con;
+	    conn_cntxt.cend = &con_cleanup;
+	    conn_cntxt.cenddata = con;
 	}
 	if(!con->canread) error(_("cannot read from this connection"));
 	s = R_ParseRd(con, &status, source, fragment, macros);
-	if(!wasopen) endcontext(&cntxt);
+	if(!wasopen) endcontext(&conn_cntxt);
 	PopState();
+	endcontext(&state_cntxt);
 	if (status != PARSE_OK) parseError(call, R_ParseError);
     }
     else {
       PopState();
+      endcontext(&state_cntxt);
       error(_("invalid Rd file"));
     }
     return s;


### PR DESCRIPTION
**Option A of two.** The companion PR takes the opposite approach and makes the parser fully re-entrant; these are alternatives, not both to be merged. Opening both mainly to get them through CI — neither has been compiled locally.

## The bug

`parseRd()` brackets each parse with `PushState()`/`PopState()`, but that machinery saves almost none of the parser's state.

`PutState()`/`UseState()` copy 17 `ParseState` fields and omit `mset` — a declared struct member, and the sole GC root for every semantic value. The rest of the lexer state is not in `ParseState` at all, so `PushState`/`PopState` structurally cannot save it: `con_parse`, `ptr_getc`, `pushbase`, `npush`, `pushsize`, `macrolevel`, `SrcFile` (a static `SEXP`), `wCalls`, `warnDups`.

A nested parse therefore leaves the outer one reading a dead connection and preserving into a released multi-set.

## Reproducer

`parse_Rd` signals warnings *during* the parse (`yyerror`, `xxWarnNewline`, the bad-markup rule), so a calling handler runs mid-parse and can re-enter:

```r
outer <- tempfile(fileext=".Rd")
writeLines(paste0("\\name{o}\\title{T}\\description{d}\\eqn{a\nb}\n",
    paste(sprintf("\\section{S%d}{b%d \\code{x%d}}",1:12,1:12,1:12), collapse="\n")), outer)
inner <- tempfile(fileext=".Rd"); writeLines("\\name{i}\\title{I}\\description{z}", inner)

withCallingHandlers(tools::parse_Rd(outer),
    warning = function(w) { tools::parse_Rd(inner); invokeRestart("muffleWarning") })
##  *** caught segfault ***  address 0x0, cause 'invalid permissions'
##  1: tools::parse_Rd(outer)
```

Fresh process per row, on R 4.6.1:

| nested | `gctorture` | result |
|---|---|---|
| no | off | ok |
| no | on | ok |
| **yes** | off | **segfault, exit 139** |
| **yes** | on | **segfault, exit 139** |

The crash needs no GC torture, which shows it is lexer-state corruption rather than the `mset` defect; `address 0x0` fits a call through a clobbered `ptr_getc` or a read from a closed `con_parse`.

## Reachability

What matters is whether the handler unwinds before it runs.

| construction | result |
|---|---|
| `tryCatch(parse_Rd(a), warning=f, error=f)`, `f` calls `parse_Rd` | safe |
| same, `options(warn=2)` aborting the try block mid-parse | safe |
| `withCallingHandlers(parse_Rd(a), warning=` re-parse `)` | **segfault** |
| `globalCallingHandlers(warning=` re-parse `)`, then plain `parse_Rd(a)` | **segfault** |

`tryCatch` installs *exiting* handlers, so `tools:::processRdChunk()` — which calls `parse_Rd` in a try block and in both its `warning` and `error` handlers for `\Sexpr[results=rd]` — is safe. The realistic vector is `globalCallingHandlers(warning=)`: installed once, session-wide, after which a plain `tools::parse_Rd(f)` on a file that merely warns segfaults, with no nesting at the call site.

## The change

1. `if (busy) error(_("'parse_Rd' is not re-entrant"))`.
2. Run `PopState()` when a parse is abandoned by a long jump. This is a prerequisite, not a nicety: several `error()` calls inside the parser unwind past the existing `PopState()` — an unterminated quoted string in `\usage` is ordinary malformed Rd and does it — which would leave `busy` set for the rest of the session and make the new check fire spuriously. `src/main/gram.y` already does this via `FinalizeSrcRefStateOnError()`; `gramRd.y` simply lacked the equivalent.
3. Save/restore `mset` in `PutState`/`UseState`. Unreachable given (1), but correct and cheap.

`endcontext(&state_cntxt)` deliberately precedes `parseError()`, whose long jump would otherwise run the cleanup a second time. The existing `cntxt` is renamed `conn_cntxt` to distinguish it from the new `state_cntxt`.

`gramRd.c` is updated to match, since it is not regenerated unless configured with `--enable-maintainer-mode`. The two files' diffs are byte-identical.

## Caveats

Not compiled or tested locally — that is what this PR is for. This is a stopgap: it converts a segfault into a clean error but does not make nesting work. If nesting should be supported, see the companion PR.