### PR TITLE
check protection stack discipline around primitive and .Call boundaries

### DIFF
--- a/doc/manual/R-exts.texi
+++ b/doc/manual/R-exts.texi
@@ -9912,7 +9912,37 @@ Most calls to accessor functions check their @code{SEXP} inputs and
 The address of the node and the old type are included in the error
 message.
 
+@item
+Calls to a primitive's C function, and calls to a native routine through
+@code{.Call} or @code{.External}, are bracketed by a @dfn{protection
+frame}.  Entries on the pointer protection stack below the frame belong
+to the caller, and an @code{UNPROTECT} that would release one signals an
+error at the point of the offending call:
+
+@example
+unprotect(3): only 2 protected items belong to this call
+@end example
+
+@noindent
+This catches an @code{UNPROTECT} with too large a count, which otherwise
+silently releases a value belonging to the caller and is diagnosed only
+much later, if at all, when that value is collected and used.  Unlike
+the @code{FREESXP} checks above it does not depend on a garbage
+collection happening at the right moment, so it does not need
+@code{gctorture}.
+
 @end itemize
+
+Independently of @option{--enable-strict-barrier}, a primitive that
+returns with the pointer protection stack unbalanced is reported as
+
+@example
+Warning: stack imbalance in 'name', 12 then 13
+@end example
+
+@noindent
+This check applies to compiled code as well as to code evaluated by the
+@abbr{AST} interpreter.
 
 @code{R CMD check --use-gct} can be set to use
 @code{gctorture2(@var{n})} rather than @code{gctorture(TRUE)} by setting

