### PR TITLE
bound total expansion of nested bounded repetitions in tre

### DIFF
--- a/src/extra/tre/tre-compile.c
+++ b/src/extra/tre/tre-compile.c
@@ -798,6 +798,15 @@ typedef enum {
   EXPAND_AFTER_ITER
 } tre_expand_ast_symbol_t;
 
+/* Upper bound on the number of positions (literal nodes) in the expanded
+   AST.  Individual repetition counts are limited to RE_DUP_MAX, but nested
+   repetitions multiply, so without this a short pattern such as
+   "(?:a{2,101,})(?:a{2,101,}){100}{100}" expands to millions of nodes and
+   gigabytes of allocation before compilation finishes.  Legitimate patterns
+   are orders of magnitude below this; even (a{255}){255}, the largest
+   nesting RE_DUP_MAX permits at two levels, needs about 65000. */
+#define TRE_EXPAND_MAX_POSITIONS 100000
+
 /* Expands each iteration node that has a finite nonzero minimum or maximum
    iteration count to a catenated sequence of copies of the node. */
 static reg_errcode_t
@@ -917,6 +926,8 @@ tre_expand_ast(tre_mem_t mem, tre_stack_t *stack, tre_ast_node_t *ast,
 					  &max_pos);
 		    if (status != REG_OK)
 		      return status;
+		    if (max_pos > TRE_EXPAND_MAX_POSITIONS)
+		      return REG_ESPACE;
 		    if (seq1 != NULL)
 		      seq1 = tre_ast_new_catenation(mem, seq1, copy);
 		    else
@@ -947,6 +958,8 @@ tre_expand_ast(tre_mem_t mem, tre_stack_t *stack, tre_ast_node_t *ast,
 					      &pos_add, NULL, &copy, &max_pos);
 			if (status != REG_OK)
 			  return status;
+			if (max_pos > TRE_EXPAND_MAX_POSITIONS)
+			  return REG_ESPACE;
 			if (seq2 != NULL)
 			  seq2 = tre_ast_new_catenation(mem, copy, seq2);
 			else


### PR DESCRIPTION
R's bundled TRE compiles bounded repetitions by duplicating the pattern
AST. Individual bounds are capped (`RE_DUP_MAX` 255), but the *product*
across nested repetitions is not, so counts multiply. A 36-byte pattern
allocates ~8.5 GB at compile time and can take the process down. Any R
code that applies a user-supplied pattern with the default (extended)
regex engine is exposed: `grep`, `grepl`, `sub`, `gsub`, `regexpr`,
`gregexpr`, `agrep`, `strsplit`.

## Reproducer

```r
p <- "(?:a{2,101,})(?:a{2,101,}){100}{100}"
nchar(p)   # 36

grepl(p, "aaaa")
```

Measured on trunk r90374, aarch64-apple-darwin25.5.0 (48 GB RAM):

```
result: FALSE   elapsed 1.36s
        maximum resident set size  9261989888      (8.63 GB)
```

An independent earlier run on Linux x86_64 with R 4.3.3 gave ~8.5 GB, so
the figure is not platform-specific; it is higher again under sanitizer
instrumentation. On a machine with less RAM the process is OOM-killed
rather than returning `FALSE`. `agrep(p, "aaaa")` behaves the same, as
does any other TRE entry point that compiles the pattern.

Raising the counts increases the cost multiplicatively, so the pattern
can be tuned to whatever the target has RAM for while staying well
under 100 bytes.

## Analysis

`tre_parse_bound` (`src/extra/tre/tre-parse.c`) rejects any single
bound above `RE_DUP_MAX` (255, `src/extra/tre/tre.h`):

```c
if ((max >= 0 && min > max) || max > RE_DUP_MAX)
    return REG_BADBR;
```

That bounds one repetition but says nothing about nesting.
`tre_expand_ast` (`src/extra/tre/tre-compile.c`, `EXPAND_AFTER_ITER`)
then materialises each repetition by making `iter->min` / `iter->max`
copies of the subtree with `tre_copy_ast`. When the copied subtree
itself contains a repetition, its already-expanded copies are copied
again, so the node count is the product of the bounds. In the pattern
above, `{100}{100}` alone is 10,000, and the inner `{2,101,}`
multiplies that by up to 101: on the order of 10^6 copies of the
subexpression, tens of millions of AST nodes.

Two parser leniencies make the pattern shorter than it otherwise could
be, though neither is required to trigger the blowup:

- `{2,101,}` -- a trailing comma inside the bound is accepted.
- `{100}{100}` -- a quantifier applied directly to another quantifier
  is accepted. POSIX ERE does not permit this, and PCRE2 rejects it
  (`grepl(p, "aaaa", perl = TRUE)` errors immediately rather than
  allocating).

## The fix

`tre_expand_ast` already threads a `max_pos` counter through every
`tre_copy_ast` call, and `tre_copy_ast` maintains it
(`if (pos > *max_pos) *max_pos = pos;`). That counter *is* the size of
the expanded automaton, so the fix is to bound it: check it inside the
two copy loops and return `REG_ESPACE` once it exceeds
`TRE_EXPAND_MAX_POSITIONS` (100000).

100000 is generous: even `(a{255}){255}`, the largest two-level nesting
`RE_DUP_MAX` permits, needs about 65000, and ordinary patterns are
three or four orders of magnitude below that. `REG_ESPACE` matches
every other size-failure return in this function; `REG_BADBR`
("Invalid content of \{\}") would arguably describe the cause better,
but would be inconsistent with the surrounding code.

A limit on total expanded nodes is preferable to one on nesting depth,
since it bounds the resource actually consumed and does not penalise
deeply nested but small patterns. PCRE2 solves the equivalent problem
the same way, with an explicit compile-time cap.

## Verification

Applied to trunk r90374 and rebuilt:

- `tre-compile.c` compiles with no new warnings.
- The reported pattern now fails in **0.011s** with
  `invalid regular expression ..., reason 'Out of memory'`, peak RSS
  for the whole R session 110 MB, instead of allocating ~8.5 GB.
- `agrep` with the same pattern likewise returns immediately.
- Ordinary patterns are unaffected: `^a{3}$`, `(ab){2,4}`, `a{255}`,
  `^(a{20}){20}$`, `sub("o+", ...)`, `gsub("[aeiou]", ...)`,
  `regexpr("[0-9]+", ...)`, `strsplit(..., "[0-9]+")`, and `agrepl`
  all behave as before.
- Boundary behaviour is as designed: `(a{200}){200}` (40000 positions)
  still compiles; `((a{250}){250}){250}` (15.6M) is rejected.

## Impact

This is a denial-of-service surface wherever R applies an untrusted
pattern: Shiny applications with a search box, packages that accept
user regexes, `grepl` over a pattern read from a file or database. The
cost is paid at pattern *compile* time, so it does not depend on the
subject string and cannot be mitigated by limiting input size.

## How this was found

Fuzzing R's regex entry points (https://github.com/r-devel/r-oss-fuzz);
the pattern above is a minimized corpus unit.

Upstream TRE (https://github.com/laurikari/tre) appears to have the
same issue, but is not actively maintained; since R carries and patches
its own copy under `src/extra/tre`, proposing the fix here.
