### PR TITLE
do not leak lzma streams on memCompress/memDecompress error paths

### DIFF
--- a/src/main/connections.c
+++ b/src/main/connections.c
@@ -7151,18 +7151,23 @@ do_memCompress(SEXP call, SEXP op, SEXP args, SEXP env)
 	filters[0].options = &opt_lzma;
 	filters[1].id = LZMA_VLI_UNKNOWN;
 
+	/* Allocate before initializing the encoder: R_alloc can signal an
+	   R error, and the longjmp would skip lzma_end() below. */
+	outlen = inlen + inlen/100 + 600; /* FIXME, copied from bzip2 case */
+	buf = (unsigned char *) R_alloc(outlen, sizeof(unsigned char));
+
 	ret = lzma_stream_encoder(&strm, filters, LZMA_CHECK_CRC32);
 	if (ret != LZMA_OK) error("internal error %d in memCompress", ret);
 
-	outlen = inlen + inlen/100 + 600; /* FIXME, copied from bzip2 case */
-	buf = (unsigned char *) R_alloc(outlen, sizeof(unsigned char));
 	strm.next_in = RAW(from);
 	strm.avail_in = inlen;
 	strm.next_out = buf;
 	strm.avail_out = outlen;
 	while(!ret) ret = lzma_code(&strm, LZMA_FINISH);
-	if (ret != LZMA_STREAM_END || (strm.avail_in > 0))
+	if (ret != LZMA_STREAM_END || (strm.avail_in > 0)) {
+	    lzma_end(&strm);
 	    error("internal error %d in memCompress", ret);
+	}
 	/* If LZMZ_BUF_ERROR, could realloc and continue */
 	outlen = (unsigned int)strm.total_out;
 	lzma_end(&strm);