--- a/src/include/Defn.h
+++ b/src/include/Defn.h
@@ -1417,6 +1417,9 @@ typedef struct RCNTXT {
     int callflag;		/* The context "type" */
     JMP_BUF cjmpbuf;		/* C stack and register information */
     int cstacktop;		/* Top of the pointer protection stack */
+#ifdef TESTING_WRITE_BARRIER
+    int ppstackfloor;		/* R_PPStackFloor value */
+#endif
     int evaldepth;	        /* evaluation depth at inception */
     SEXP promargs;		/* Promises supplied to closure */
     SEXP callfun;		/* The closure called */
@@ -1586,6 +1589,24 @@ extern0 int	R_Is_Running;	    /* for Windows memory manager */
 LibExtern int	R_PPStackSize	INI_as(R_PPSSIZE); /* The stack size (elements) */
 LibExtern int	R_PPStackTop;	    /* The top of the stack */
 LibExtern SEXP*	R_PPStack;	    /* The pointer protection stack */
+
+/* Protection stack floor.  Calls into code that is expected to manage
+   its own protections -- a primitive's C function, or a native routine
+   reached through .Call/.External -- are bracketed by a frame that
+   raises the floor to the current top.  Entries below the floor belong
+   to the caller, so a callee that unprotects past it has released a
+   value it does not own.  That is a protection bug even though the
+   stack itself does not underflow, and it is the usual way an
+   UNPROTECT with too large a count goes unnoticed.  Only checked when
+   R is configured with --enable-strict-barrier. */
+#ifdef TESTING_WRITE_BARRIER
+extern0 int	R_PPStackFloor;	    /* Lowest entry the callee may release */
+int  R_OpenPPFrame(void);
+void R_ClosePPFrame(int savedfloor);
+#else
+# define R_OpenPPFrame() 0
+# define R_ClosePPFrame(savedfloor) do { (void) (savedfloor); } while (0)
+#endif
 
 void R_ReleaseMSet(SEXP mset, int keepSize);
 
@@ -2146,6 +2167,7 @@ void Rf_checkArityCall(SEXP, SEXP, SEXP);
 void CheckFormals(SEXP, const char*);
 void R_check_locale(void);
 void check_stack_balance(SEXP op, int save);
+SEXP R_callPrimFun(SEXP fun, SEXP call, SEXP args, SEXP rho);
 void CleanEd(void);
 void copyMostAttribNoTs(SEXP, SEXP);
 SEXP createS3Vars(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);

--- a/src/main/context.c
+++ b/src/main/context.c
@@ -170,6 +170,9 @@ attribute_hidden void R_run_onexits(RCNTXT *cptr)
 static void R_restore_globals(RCNTXT *cptr)
 {
     R_PPStackTop = cptr->cstacktop;
+#ifdef TESTING_WRITE_BARRIER
+    R_PPStackFloor = cptr->ppstackfloor;
+#endif
     R_GCEnabled = cptr->gcenabled;
     R_BCIntActive = cptr->bcintactive;
     R_BCpc = cptr->bcpc;
@@ -253,6 +256,9 @@ void begincontext(RCNTXT * cptr, int flags,
 		  SEXP promargs, SEXP callfun)
 {
     cptr->cstacktop = R_PPStackTop;
+#ifdef TESTING_WRITE_BARRIER
+    cptr->ppstackfloor = R_PPStackFloor;
+#endif
     cptr->gcenabled = R_GCEnabled;
     cptr->relpc = R_BCRelPC(R_BCbody, R_BCpc);
     cptr->bcpc = R_BCpc;

--- a/src/main/dotcode.c
+++ b/src/main/dotcode.c
@@ -746,6 +746,10 @@ R_FUNTYPES(void, V, void *)
 attribute_hidden SEXP R_doDotCall(DL_FUNC fun, int nargs, SEXP *cargs,
 				  SEXP call) {
     SEXP retval = R_NilValue;	/* -Wall */
+    /* A native routine is expected to manage its own protections, so
+       bracket it: unprotecting past this point releases values owned by
+       .Call itself.  A no-op unless --enable-strict-barrier. */
+    int savedfloor = R_OpenPPFrame();
     switch (nargs) {
     case 0:
 	retval = ((FUNS0)fun)();
@@ -1399,6 +1403,8 @@ attribute_hidden SEXP R_doDotCall(DL_FUNC fun, int nargs, SEXP *cargs,
     default:
 	errorcall(call, _("too many arguments, sorry"));
     }
+    R_ClosePPFrame(savedfloor);
+
     return check_retval(call, retval);
 }
 

--- a/src/main/eval.c
+++ b/src/main/eval.c
@@ -933,6 +933,27 @@ attribute_hidden void check_stack_balance(SEXP op, int save)
 	     PRIMNAME(op), save, R_PPStackTop);
 }
 
+/* Calls to a primitive's C function go through this so that the
+   primitive's use of the protection stack is checked: it must leave the
+   stack balanced, and (in a strict barrier build) must not unprotect
+   values belonging to its caller.  The AST interpreter has always
+   checked balance around its own dispatch sites and continues to do so;
+   routing the byte code interpreter through here gives compiled code
+   the same coverage.  R_OpenPPFrame/R_ClosePPFrame are no-ops unless R
+   is configured with --enable-strict-barrier. */
+attribute_hidden SEXP R_callPrimFun(SEXP fun, SEXP call, SEXP args, SEXP rho)
+{
+    int savedfloor = R_OpenPPFrame();
+    int save = R_PPStackTop;
+
+    SEXP value = PRIMFUN(fun) (call, fun, args, rho);
+
+    R_ClosePPFrame(savedfloor);
+    check_stack_balance(fun, save);
+
+    return value;
+}
+
 #define ENSURE_PROMISE_IS_EVALUATED(x) do {	\
 	SEXP __x__ = (x);			\
 	if (! PROMISE_IS_EVALUATED(__x__))	\
@@ -1227,7 +1248,7 @@ SEXP eval(SEXP e, SEXP rho)
 	    const void *vmax = vmaxget();
 	    PROTECT(e);
 	    R_Visible = flag != 1;
-	    tmp = PRIMFUN(op) (e, op, CDR(e), rho);
+	    tmp = R_callPrimFun(op, e, CDR(e), rho);
 #ifdef CHECK_VISIBILITY
 	    if(flag < 2 && R_Visible == flag) {
 		char *nm = PRIMNAME(op);
@@ -1255,11 +1276,11 @@ SEXP eval(SEXP e, SEXP rho)
 		begincontext(&cntxt, CTXT_BUILTIN, e,
 			     R_BaseEnv, R_BaseEnv, R_NilValue, R_NilValue);
 		R_Srcref = NULL;
-		tmp = PRIMFUN(op) (e, op, tmp, rho);
+		tmp = R_callPrimFun(op, e, tmp, rho);
 		R_Srcref = oldref;
 		endcontext(&cntxt);
 	    } else {
-		tmp = PRIMFUN(op) (e, op, tmp, rho);
+		tmp = R_callPrimFun(op, e, tmp, rho);
 	    }
 #ifdef CHECK_VISIBILITY
 	    if(flag < 2 && R_Visible == flag) {
@@ -2424,7 +2445,7 @@ SEXP R_forceAndCall(SEXP e, int n, SEXP rho)
 	int flag = PRIMPRINT(fun);
 	PROTECT(e);
 	R_Visible = flag != 1;
-	tmp = PRIMFUN(fun) (e, fun, CDR(e), rho);
+	tmp = R_callPrimFun(fun, e, CDR(e), rho);
 	if (flag < 2) R_Visible = flag != 1;
 	UNPROTECT(1);
     }
@@ -2440,11 +2461,11 @@ SEXP R_forceAndCall(SEXP e, int n, SEXP rho)
 	    begincontext(&cntxt, CTXT_BUILTIN, e,
 			 R_BaseEnv, R_BaseEnv, R_NilValue, R_NilValue);
 	    R_Srcref = NULL;
-	    tmp = PRIMFUN(fun) (e, fun, tmp, rho);
+	    tmp = R_callPrimFun(fun, e, tmp, rho);
 	    R_Srcref = oldref;
 	    endcontext(&cntxt);
 	} else {
-	    tmp = PRIMFUN(fun) (e, fun, tmp, rho);
+	    tmp = R_callPrimFun(fun, e, tmp, rho);
 	}
 	if (flag < 2) R_Visible = flag != 1;
 	UNPROTECT(1);
@@ -8082,13 +8103,13 @@ static SEXP bcEval_loop(struct bcEval_locals *ploc)
 	  checkForMissings(args, call);
 	  flag = PRIMPRINT(fun);
 	  R_Visible = flag != 1;
-	  value = PRIMFUN(fun) (call, fun, args, rho);
+	  value = R_callPrimFun(fun, call, args, rho);
 	  if (flag < 2) R_Visible = flag != 1;
 	  break;
 	case SPECIALSXP:
 	  flag = PRIMPRINT(fun);
 	  R_Visible = flag != 1;
-	  value = PRIMFUN(fun) (call, fun, markSpecialArgs(CDR(call)), rho);
+	  value = R_callPrimFun(fun, call, markSpecialArgs(CDR(call)), rho);
 	  if (flag < 2) R_Visible = flag != 1;
 	  break;
 	case CLOSXP:
@@ -8143,11 +8164,11 @@ static SEXP bcEval_loop(struct bcEval_locals *ploc)
 	    begincontext(&cntxt, CTXT_BUILTIN, call,
 			 R_BaseEnv, R_BaseEnv, R_NilValue, R_NilValue);
 	    R_Srcref = NULL;
-	    value = PRIMFUN(fun) (call, fun, args, rho);
+	    value = R_callPrimFun(fun, call, args, rho);
 	    R_Srcref = oldref;
 	    endcontext(&cntxt);
 	} else {
-	    value = PRIMFUN(fun) (call, fun, args, rho);
+	    value = R_callPrimFun(fun, call, args, rho);
 	}
 	if (flag < 2) R_Visible = flag != 1;
 	vmaxset(vmax);
