### PR TITLE
[Bugzilla#19117/c1] Change order in which mbcstowcs error is checked (aggressive version)

### DIFF
--- a/src/main/Rstrptime.h
+++ b/src/main/Rstrptime.h
@@ -1299,14 +1299,14 @@ R_strptime (const char *buf, const char *format, stm *tm,
 	// but seems content with 0 rather than 1000.
 	// (Not mentioned by C99/C11).
 	n = mbstowcs(NULL, buf, 0); 
+	if(n == -1) error(_("invalid multibyte input string"));
 	if(n > 1000) error(_("input string is too long"));
 	n = mbstowcs(wbuf, buf, 1000);
-	if(n == -1) error(_("invalid multibyte input string"));
 
 	n = mbstowcs(NULL, format, 0); // ditto
+	if(n == -1) error(_("invalid multibyte format string"));
 	if(n > 1000) error(_("format string is too long"));
 	n = mbstowcs(wfmt, format, 1000);
-	if(n == -1) error(_("invalid multibyte format string"));
 	return (void *) w_strptime_internal (wbuf, wfmt, tm, psecs, poffset);
     } else
 #endif

--- a/src/main/Rstrptime.h
+++ b/src/main/Rstrptime.h
@@ -1295,18 +1295,13 @@ R_strptime (const char *buf, const char *format, stm *tm,
 #if defined(HAVE_WCSTOD)
     if(mbcslocale) {
 	wchar_t wbuf[1001], wfmt[1001]; size_t n;
-	// GCC 12 does not ignore third arg, contradicting the glibc man page
-	// but seems content with 0 rather than 1000.
-	// (Not mentioned by C99/C11).
-	n = mbstowcs(NULL, buf, 0); 
+	n = mbstowcs(wbuf, buf, 1000);
 	if(n == -1) error(_("invalid multibyte input string"));
 	if(n > 1000) error(_("input string is too long"));
-	n = mbstowcs(wbuf, buf, 1000);
 
-	n = mbstowcs(NULL, format, 0); // ditto
+	n = mbstowcs(wfmt, format, 1000);
 	if(n == -1) error(_("invalid multibyte format string"));
 	if(n > 1000) error(_("format string is too long"));
-	n = mbstowcs(wfmt, format, 1000);
 	return (void *) w_strptime_internal (wbuf, wfmt, tm, psecs, poffset);
     } else
 #endif


### PR DESCRIPTION
The same as #287, except this one takes the bolder step to remove the first call to `mbcstowcs()` altogether.