### PR TITLE
flush package lazy-load databases in unloadNamespace()

### DIFF
--- a/src/library/base/R/namespace.R
+++ b/src/library/base/R/namespace.R
@@ -908,6 +908,7 @@ unloadNamespace <- function(ns)
 	if(.isMethodsDispatchOn() && methods:::.hasS4MetaData(ns))
 	    methods::cacheMetaData(ns, FALSE, ns)
 	.Internal(lazyLoadDBflush(paste0(nspath, "/R/", nsname, ".rdb")))
+	.Internal(lazyLoadDBflush(paste0(nspath, "/help/", nsname, ".rdb")))
     }
     invisible()
 }

--- a/src/library/base/R/namespace.R
+++ b/src/library/base/R/namespace.R
@@ -907,7 +907,12 @@ unloadNamespace <- function(ns)
 	.Internal(unregisterNamespace(nsname))
 	if(.isMethodsDispatchOn() && methods:::.hasS4MetaData(ns))
 	    methods::cacheMetaData(ns, FALSE, ns)
+	## flush the package's lazy-load databases: stale cached copies
+	## could otherwise be seen if the package is re-installed and
+	## re-loaded in this session
 	.Internal(lazyLoadDBflush(paste0(nspath, "/R/", nsname, ".rdb")))
+	.Internal(lazyLoadDBflush(paste0(nspath, "/R/sysdata.rdb")))
+	.Internal(lazyLoadDBflush(paste0(nspath, "/data/Rdata.rdb")))
 	.Internal(lazyLoadDBflush(paste0(nspath, "/help/", nsname, ".rdb")))
     }
     invisible()


### PR DESCRIPTION
## Problem

The lazy-load database cache (`readRawFromFile` in `src/main/serialize.c`) caches `.rdb` file contents in memory, keyed by file path alone, with no invalidation. `unloadNamespace()` flushes only the package's *code* database (`R/<pkg>.rdb`). The package's other lazy-load databases -- `help/<pkg>.rdb`, `R/sysdata.rdb`, and `data/Rdata.rdb` -- are never flushed, so re-installing a package within a session leaves stale cached copies, and the offsets from the freshly-read `.rdx` index are applied to stale bytes.

Two observed failure modes (repros in the PR discussion below):

1. **Help**: queries fail with `lazy-load database '.../help/<pkg>.rdb' is corrupt` (often with `internal error ... in R_decompress1`) until the session is restarted.
2. **Lazy data (silent!)**: when blob offsets happen to coincide across installs, a stale `data/Rdata.rdb` silently serves values from the *previously installed version* of the package -- no error or warning. Verified with a minimal package: after unload + reinstall + reload, `pkg::d` returned the old version's value.

renv and pak currently work around the help-db case by calling the internal `lazyLoadDBflush()` from `.onUnload()`, which requires contortions to keep `R CMD check` quiet about the `.Internal()` call (see https://github.com/rstudio/renv/issues/1294).

## Fix

Flush all of the package's lazy-load databases in `unloadNamespace()`, alongside the existing code-db flush, so the unload + reinstall + reload cycle works. Four lines (plus comment).

## Reproduction (help)

```r
lib <- tempfile("lib"); dir.create(lib)
.libPaths(c(lib, .libPaths()))
src <- tempfile("src"); dir.create(src)
pkg <- file.path(src, "lazytest")
dir.create(file.path(pkg, "R"), recursive = TRUE)
dir.create(file.path(pkg, "man"), recursive = TRUE)
dir.create(file.path(pkg, "data"), recursive = TRUE)
writeLines(c("Package: lazytest", "Version: 1.0", "Title: Test",
             "Description: Test.", "Author: A", "Maintainer: A <a@b.c>",
             "License: GPL-3", "LazyData: true"), file.path(pkg, "DESCRIPTION"))
writeLines("export(f)", file.path(pkg, "NAMESPACE"))
writeLines("f <- function() 42", file.path(pkg, "R", "f.R"))
rd <- function(x) writeLines(c("\\name{f}", "\\alias{f}", "\\title{t}",
  "\\description{d}", paste0("\\details{", x, "}")), file.path(pkg, "man", "f.Rd"))
mkdata <- function(x) { d <- x; save(d, file = file.path(pkg, "data", "d.rda")) }

rd("short docs"); mkdata("short")
install.packages(pkg, lib = lib, repos = NULL, type = "source")
library(lazytest)
length(tools::Rd_db("lazytest", lib.loc = lib))  # ok; populates help cache
lazytest::d                                      # "short"; populates data cache

detach("package:lazytest", character.only = TRUE)
unloadNamespace("lazytest")

rd(strrep("much longer docs to shift the offsets ", 50))
mkdata(strrep("a much longer data value to shift database offsets ", 50))
install.packages(pkg, lib = lib, repos = NULL, type = "source")
library(lazytest)

length(tools::Rd_db("lazytest", lib.loc = lib))
#> Error: lazy-load database '.../lazytest/help/lazytest.rdb' is corrupt
lazytest::d
#> [1] "short"     <- silently stale: the OLD version's value, no error
```

With this patch, both help and data return the new version's contents.

## Notes / scope

- The cache is keyed by the literal path string. The flush uses the namespace's stored (normalized) path, matching how help/data keys are built in standard use (`.libPaths()` entries are normalized). Loading from an unnormalized `lib.loc` spelling can still defeat the flush -- but that limitation applies identically to the *existing* code-db flush, since `loadNamespace()` keys its promises with the raw `find.package()` path while `unloadNamespace()` flushes the normalized stored path. Not made worse here.
- Out-of-process reinstalls (a second R session, `R CMD INSTALL` in a terminal) are still not covered. A fuller fix would validate cache entries in `readRawFromFile()` against the file's size/mtime/inode; happy to propose that instead or as a follow-up. Related: on a cache hit, `readRawFromFile()` does `memcpy(ptr[icache]+offset, len)` without storing or checking the cached file's length, so index offsets pointing beyond a stale (smaller) cached file read out of bounds of the malloc'd buffer.

(As this repo is a mirror, this patch is also being submitted to Bugzilla.)