@@ -8167,7 +8188,7 @@ static SEXP bcEval_loop(struct bcEval_locals *ploc)
 	}
 	flag = PRIMPRINT(fun);
 	R_Visible = flag != 1;
-	SEXP value = PRIMFUN(fun) (call, fun, markSpecialArgs(CDR(call)), rho);
+	SEXP value = R_callPrimFun(fun, call, markSpecialArgs(CDR(call)), rho);
 	if (flag < 2) R_Visible = flag != 1;
 	vmaxset(vmax);
 	BCNPUSH(value);
@@ -8508,7 +8529,7 @@ static SEXP bcEval_loop(struct bcEval_locals *ploc)
 	  SETCAR(args, lhs);
 	  /* make the call */
 	  checkForMissings(args, call);
-	  value = PRIMFUN(fun) (call, fun, args, rho);
+	  value = R_callPrimFun(fun, call, args, rho);
 	  break;
 	case SPECIALSXP:
 	  /* duplicate arguments and protect */
@@ -8524,7 +8545,7 @@ static SEXP bcEval_loop(struct bcEval_locals *ploc)
 	  prom = mkRHSPROMISE(vexpr, rhs);
 	  SETCAR(last, prom);
 	  /* make the call */
-	  value = PRIMFUN(fun) (call, fun, args, rho);
+	  value = R_callPrimFun(fun, call, args, rho);
 	  UNPROTECT(1);
 	  break;
 	case CLOSXP:
