### PR TITLE
validate lazy-load database cache entries at fetch time

### DIFF
--- a/src/main/serialize.c
+++ b/src/main/serialize.c
@@ -3089,10 +3089,57 @@ static SEXP appendRawToFile(SEXP file, SEXP bytes)
 
 /* Interface to cache the pkg.rdb files */
 
+#ifdef HAVE_SYS_TYPES_H
+# include <sys/types.h>
+#endif
+#ifdef HAVE_SYS_STAT_H
+# include <sys/stat.h>
+#endif
+
+struct fileid {
+    double size, mtime, ino, dev;
+};
+
 #define NC 100
 static int used = 0;
 static char *names[NC];
 static char *ptr[NC];
+static size_t lens[NC];		/* length of the cached copy */
+static struct fileid ids[NC];	/* identity of the file when cached */
+
+/* Capture the identity of a database file, used to detect that a
+   cached copy has become stale because the file was replaced, e.g. by
+   re-installing the package (possibly from another process).  Returns
+   false if the file cannot be stat-ed, in which case its contents
+   should not be cached. */
+static bool getFileID(const char *cfile, struct fileid *id)
+{
+#ifdef Win32
+    struct _stati64 sb;
+    if (_stati64(cfile, &sb) != 0)
+	return false;
+#else
+    struct stat sb;
+    if (stat(cfile, &sb) != 0)
+	return false;
+#endif
+    id->size = (double) sb.st_size;
+    /* use sub-second modification times where available, as in
+       do_fileinfo (platform.c) */
+#if defined HAVE_STRUCT_STAT_ST_ATIM_TV_NSEC \
+    && defined TYPEOF_STRUCT_STAT_ST_ATIM_IS_STRUCT_TIMESPEC
+    id->mtime = (double) sb.st_mtim.tv_sec
+	+ 1e-9 * (double) sb.st_mtim.tv_nsec;
+#elif defined HAVE_STRUCT_STAT_ST_ATIMESPEC_TV_NSEC
+    id->mtime = (double) sb.st_mtimespec.tv_sec
+	+ 1e-9 * (double) sb.st_mtimespec.tv_nsec;
+#else
+    id->mtime = (double) sb.st_mtime;
+#endif
+    id->ino = (double) sb.st_ino;
+    id->dev = (double) sb.st_dev;
+    return true;
+}
 
 attribute_hidden SEXP
 do_lazyLoadDBflush(SEXP call, SEXP op, SEXP args, SEXP env)