@@ -7351,6 +7356,10 @@ do_memDecompress(SEXP call, SEXP op, SEXP args, SEXP env)
 	lzma_stream strm = LZMA_STREAM_INIT;
 	lzma_ret ret;
 	while(1) {
+	    /* Allocate before initializing the decoder: R_alloc can signal
+	       an R error, and the longjmp would skip lzma_end() below. */
+	    buf = (unsigned char *) R_alloc(outlen, sizeof(unsigned char));
+
 	    /* Initialize lzma_stream in each iteration. */
 	    /* probably at most 80Mb is required, but 512Mb seems OK as a limit */
 	    if (subtype == 1)
@@ -7360,7 +7369,6 @@ do_memDecompress(SEXP call, SEXP op, SEXP args, SEXP env)
 	    if (ret != LZMA_OK)
 		error(_("cannot initialize lzma decoder, error %d"), ret);
 
-	    buf = (unsigned char *) R_alloc(outlen, sizeof(unsigned char));
 	    strm.avail_in = inlen;
 	    strm.avail_out = outlen;
 	    strm.next_in = (unsigned char *) RAW(from);


### PR DESCRIPTION
`do_memCompress` and `do_memDecompress` in `src/main/connections.c` call
`error()` while an initialized `lzma_stream` is live. The longjmp skips
`lzma_end()`, so everything liblzma has allocated is lost.

The compression side is the serious one. `lzma_stream_encoder` at
preset 9 | `LZMA_PRESET_EXTREME` allocates its full working memory up
front -- 673 MB -- and the very next statement is an `R_alloc` that can
fail. Each failing `memCompress(x, "xz")` leaks **672.8 MB**, and it
repeats for every call.

The decompression side leaks as well, but only 1840 bytes per call: the
decoder allocates its dictionary lazily, and the failing `R_alloc`
happens before the first `lzma_code`.

## Affected code

### 1. `do_memCompress`, `case 4 /* xz */` -- 673 MB per occurrence

```c
ret = lzma_stream_encoder(&strm, filters, LZMA_CHECK_CRC32);
if (ret != LZMA_OK) error("internal error %d in memCompress", ret);

outlen = inlen + inlen/100 + 600; /* FIXME, copied from bzip2 case */
buf = (unsigned char *) R_alloc(outlen, sizeof(unsigned char));   /* (a) */
...
while(!ret) ret = lzma_code(&strm, LZMA_FINISH);
if (ret != LZMA_STREAM_END || (strm.avail_in > 0))
    error("internal error %d in memCompress", ret);                /* (b) */
```

The encoder is fully allocated by the time either error can fire:

- **(a)** `R_alloc` signals an ordinary R error ("vector memory limit
  of N reached", or "cannot allocate vector of size ...") when the
  request does not fit. This is readily reachable -- the request is
  `inlen + inlen/100 + 600`, so any input close to the vector-heap
  limit triggers it. On macOS R sets a default `max_vsize` at startup,
  so no configuration is needed there.
- **(b)** the `error()` after `lzma_code` runs with `strm` live and no
  `lzma_end`. This one is hard to reach in practice, because the
  1% + 600 byte output budget is generous even for incompressible
  input, but the leak is the same size if it ever fires.

### 2. `do_memDecompress`, `case 4 /* xz */` -- 1840 bytes per occurrence

Same shape: decoder initialized, then an allocation that can longjmp
past both the retry-path `lzma_end(&strm)` and the final one after the
loop. The retry loop doubles `outlen`, so a small input with a large
expansion ratio walks `outlen` up until the allocation fails -- a
normal outcome, not an exotic one. Only 1840 bytes (three blocks: the
stream coder structures) are outstanding at that point, since liblzma
defers the dictionary allocation to the first `lzma_code`.

For contrast, the other branches are correct: the retry-path error
inside `do_memDecompress` is properly preceded by `lzma_end(&strm)`;
bzip2 uses the one-shot `BZ2_bzBuffToBuffDecompress`; the libdeflate
decompressor is a function-scope static; and zstd's one-shot API holds
no state across the `R_alloc`.

## Reproducer

The leak is address space, not resident memory -- liblzma allocates the
encoder's 673 MB but never touches it before the error, so the pages
stay untouched and `ps -o rss` does not move. Measure `vsz`:

```r
invisible(mem.maxVSize(1200))   # MB

vsz_mb <- function()
    as.numeric(trimws(system2("ps", c("-o","vsz=","-p",Sys.getpid()), stdout=TRUE)))/1024

## Sized so inlen + inlen/100 + 600 overshoots the cap while the input fits:
## R_alloc then fails immediately after the encoder is initialized.
x <- raw(1100e6)
invisible(gc())

for (i in 1:4) {
    before <- vsz_mb()
    try(memCompress(x, "xz"), silent = TRUE)
    invisible(gc())
    cat(sprintf("call %d: VSZ +%.1f MB\n", i, vsz_mb() - before))
}
```

Unpatched (trunk r90374, aarch64-apple-darwin25.5.0, liblzma 5.8.x):

```
call 1: VSZ +736.9 MB
call 2: VSZ +672.8 MB
call 3: VSZ +672.8 MB
call 4: VSZ +673.3 MB
```

Patched:

```
call 1: VSZ +64.1 MB      <- one-time allocator arena, not per-call
call 2: VSZ +0.0 MB
call 3: VSZ +0.0 MB
call 4: VSZ +0.0 MB
```

The 672.8 MB figure matches an independent measurement made by
installing counting `alloc`/`free` hooks in `lzma_stream.allocator` and
calling `lzma_stream_encoder` with R's exact filter chain: 705,764,003
bytes live in 12 blocks immediately after init, all of it still live
when `lzma_code` returns `LZMA_BUF_ERROR`, and zero after `lzma_end`.
The same technique gives 1840 bytes in 3 blocks outstanding at the
point the decompression-side `R_alloc` fails.

## The fix

For both `R_alloc` sites, allocate *before* initializing the codec, so
no liblzma state is live across an allocation that can longjmp.
`R_alloc` memory lives on the vmax stack and is reclaimed by the
context unwind, so moving it earlier is safe. Case (b) additionally
gets an explicit `lzma_end(&strm)` before the `error()`, matching what
the decompress retry path already does.

## Verification

Applied to trunk r90374 and rebuilt:

- `connections.c` compiles with no new warnings.
- The leak goes from 672.8 MB per call to 0.0 MB per call (figures above).
- Round-trip `memCompress`/`memDecompress` over gzip, bzip2 and xz for
  empty, tiny, all-zero, random, and repetitive-text payloads: all
  identical, including via `type = "unknown"` auto-detection.
- Malformed and truncated inputs still error cleanly for every type.
- The xz doubling-retry path still works (20 MB round-trip through a
  3036-byte stream).

## How this was found

While adding an `R_MAX_VSIZE` cap to fuzz harnesses for R
(https://github.com/r-devel/r-oss-fuzz). Capping the vector heap makes
the `R_alloc` error path routinely reachable. The underlying defect is
independent of fuzzing and applies to stock R whenever the allocation
fails -- which on macOS needs no configuration at all, given the
default `max_vsize`.