@@ -8561,7 +8582,7 @@ static SEXP bcEval_loop(struct bcEval_locals *ploc)
 	  SETCAR(args, lhs);
 	  /* make the call */
 	  checkForMissings(args, call);
-	  value = PRIMFUN(fun) (call, fun, args, rho);
+	  value = R_callPrimFun(fun, call, args, rho);
 	  break;
 	case SPECIALSXP:
 	  /* duplicate arguments and put into stack for GC protection */
@@ -8572,7 +8593,7 @@ static SEXP bcEval_loop(struct bcEval_locals *ploc)
 	  prom = R_mkEVPROMISE_NR(R_TmpvalSymbol, lhs);
 	  SETCAR(args, prom);
 	  /* make the call */
-	  value = PRIMFUN(fun) (call, fun, args, rho);
+	  value = R_callPrimFun(fun, call, args, rho);
 	  break;
 	case CLOSXP:
 	  /* replace first argument with evaluated promise for LHS */

--- a/src/main/main.c
+++ b/src/main/main.c
@@ -381,6 +381,9 @@ int R_ReplDLLdo1(void)
 	if(c == ';' || c == '\n') break;
     }
     R_PPStackTop = 0;
+#ifdef TESTING_WRITE_BARRIER
+    R_PPStackFloor = 0;
+#endif
     R_CurrentExpr = R_Parse1Buffer(&R_ConsoleIob, 0, &status);
 
     switch(status) {
@@ -1013,6 +1016,9 @@ void setup_Rmainloop(void)
     R_Toplevel.nextcontext = NULL;
     R_Toplevel.callflag = CTXT_TOPLEVEL;
     R_Toplevel.cstacktop = 0;
+#ifdef TESTING_WRITE_BARRIER
+    R_Toplevel.ppstackfloor = 0;
+#endif
     R_Toplevel.gcenabled = R_GCEnabled;
     R_Toplevel.promargs = R_NilValue;
     R_Toplevel.callfun = R_NilValue;

--- a/src/main/memory.c
+++ b/src/main/memory.c
@@ -3422,6 +3422,33 @@ NORET void R_signal_unprotect_error(void)
 	  R_PPStackTop);
 }
 