@@ -3145,6 +3192,24 @@ static SEXP readRawFromFile(SEXP file, SEXP key)
     for (i = 0; i < used; i++)
 	if(names[i] != NULL && strcmp(cfile, names[i]) == 0) {icache = i; break;}
     if (icache >= 0) {
+	/* The file may have been replaced since it was cached, e.g. by
+	   re-installing the package, possibly from another process.  If
+	   so, drop the cached copy: the offsets in 'key' come from the
+	   current index file and need not be valid in a stale copy of
+	   the database. */
+	struct fileid id;
+	if (! getFileID(cfile, &id) ||
+	    id.size != ids[icache].size || id.mtime != ids[icache].mtime ||
+	    id.ino != ids[icache].ino || id.dev != ids[icache].dev) {
+	    free(names[icache]);
+	    names[icache] = NULL;
+	    free(ptr[icache]);
+	    icache = -1;
+	}
+    }
+    if (icache >= 0) {
+	if (offset < 0 || (size_t) offset + (size_t) len > lens[icache])
+	    error(_("bad offset/length argument"));
 	if (len)
 	    memcpy(RAW(val), ptr[icache]+offset, len);
 	vmaxset(vmax);
@@ -3160,6 +3225,11 @@ static SEXP readRawFromFile(SEXP file, SEXP key)
     }
 
     if(icache >= 0) {
+	/* Capture the file's identity before reading it: if the file
+	   is replaced while it is being read, the next fetch will see
+	   a mismatch and drop the cached copy. */
+	struct fileid id;
+	bool cacheable = getFileID(cfile, &id);
 	if ((fp = R_fopen(cfile, "rb")) == NULL)
 	    error(_("cannot open file '%s': %s"), cfile, strerror(errno));
 	if (fseek(fp, 0, SEEK_END) != 0) {
@@ -3167,7 +3237,7 @@ static SEXP readRawFromFile(SEXP file, SEXP key)
 	    error(_("seek failed on %s"), cfile);
 	}
 	filelen = ftell(fp);
-	if (filelen < LEN_LIMIT) {
+	if (cacheable && filelen < LEN_LIMIT) {
 	    char *p, *n;
 	    /* fprintf(stderr, "adding file '%s' at pos %d in cache, length %d\n",
 	       cfile, icache, filelen); */
@@ -3177,6 +3247,8 @@ static SEXP readRawFromFile(SEXP file, SEXP key)
 		names[icache] = n;
 		strcpy(names[icache], cfile);
 		ptr[icache] = p;
+		lens[icache] = (size_t) filelen;
+		ids[icache] = id;
 		if (fseek(fp, 0, SEEK_SET) != 0) {
 		    fclose(fp);
 		    error(_("seek failed on %s"), cfile);
@@ -3184,6 +3256,8 @@ static SEXP readRawFromFile(SEXP file, SEXP key)
 		in = (int) fread(p, 1, filelen, fp);
 		fclose(fp);
 		if (filelen != in) error(_("read failed on %s"), cfile);
+		if (offset < 0 || (size_t) offset + (size_t) len > lens[icache])
+		    error(_("bad offset/length argument"));
 		if (len)
 		    memcpy(RAW(val), p+offset, len);
 	    } else {


### PR DESCRIPTION
## Problem

Follow-up to #295 (Bugzilla [PR#19131](https://bugs.r-project.org/show_bug.cgi?id=19131)): the lazy-load database cache in `readRawFromFile()` (`src/main/serialize.c`) caches `.rdb` contents keyed by file path alone, with no invalidation. #295 flushes the cache from `unloadNamespace()`, which covers in-session reinstalls, but a re-installation performed by *another process* (a second R session, or `R CMD INSTALL` from a terminal) while the databases are cached is not covered by any R-level flush: offsets from the freshly-read `.rdx` index get applied to a stale cached copy of the `.rdb`, producing `lazy-load database ... is corrupt` errors for help databases and silently wrong values for lazy data.

R Core expressed interest in this fuller fix on the Bugzilla report.

## Fix

Validate cache entries at fetch time. When a file is read into the cache, record its identity: size, mtime (sub-second resolution where available, using the same config macros as `file.info()`), inode, and device. On every cache hit, re-`stat()` the file and compare; on any mismatch drop the cached copy and re-read. This invalidates stale entries regardless of how or where the re-installation happened.

Details:

- The identity is captured *before* the file is read, so if the file is replaced between the stat and the read (or during the read), the recorded identity no longer matches the new file and the next fetch drops the entry. A file that cannot be stat-ed is read directly and not cached.
- Also adds the bounds check noted in #295: the requested offset/length is checked against the cached copy's length before the `memcpy`, so keys pointing beyond the end of the database fail with `bad offset/length argument` instead of reading out of bounds of the malloc'd cache buffer.
- Cost on the hot path is one `stat()` per fetch on a cache hit, small relative to the decompression that follows.
- With this in place, #295 is no longer needed for correctness (its flush still releases cached contents sooner). The two are independent and compatible.

## Reproduction (cross-process)

Same package setup as in #295, but the re-installation is done by a second process while the package stays loaded and cached in the first session -- no `unloadNamespace()` at all:

```r
lib <- tempfile("lib"); dir.create(lib)
.libPaths(c(lib, .libPaths()))
src <- tempfile("src"); dir.create(src)
pkg <- file.path(src, "lazytest")
dir.create(file.path(pkg, "R"), recursive = TRUE)
dir.create(file.path(pkg, "man"), recursive = TRUE)
dir.create(file.path(pkg, "data"), recursive = TRUE)
writeLines(c("Package: lazytest", "Version: 1.0", "Title: Test",
             "Description: Test.", "Author: A", "Maintainer: A <a@b.c>",
             "License: GPL-3", "LazyData: true"), file.path(pkg, "DESCRIPTION"))
writeLines("export(f)", file.path(pkg, "NAMESPACE"))
writeLines("f <- function() 42", file.path(pkg, "R", "f.R"))
rd <- function(x) writeLines(c("\\name{f}", "\\alias{f}", "\\title{t}",
  "\\description{d}", paste0("\\details{", x, "}")), file.path(pkg, "man", "f.Rd"))
mkdata <- function(x) { d <- x; save(d, file = file.path(pkg, "data", "d.rda")) }

rd("short docs"); mkdata("short")
install.packages(pkg, lib = lib, repos = NULL, type = "source")
library(lazytest)
length(tools::Rd_db("lazytest", lib.loc = lib))       # populates help cache
e <- new.env(); data("d", package = "lazytest", envir = e)
e$d                                                   # "short"; populates data cache

## re-install the modified package FROM A SECOND PROCESS
rd(strrep("much longer docs to shift the offsets ", 50))
mkdata(strrep("a much longer data value to shift database offsets ", 50))
system2(file.path(R.home("bin"), "R"),
        c("CMD", "INSTALL", "-l", shQuote(lib), shQuote(pkg)))

length(tools::Rd_db("lazytest", lib.loc = lib))
#> Error: lazy-load database '.../lazytest/help/lazytest.rdb' is corrupt
e2 <- new.env(); data("d", package = "lazytest", envir = e2)
e2$d
#> [1] "short"     <- silently stale: the OLD version's value, no error
```

With this patch, both fetches return the newly installed contents. The single-session repro from #295 also passes with this patch alone (no R-level flush).

## Notes

- On Windows, `_stati64()` is used on the same `(char *)` path that `R_fopen()` already opens; its mtime has second resolution and `st_ino` carries no information there, so in principle a same-second replacement with an identical file size could go undetected on Windows. For that to matter the contents must differ, which almost surely changes the compressed size.
- Tested on macOS arm64 against trunk (r90392): both repros above, plus out-of-range/negative keys against a cached database now failing cleanly (with the cache entry surviving the rejected fetch). `make check` passes locally apart from a pre-existing x86_64/arm64 Tcl/Tk mismatch on the test machine, unrelated to this change.

(As this repo is a mirror, this patch is also being submitted to Bugzilla.)