+#ifdef TESTING_WRITE_BARRIER
+/* Open a protection frame around a call into code that manages its own
+   protections; see the comment on R_PPStackFloor in Defn.h.  The frame
+   is closed on normal return by the caller and on a non-local exit by
+   R_restore_globals, which restores the floor saved by begincontext. */
+int R_OpenPPFrame(void)
+{
+    int savedfloor = R_PPStackFloor;
+    R_PPStackFloor = R_PPStackTop;
+    return savedfloor;
+}
+
+void R_ClosePPFrame(int savedfloor)
+{
+    R_PPStackFloor = savedfloor;
+}
+
+NORET static void R_signal_unprotect_floor_error(int l)
+{
+    int owned = R_PPStackTop - R_PPStackFloor;
+    error(ngettext("unprotect(%d): only %d protected item belongs to this call",
+		   "unprotect(%d): only %d protected items belong to this call",
+		   owned),
+	  l, owned);
+}
+#endif
+
 #ifndef INLINE_PROTECT
 SEXP protect(SEXP s)
 {
@@ -3438,6 +3465,10 @@ SEXP protect(SEXP s)
 void unprotect(int l)
 {
     R_CHECK_THREAD;
+#ifdef TESTING_WRITE_BARRIER
+    if (R_PPStackTop - l < R_PPStackFloor)
+	R_signal_unprotect_floor_error(l);
+#endif
     if (R_PPStackTop >=  l)
 	R_PPStackTop -= l;
     else R_signal_unprotect_error();
@@ -3459,6 +3490,11 @@ void unprotect_ptr(SEXP s)
     } while ( R_PPStack[--i] != s );
 
     /* OK, got it, and  i  is indexing its location */
+#ifdef TESTING_WRITE_BARRIER
+    if (i < R_PPStackFloor)
+	R_signal_unprotect_floor_error(1);
+#endif
+
     /* Now drop stack above it, if any */
 
     while (++i < R_PPStackTop) R_PPStack[i - 1] = R_PPStack[i];
@@ -3533,6 +3569,9 @@ attribute_hidden
 void initStack(void)
 {
     R_PPStackTop = 0;
+#ifdef TESTING_WRITE_BARRIER
+    R_PPStackFloor = 0;
+#endif
 }
 
 

--- a/src/main/names.c
+++ b/src/main/names.c
@@ -1422,7 +1422,7 @@ attribute_hidden SEXP do_internal(SEXP call, SEXP op, SEXP args, SEXP env)
     PROTECT(args);
     flag = PRIMPRINT(INTERNAL(fun));
     R_Visible = flag != 1;
-    ans = PRIMFUN(INTERNAL(fun)) (s, INTERNAL(fun), args, env);
+    ans = R_callPrimFun(INTERNAL(fun), s, args, env);
     /* This resetting of R_Visible = FALSE was to fix PR#7397,
        now fixed in GEText */
     if (flag < 2) R_Visible = flag != 1;

--- a/src/main/objects.c
+++ b/src/main/objects.c
@@ -95,7 +95,7 @@ static SEXP applyMethod(SEXP call, SEXP op, SEXP args, SEXP rho, SEXP newvars)
 	int save = R_PPStackTop, flag = PRIMPRINT(op);
 	const void *vmax = vmaxget();
 	R_Visible = flag != 1;
-	ans = PRIMFUN(op) (call, op, args, rho);
+	ans = R_callPrimFun(op, call, args, rho);
 	if (flag < 2) R_Visible = flag != 1;
 	check_stack_balance(op, save);
 	vmaxset(vmax);
@@ -110,7 +110,7 @@ static SEXP applyMethod(SEXP call, SEXP op, SEXP args, SEXP rho, SEXP newvars)
 	const void *vmax = vmaxget();
 	PROTECT(args = evalList(args, rho, call, 0));
 	R_Visible = flag != 1;
-	ans = PRIMFUN(op) (call, op, args, rho);
+	ans = R_callPrimFun(op, call, args, rho);
 	if (flag < 2) R_Visible = flag != 1;
 	UNPROTECT(1);
 	check_stack_balance(op, save);


### PR DESCRIPTION
Two additions to the protection-stack diagnostics, both aimed at the
failure mode where an `UNPROTECT` with too large a count releases a
value belonging to the caller.

## 1. A protection floor (`--enable-strict-barrier` only)

`unprotect()` only detects underflow past zero
(`R_signal_unprotect_error`). A function that does `UNPROTECT(3)` having
protected 2 pops one of its *caller's* entries and keeps going. Today
that is noticed only indirectly and after the fact:

- `check_stack_balance` may report `stack imbalance` when control
  reaches the enclosing primitive, but only if the miscount survives
  that far -- a later compensating `PROTECT` in the same primitive hides
  it completely, while the caller's value has still been left
  unprotected in between;
- otherwise nothing reports it until the value is collected and used,
  which needs `gctorture` and some luck to catch.

This adds `R_PPStackFloor`, the lowest stack entry the code currently
running may release. Calls into code expected to manage its own
protections raise the floor to the current top:

- a primitive's C function, via the new `R_callPrimFun` in `eval.c`;
- a native routine reached through `.Call`/`.External`, in
  `R_doDotCall`.

`unprotect()` and `unprotect_ptr()` then signal an error at the
offending call:

```
unprotect(2): only 1 protected item belongs to this call
```

The floor is saved and restored by `begincontext`/`R_restore_globals`
alongside `cstacktop`, so non-local exits behave. This mirrors
`R_BCProtTop` and `CHECK_SET_BELOW_PROT`, which already do exactly this
for the byte code node stack.

The global, the `RCNTXT` field and the checks are all under
`TESTING_WRITE_BARRIER`; a default build is unchanged.

## 2. Stack balance checking in the byte code interpreter

`check_stack_balance` has been called around the AST interpreter's
primitive dispatch for a long time, but its five call sites are all in
`eval` (`SPECIALSXP`/`BUILTINSXP`), `applyMethod` and `do_internal`.
The byte code interpreter's own dispatch sites -- `OP(CALL)`,
`OP(CALLBUILTIN)`, `OP(CALLSPECIAL)`, `OP(SETTER_CALL)`,
`OP(GETTER_CALL)` -- never checked, and with the JIT on by default most
primitive calls now take the unchecked path. `R_forceAndCall` had no
check either.

Routing all of them through `R_callPrimFun` gives compiled code the same
coverage. The cost is one integer save and one comparison per primitive
call. This is left unconditional to match the AST interpreter; happy to
put it behind `TESTING_WRITE_BARRIER` instead if that is preferred.

## Testing

Built and tested on aarch64-apple-darwin, with and without
`--enable-strict-barrier`.

- Default build: `test-Reg` passes in full, with **no** new
  `stack imbalance` reports anywhere in the regression suite or in the
  byte-compilation of the base packages -- i.e. the newly-checked byte
  code paths are clean today.
- Strict barrier build: `test-Specific` passes, and `test-Reg` output is
  byte-identical to an unmodified strict-barrier build of the same
  commit. Both hit the same pre-existing failure in `reg-tests-1d.R`
  (`row.names(trees) <- 42 + seq_len(nrow(trees))` trips the existing
  `inserting non-tracking CDR in tracking cell` assertion in `SETCDR`);
  that reproduces without this patch and looks like a separate issue.
- A native routine that unprotects one too many is reported at the
  offending `UNPROTECT` rather than at the `.Call` boundary:

  ```
  # before: Warning: stack imbalance in '.Call', 18 then 17   (execution continues)
  # after:  Error: unprotect(2): only 1 protected item belongs to this call
  ```

  A routine that leaks a protection is still reported by the balance
  check on `.Call`, and a correct routine is silent.

## Notes

- The mechanical part of the diff is
  `PRIMFUN(f) (call, f, args, rho)` -> `R_callPrimFun(f, call, args, rho)`.
- The existing outer `check_stack_balance` calls in the AST paths are
  left alone: their `save` spans `evalList` too, which is coverage the
  inner check does not give.
- The floor is only raised at primitive and `.Call`/`.External`
  boundaries. Raising it per closure application would catch more but
  costs more; that seemed a separate question.
- Documented in R-exts, "Checking memory access".
