### PR TITLE
prototype: dual-representation wide (64-bit) integer vectors

### DIFF
--- a/WIDEINT-NOTES.md
+++ b/WIDEINT-NOTES.md
@@ -1,9 +1,11 @@
 # Wide (64-bit) integer vector prototype
 
 Dual-representation INTSXP experiment: a standard (non-ALTREP) INTSXP
-whose payload holds `long long` elements, tagged with gp bit 7
-(`WIDEINT_MASK`, free on vectors). NA is `INT64_MIN`, mirroring
-`NA_INTEGER == INT32_MIN`.
+whose payload holds `R_wideint_t` elements (a typedef, currently
+`long long`), tagged with gp bit 7 (`WIDEINT_MASK`, free on vectors).
+NA is `INT64_MIN`, mirroring `NA_INTEGER == INT32_MIN`. Code printing
+a wide value with `"%lld"` casts to `long long` explicitly, so the
+typedef can change without breaking formats.
 
 ## Design rules
 

--- a/WIDEINT-NOTES.md
+++ b/WIDEINT-NOTES.md
@@ -98,6 +98,15 @@ Notable systemic fixes found while working through the failures:
   ITERATE_BY_REGION users take the guarded region path (this closed
   the only silent-corruption hole: sum/min/max read wide payloads as
   int32 pairs).
+- KNOWN REMAINING ESCAPE HATCH: DATAPTR / DATAPTR_RO / STDVEC_DATAPTR
+  (and the LOGICAL macro, which is (int *) DATAPTR) are deliberately
+  not guarded, unlike INTEGER/INTEGER0/INTEGER_RO.  Package C code
+  that reads an integer payload through DATAPTR silently misreads a
+  wide vector's 64-bit elements as int32 pairs.  Guarding DATAPTR
+  would tax every vector access and break legitimate whole-payload
+  uses (duplication, serialization), so a real implementation must
+  instead audit DATAPTR consumers -- this is the one place the
+  "fail loudly by construction" perimeter is open.
 - ALTREP wrappers (wrap_meta) refuse wide vectors: the alt bit would
   hide the wide bit and present the payload as 32-bit.
 - The fastpass_sortcheck() quick-sequence scan and the byte-code

--- a/WIDEINT-NOTES.md
+++ b/WIDEINT-NOTES.md
@@ -60,8 +60,46 @@ typedef can change without breaking formats.
   subset.c, relop.c, arithmetic.c -- wide paths
 - src/main/names.c, src/include/Internal.h, src/main/Makefile.in
 
+## Parser
+
+The `L` suffix now produces a wide integer when the value does not
+fit in 32 bits: `5000000000L`, `9007199254740993L` (parsed via
+strtoll for exactness above 2^53), `0x1FFFFFFFFL`, `1e10L`.  Values
+outside 64 bits, or with fractional parts, keep the old
+warn-and-use-numeric behavior.  deparse() emits plain L literals, so
+values round-trip exactly; storage width intentionally does not
+round-trip (a small value reparses narrow), which is consistent with
+identical() comparing values, not widths.
+
+## Coverage status (after waves 1-4)
+
+All ~155 gauntlet probes pass except two intentional errors
+(fractional as.wideint(), serialization).  Covered beyond the initial
+prototype: the display layer (format/cat/deparse/sprintf/str, named
+vectors, matrices, data.frames), asInteger/asReal/asXLength,
+summaries (mean/min/max/range/prod/cumsum/cummax/cummin/which.max),
+abs, bitwNot/And/Or/Xor, subassignment everywhere (vector/[[/matrix/
+array/stretch) with narrow-to-wide promotion, rep, matrix(), rbind/
+cbind, sort/order/rank (comparison sorts; radix is excluded at the R
+level since it works on 32-bit keys), unique/duplicated/match/%in%/
+factor/table via width-agnostic ihash/iequal, and the byte-code
+STEPFOR/VECSUBSET fast paths.
+
+Notable systemic fixes found while working through the failures:
+- DATAPTR_OR_NULL / INTEGER_OR_NULL return NULL for wide vectors, so
+  ITERATE_BY_REGION users take the guarded region path (this closed
+  the only silent-corruption hole: sum/min/max read wide payloads as
+  int32 pairs).
+- ALTREP wrappers (wrap_meta) refuse wide vectors: the alt bit would
+  hide the wide bit and present the payload as 32-bit.
+- The fastpass_sortcheck() quick-sequence scan and the byte-code
+  scalar fast paths bail to the generic handlers for wide input.
+
+Still unsupported (by design or out of scope): serialization, radix
+sort on wide keys, %o%/%x% conversions beyond sprintf, split/tapply
+and friends were not explicitly probed.
+
 ## Gauntlet
 
-`wideint-gauntlet.R` probes ~100 base operations; the ok/ERR pattern
-is the catalog of what a real implementation would still need to
-touch.
+`wideint-gauntlet.R` probes ~155 base operations; run it after any
+change and diff the ok/ERR pattern.

--- a/WIDEINT-NOTES.md
+++ b/WIDEINT-NOTES.md
@@ -87,8 +87,11 @@ abs, bitwNot/And/Or/Xor, subassignment everywhere (vector/[[/matrix/
 array/stretch) with narrow-to-wide promotion, rep, matrix(), rbind/
 cbind, sort/order/rank (comparison sorts; radix is excluded at the R
 level since it works on 32-bit keys), unique/duplicated/match/%in%/
-factor/table via width-agnostic ihash/iequal, and the byte-code
-STEPFOR/VECSUBSET fast paths.
+factor/table via a two-scheme integer hash (ihash32 for all-narrow
+inputs, width-agnostic ihash64 whenever a wide vector participates;
+the schemes disagree for negative values, so the choice is made once
+per hash table, and lookups branch on the scheme the table was built
+with), and the byte-code STEPFOR/VECSUBSET fast paths.
 
 Notable systemic fixes found while working through the failures:
 - DATAPTR_OR_NULL / INTEGER_OR_NULL return NULL for wide vectors, so

--- a/WIDEINT-NOTES.md
+++ b/WIDEINT-NOTES.md
@@ -58,7 +58,7 @@ typedef can change without breaking formats.
   declarations
 - src/include/Rinternals.h, Rinlinedfuns.h -- API decls, wide-aware
   INTEGER_ELT/SET_INTEGER_ELT/INTEGER0/INTEGER_OR_NULL
-- src/main/memory.c -- checked accessors, allocWideIntVector, ELT64,
+- src/main/memory.c -- checked accessors, R_allocWideIntVector, ELT64,
   GC size accounting
 - src/main/wideint.c -- .Internal hooks, coercion, formatting (new)
 - src/main/duplicate.c, coerce.c, printvector.c, serialize.c,

--- a/WIDEINT-NOTES.md
+++ b/WIDEINT-NOTES.md
@@ -39,7 +39,12 @@ typedef can change without breaking formats.
 - Wide vectors are allocated via `allocVector(REALSXP, n)` + relabel,
   so GC node classes and heap accounting see the true 8-byte payload;
   `getVecSizeInVEC` is wide-aware. Scalar flag is kept off to avoid
-  32-bit scalar fast paths.
+  32-bit scalar fast paths. The relabel trick assumes
+  `sizeof(long long) == sizeof(double)` (a `_Static_assert` in
+  memory.c enforces this); a real implementation should instead grow
+  an internal allocator taking an explicit payload element size
+  (an `allocVector0(size, n)`), which removes the coupling and keeps
+  type-checking instrumentation honest.
 
 ## Test hooks
 

--- a/WIDEINT-NOTES.md
+++ b/WIDEINT-NOTES.md
@@ -1,0 +1,65 @@
+# Wide (64-bit) integer vector prototype
+
+Dual-representation INTSXP experiment: a standard (non-ALTREP) INTSXP
+whose payload holds `long long` elements, tagged with gp bit 7
+(`WIDEINT_MASK`, free on vectors). NA is `INT64_MIN`, mirroring
+`NA_INTEGER == INT32_MIN`.
+
+## Design rules
+
+- One integer type at the R level: `typeof()` stays "integer",
+  `is.integer()` is TRUE. Wide-ness is a storage property, not a type.
+- No 64-bit pointer accessor, by design. The 64-bit API is
+  element-based only: `INTEGER64_ELT` / `SET_INTEGER64_ELT`. This
+  sidesteps the write-back/aliasing problem entirely.
+- The 32-bit pointer accessors (`INTEGER()`, `INTEGER_RO()`,
+  `INTEGER0()`) error loudly on wide vectors -- both the package-facing
+  functions and the core macros in Defn.h route through
+  `R_INTEGER32chk*()`. There is no silent misread path.
+- `INTEGER_ELT` on a wide vector narrows per element: succeeds for
+  values representable in 32 bits, errors otherwise. So old ELT-based
+  code keeps working until a big value actually reaches it.
+- `INTEGER_OR_NULL` returns NULL on wide vectors (callers then use the
+  region path); `INTEGER_GET_REGION` narrows element-wise with the
+  same per-element rule.
+- Narrow arithmetic overflow (`+`, `-`, `*`) promotes to a wide result
+  instead of NA-with-warning. To keep the redo sound, those three ops
+  no longer reuse an input vector as the result buffer.
+- Wide arithmetic overflow (past 64 bits) produces NA64 + warning,
+  mirroring narrow semantics pre-promotion.
+- Mixed wide/double arithmetic coerces to double (precision warning
+  above 2^53). Comparisons wide-vs-double are exact (no round trip
+  through double).
+- `coerceVector(wide, INTSXP)` is the identity: `as.integer()` of a
+  wide vector stays wide. One type.
+- Serialization of wide vectors errors (format work out of scope);
+  unserialization clears the bit defensively.
+- Wide vectors are allocated via `allocVector(REALSXP, n)` + relabel,
+  so GC node classes and heap accounting see the true 8-byte payload;
+  `getVecSizeInVEC` is wide-aware. Scalar flag is kept off to avoid
+  32-bit scalar fast paths.
+
+## Test hooks
+
+- `.Internal(as.wideint(x))` -- from logical/integer/double/character
+  (strings allow exact big values like "9007199254740993").
+- `.Internal(is.wideint(x))`.
+
+## Files touched
+
+- src/include/Defn.h -- bit, macros, guarded INTEGER()/INTEGER_RO(),
+  declarations
+- src/include/Rinternals.h, Rinlinedfuns.h -- API decls, wide-aware
+  INTEGER_ELT/SET_INTEGER_ELT/INTEGER0/INTEGER_OR_NULL
+- src/main/memory.c -- checked accessors, allocWideIntVector, ELT64,
+  GC size accounting
+- src/main/wideint.c -- .Internal hooks, coercion, formatting (new)
+- src/main/duplicate.c, coerce.c, printvector.c, serialize.c,
+  subset.c, relop.c, arithmetic.c -- wide paths
+- src/main/names.c, src/include/Internal.h, src/main/Makefile.in
+
+## Gauntlet
+
+`wideint-gauntlet.R` probes ~100 base operations; the ok/ERR pattern
+is the catalog of what a real implementation would still need to
+touch.

--- a/doc/manual/R-exts.texi
+++ b/doc/manual/R-exts.texi
@@ -14995,6 +14995,18 @@ have to fully materialize the object.
 @apifun SET_RAW_ELT
 @apifun SET_REAL_ELT
 
+As an experimental extension, an integer vector may store 64-bit
+(``wide'') elements.  @code{R_isWideInteger} tests for this storage,
+and such elements can be accessed and set with @code{INTEGER64_ELT}
+and @code{SET_INTEGER64_ELT}; @code{allocWideIntVector} allocates an
+integer vector with wide storage.  There is deliberately no wide
+data-pointer accessor, and the 32-bit data-pointer accessors signal an
+error for wide vectors.
+@eapifun allocWideIntVector
+@eapifun INTEGER64_ELT
+@eapifun R_isWideInteger
+@eapifun SET_INTEGER64_ELT
+
 
 @node Character encoding issues
 @section Character encoding issues

--- a/doc/manual/R-exts.texi
+++ b/doc/manual/R-exts.texi
@@ -14998,12 +14998,12 @@ have to fully materialize the object.
 As an experimental extension, an integer vector may store 64-bit
 (``wide'') elements.  @code{R_isWideInteger} tests for this storage,
 and such elements can be accessed and set with @code{INTEGER64_ELT}
-and @code{SET_INTEGER64_ELT}; @code{allocWideIntVector} allocates an
+and @code{SET_INTEGER64_ELT}; @code{R_allocWideIntVector} allocates an
 integer vector with wide storage.  There is deliberately no wide
 data-pointer accessor, and the 32-bit data-pointer accessors signal an
 error for wide vectors.
-@eapifun allocWideIntVector
 @eapifun INTEGER64_ELT
+@eapifun R_allocWideIntVector
 @eapifun R_isWideInteger
 @eapifun SET_INTEGER64_ELT
 

--- a/src/include/Defn.h
+++ b/src/include/Defn.h
@@ -406,6 +406,16 @@ typedef long long R_wideint_t;
 #define R_WIDEINT_MAX ((R_wideint_t) 9223372036854775807LL)
 #define R_WIDEINT_MIN ((R_wideint_t)(-9223372036854775807LL - 1))
 
+/* 2^63 as a double.  INT64_MAX (2^63 - 1) is not exactly representable as
+   a double, so 2^63 is the exclusive bound when testing whether a double
+   fits in a wide integer: |v| >= this does not fit. */
+#define R_WIDEINT_DBL_MAX 9223372036854775808.0
+
+/* 2^53, the largest magnitude for which every integer is exactly
+   representable as a double; a wide integer beyond +/- this loses
+   precision when coerced to double. */
+#define R_WIDEINT_DBL_EXACT ((R_wideint_t) 9007199254740992LL)
+
 /* Checked wide-integer arithmetic.  GCC/Clang expose __builtin_*_overflow;
    on other toolchains fall back to portable checks (SEI CERT INT32-C).
    R_ovf_{add,sub,mul}(a, b, r) store a op b into *r and return nonzero on

--- a/src/include/Defn.h
+++ b/src/include/Defn.h
@@ -383,6 +383,31 @@ typedef union { VECTOR_SEXPREC s; double align; } SEXPREC_ALIGN;
 #define SET_GROWABLE_BIT(x) (((x)->sxpinfo.gp) |= GROWABLE_MASK)
 #define IS_GROWABLE(x) (GROWABLE_BIT_SET(x) && XLENGTH(x) < XTRUELENGTH(x))
 
+/* Wide (64-bit) integer vector prototype.  A standard (non-ALTREP)
+   INTSXP with this bit set stores long long elements in its payload;
+   gp bit 7 is unused on vectors.  The 32-bit accessors must not touch
+   such vectors, so the INTEGER()/INTEGER_RO() macros below go through
+   checked functions.  NA is INT64_MIN, mirroring NA_INTEGER. */
+#define WIDEINT_MASK ((unsigned short)(1<<7))
+#define IS_WIDEINT(x) (((x)->sxpinfo.alt) == 0 && \
+		       ((x)->sxpinfo.gp & WIDEINT_MASK))
+#define SET_WIDEINT(x) (((x)->sxpinfo.gp) |= WIDEINT_MASK)
+#define UNSET_WIDEINT(x) (((x)->sxpinfo.gp) &= ~WIDEINT_MASK)
+#define WIDEINT_PTR(x) ((long long *) STDVEC_DATAPTR(x))
+
+#ifndef NA_INTEGER64
+# define NA_INTEGER64 (-9223372036854775807LL - 1)
+#endif
+int R_isWideInteger(SEXP x);
+SEXP allocWideIntVector(R_xlen_t length);
+long long INTEGER64_ELT(SEXP x, R_xlen_t i);
+void SET_INTEGER64_ELT(SEXP x, R_xlen_t i, long long v);
+int R_wideIntegerElt32(SEXP x, R_xlen_t i);
+void R_wideIntegerSetElt32(SEXP x, R_xlen_t i, int v);
+SEXP ScalarWideInt(long long v);
+SEXP R_wideIntCoerce(SEXP v, SEXPTYPE type);
+SEXP R_formatWideInt(SEXP x);
+
 /* Vector Access Macros */
 #ifdef LONG_VECTOR_SUPPORT
 # define IS_LONG_VEC(x) (XLENGTH(x) > R_SHORT_LEN_MAX)
@@ -421,13 +446,16 @@ typedef union { VECTOR_SEXPREC s; double align; } SEXPREC_ALIGN;
 #undef CHAR
 #define CHAR(x)		((const char *) STDVEC_DATAPTR(x))
 #define LOGICAL(x)	((int *) DATAPTR(x))
-#define INTEGER(x)	((int *) DATAPTR(x))
+/* wide-int prototype: error on 32-bit pointer access to wide vectors */
+int *R_INTEGER32chk(SEXP x);
+const int *R_INTEGER32chk_ro(SEXP x);
+#define INTEGER(x)	(R_INTEGER32chk(x))
 #define RAW(x)		((Rbyte *) DATAPTR(x))
 #define COMPLEX(x)	((Rcomplex *) DATAPTR(x))
 #define REAL(x)		((double *) DATAPTR(x))
 #define STRING_PTR(x)	((SEXP *) DATAPTR(x))
 #define LOGICAL_RO(x)	((const int *) DATAPTR_RO(x))
-#define INTEGER_RO(x)	((const int *) DATAPTR_RO(x))
+#define INTEGER_RO(x)	(R_INTEGER32chk_ro(x))
 #define RAW_RO(x)	((const Rbyte *) DATAPTR_RO(x))
 #define COMPLEX_RO(x)	((const Rcomplex *) DATAPTR_RO(x))
 #define REAL_RO(x)	((const double *) DATAPTR_RO(x))

--- a/src/include/Defn.h
+++ b/src/include/Defn.h
@@ -412,6 +412,8 @@ void R_wideIntegerSetElt32(SEXP x, R_xlen_t i, int v);
 SEXP ScalarWideInt(R_wideint_t v);
 SEXP R_wideIntCoerce(SEXP v, SEXPTYPE type);
 SEXP R_formatWideInt(SEXP x);
+const char *EncodeWideInt(R_wideint_t x, int w);
+SEXP R_widenInteger(SEXP x);
 
 /* Vector Access Macros */
 #ifdef LONG_VECTOR_SUPPORT

--- a/src/include/Defn.h
+++ b/src/include/Defn.h
@@ -384,27 +384,32 @@ typedef union { VECTOR_SEXPREC s; double align; } SEXPREC_ALIGN;
 #define IS_GROWABLE(x) (GROWABLE_BIT_SET(x) && XLENGTH(x) < XTRUELENGTH(x))
 
 /* Wide (64-bit) integer vector prototype.  A standard (non-ALTREP)
-   INTSXP with this bit set stores long long elements in its payload;
-   gp bit 7 is unused on vectors.  The 32-bit accessors must not touch
-   such vectors, so the INTEGER()/INTEGER_RO() macros below go through
-   checked functions.  NA is INT64_MIN, mirroring NA_INTEGER. */
+   INTSXP with this bit set stores R_wideint_t (currently long long)
+   elements in its payload; gp bit 7 is unused on vectors.  The 32-bit
+   accessors must not touch such vectors, so the INTEGER()/INTEGER_RO()
+   macros below go through checked functions.  NA is INT64_MIN,
+   mirroring NA_INTEGER. */
 #define WIDEINT_MASK ((unsigned short)(1<<7))
 #define IS_WIDEINT(x) (((x)->sxpinfo.alt) == 0 && \
 		       ((x)->sxpinfo.gp & WIDEINT_MASK))
 #define SET_WIDEINT(x) (((x)->sxpinfo.gp) |= WIDEINT_MASK)
 #define UNSET_WIDEINT(x) (((x)->sxpinfo.gp) &= ~WIDEINT_MASK)
-#define WIDEINT_PTR(x) ((long long *) STDVEC_DATAPTR(x))
+#define WIDEINT_PTR(x) ((R_wideint_t *) STDVEC_DATAPTR(x))
 
+#ifndef R_WIDEINT_T_DEFINED
+# define R_WIDEINT_T_DEFINED
+typedef long long R_wideint_t;
+#endif
 #ifndef NA_INTEGER64
-# define NA_INTEGER64 (-9223372036854775807LL - 1)
+# define NA_INTEGER64 ((R_wideint_t)(-9223372036854775807LL - 1))
 #endif
 int R_isWideInteger(SEXP x);
 SEXP allocWideIntVector(R_xlen_t length);
-long long INTEGER64_ELT(SEXP x, R_xlen_t i);
-void SET_INTEGER64_ELT(SEXP x, R_xlen_t i, long long v);
+R_wideint_t INTEGER64_ELT(SEXP x, R_xlen_t i);
+void SET_INTEGER64_ELT(SEXP x, R_xlen_t i, R_wideint_t v);
 int R_wideIntegerElt32(SEXP x, R_xlen_t i);
 void R_wideIntegerSetElt32(SEXP x, R_xlen_t i, int v);
-SEXP ScalarWideInt(long long v);
+SEXP ScalarWideInt(R_wideint_t v);
 SEXP R_wideIntCoerce(SEXP v, SEXPTYPE type);
 SEXP R_formatWideInt(SEXP x);
 

--- a/src/include/Defn.h
+++ b/src/include/Defn.h
@@ -403,12 +403,12 @@ typedef long long R_wideint_t;
 #ifndef NA_INTEGER64
 # define NA_INTEGER64 ((R_wideint_t)(-9223372036854775807LL - 1))
 #endif
-int R_isWideInteger(SEXP x);
+/* R_isWideInteger, INTEGER64_ELT, SET_INTEGER64_ELT and the
+   narrowing helpers are inlinable and so must only be declared via
+   Rinlinedfuns.h (or its fallback block below): an unguarded
+   declaration here would demote the C99 inline definitions to
+   external ones in every translation unit */
 SEXP allocWideIntVector(R_xlen_t length);
-R_wideint_t INTEGER64_ELT(SEXP x, R_xlen_t i);
-void SET_INTEGER64_ELT(SEXP x, R_xlen_t i, R_wideint_t v);
-int R_wideIntegerElt32(SEXP x, R_xlen_t i);
-void R_wideIntegerSetElt32(SEXP x, R_xlen_t i, int v);
 SEXP ScalarWideInt(R_wideint_t v);
 SEXP R_wideIntCoerce(SEXP v, SEXPTYPE type);
 SEXP R_formatWideInt(SEXP x);
@@ -453,9 +453,8 @@ SEXP R_widenInteger(SEXP x);
 #undef CHAR
 #define CHAR(x)		((const char *) STDVEC_DATAPTR(x))
 #define LOGICAL(x)	((int *) DATAPTR(x))
-/* wide-int prototype: error on 32-bit pointer access to wide vectors */
-int *R_INTEGER32chk(SEXP x);
-const int *R_INTEGER32chk_ro(SEXP x);
+/* wide-int prototype: error on 32-bit pointer access to wide vectors;
+   R_INTEGER32chk is declared via Rinlinedfuns.h (see above) */
 #define INTEGER(x)	(R_INTEGER32chk(x))
 #define RAW(x)		((Rbyte *) DATAPTR(x))
 #define COMPLEX(x)	((Rcomplex *) DATAPTR(x))
@@ -877,6 +876,15 @@ int *INTEGER0(SEXP x);
 double *REAL0(SEXP x);
 Rcomplex *COMPLEX0(SEXP x);
 Rbyte *RAW0(SEXP x);
+
+int R_isWideInteger(SEXP x);
+R_wideint_t INTEGER64_ELT(SEXP x, R_xlen_t i);
+void SET_INTEGER64_ELT(SEXP x, R_xlen_t i, R_wideint_t v);
+int R_wideIntegerElt32(SEXP x, R_xlen_t i);
+void R_wideIntegerSetElt32(SEXP x, R_xlen_t i, int v);
+int *R_INTEGER32chk(SEXP x);
+const int *R_INTEGER32chk_ro(SEXP x);
+int *R_INTEGER32chk0(SEXP x);
 
 Rboolean Rf_conformable(SEXP, SEXP);
 Rboolean Rf_isUserBinop(SEXP);

--- a/src/include/Defn.h
+++ b/src/include/Defn.h
@@ -403,6 +403,67 @@ typedef long long R_wideint_t;
 #ifndef NA_INTEGER64
 # define NA_INTEGER64 ((R_wideint_t)(-9223372036854775807LL - 1))
 #endif
+#define R_WIDEINT_MAX ((R_wideint_t) 9223372036854775807LL)
+#define R_WIDEINT_MIN ((R_wideint_t)(-9223372036854775807LL - 1))
+
+/* Checked wide-integer arithmetic.  GCC/Clang expose __builtin_*_overflow;
+   on other toolchains fall back to portable checks (SEI CERT INT32-C).
+   R_ovf_{add,sub,mul}(a, b, r) store a op b into *r and return nonzero on
+   signed 64-bit overflow.  Result pointers must be R_wideint_t *. */
+#if defined(__has_builtin)
+# if __has_builtin(__builtin_add_overflow)
+#  define R_HAVE_BUILTIN_OVERFLOW 1
+# endif
+#endif
+#if !defined(R_HAVE_BUILTIN_OVERFLOW) && \
+    defined(__GNUC__) && !defined(__INTEL_COMPILER) && (__GNUC__ >= 5)
+# define R_HAVE_BUILTIN_OVERFLOW 1
+#endif
+
+#ifdef R_HAVE_BUILTIN_OVERFLOW
+# define R_ovf_add(a, b, r) __builtin_add_overflow((a), (b), (r))
+# define R_ovf_sub(a, b, r) __builtin_sub_overflow((a), (b), (r))
+# define R_ovf_mul(a, b, r) __builtin_mul_overflow((a), (b), (r))
+#else
+static R_INLINE int R_wideint_add_ovf(R_wideint_t a, R_wideint_t b,
+				      R_wideint_t *r)
+{
+    if ((b > 0 && a > R_WIDEINT_MAX - b) || (b < 0 && a < R_WIDEINT_MIN - b))
+	return 1;
+    *r = a + b;
+    return 0;
+}
+static R_INLINE int R_wideint_sub_ovf(R_wideint_t a, R_wideint_t b,
+				      R_wideint_t *r)
+{
+    if ((b < 0 && a > R_WIDEINT_MAX + b) || (b > 0 && a < R_WIDEINT_MIN + b))
+	return 1;
+    *r = a - b;
+    return 0;
+}
+static R_INLINE int R_wideint_mul_ovf(R_wideint_t a, R_wideint_t b,
+				      R_wideint_t *r)
+{
+    if (a > 0) {
+	if (b > 0) {
+	    if (a > R_WIDEINT_MAX / b) return 1;
+	} else {
+	    if (b < R_WIDEINT_MIN / a) return 1;
+	}
+    } else {
+	if (b > 0) {
+	    if (a < R_WIDEINT_MIN / b) return 1;
+	} else {
+	    if (a != 0 && b < R_WIDEINT_MAX / a) return 1;
+	}
+    }
+    *r = a * b;
+    return 0;
+}
+# define R_ovf_add(a, b, r) R_wideint_add_ovf((a), (b), (r))
+# define R_ovf_sub(a, b, r) R_wideint_sub_ovf((a), (b), (r))
+# define R_ovf_mul(a, b, r) R_wideint_mul_ovf((a), (b), (r))
+#endif
 /* R_isWideInteger, INTEGER64_ELT, SET_INTEGER64_ELT and the
    narrowing helpers are inlinable and so must only be declared via
    Rinlinedfuns.h (or its fallback block below): an unguarded

--- a/src/include/Defn.h
+++ b/src/include/Defn.h
@@ -485,6 +485,7 @@ SEXP R_wideIntCoerce(SEXP v, SEXPTYPE type);
 SEXP R_formatWideInt(SEXP x);
 const char *EncodeWideInt(R_wideint_t x, int w);
 SEXP R_widenInteger(SEXP x);
+SEXP R_asWideInteger(SEXP x);
 
 /* Vector Access Macros */
 #ifdef LONG_VECTOR_SUPPORT

--- a/src/include/Defn.h
+++ b/src/include/Defn.h
@@ -510,11 +510,14 @@ SEXP R_widenInteger(SEXP x);
 #define XLENGTH(x) XLENGTH_EX(x)
 
 /* THIS ABSOLUTELY MUST NOT BE USED IN PACKAGES !!! */
+/* A wide integer vector must never carry the scalar bit: the
+   IS_SCALAR fast paths read the payload as a 4-byte int. */
 #define SET_STDVEC_LENGTH(x,v) do {		\
 	SEXP __x__ = (x);			\
 	R_xlen_t __v__ = (v);			\
 	STDVEC_LENGTH(__x__) = __v__;		\
-	SETSCALAR(__x__, __v__ == 1 ? 1 : 0);	\
+	SETSCALAR(__x__, (__v__ == 1 &&		\
+			  ! R_isWideInteger(__x__)) ? 1 : 0);	\
     } while (0)
 
 /* Under the generational allocator the data for vector nodes comes

--- a/src/include/Defn.h
+++ b/src/include/Defn.h
@@ -408,7 +408,7 @@ typedef long long R_wideint_t;
    Rinlinedfuns.h (or its fallback block below): an unguarded
    declaration here would demote the C99 inline definitions to
    external ones in every translation unit */
-SEXP allocWideIntVector(R_xlen_t length);
+SEXP R_allocWideIntVector(R_xlen_t length);
 SEXP ScalarWideInt(R_wideint_t v);
 SEXP R_wideIntCoerce(SEXP v, SEXPTYPE type);
 SEXP R_formatWideInt(SEXP x);

--- a/src/include/Internal.h
+++ b/src/include/Internal.h
@@ -66,6 +66,8 @@ SEXP do_asfunction(SEXP, SEXP, SEXP, SEXP);
 SEXP do_asmatrixdf(SEXP, SEXP, SEXP, SEXP);
 SEXP do_assign(SEXP, SEXP, SEXP, SEXP);
 SEXP do_asvector(SEXP, SEXP, SEXP, SEXP);
+SEXP do_aswideint(SEXP, SEXP, SEXP, SEXP);
+SEXP do_iswideint(SEXP, SEXP, SEXP, SEXP);
 SEXP do_asCharacterFactor(SEXP, SEXP, SEXP, SEXP);
 SEXP do_AT(SEXP call, SEXP op, SEXP args, SEXP env);
 SEXP do_attach(SEXP,SEXP,SEXP,SEXP);

--- a/src/include/R_ext/Itermacros.h
+++ b/src/include/R_ext/Itermacros.h
@@ -179,12 +179,16 @@
     } while (0)
 
 #define GET_REGION_BUFSIZE 512
+/* a wide integer vector has no 32-bit payload to point at, so it must
+   take the (narrowing) GET_REGION path like an ALTREP vector */
 #ifdef USE_RINTERNALS
 # define GET_REGION_PTR(x, i, n, buf, type)				\
-    (ALTREP(x) == 0 ? type##0(x) + (i) : (type##_GET_REGION(x, i, n, buf), buf))
+    (ALTREP(x) == 0 && ! R_isWideInteger(x) ?				\
+     type##0(x) + (i) : (type##_GET_REGION(x, i, n, buf), buf))
 #else
 # define GET_REGION_PTR(x, i, n, buf, type)				\
-    (ALTREP(x) == 0 ? type(x) + (i) : (type##_GET_REGION(x, i, n, buf), buf))
+    (ALTREP(x) == 0 && ! R_isWideInteger(x) ?				\
+     type(x) + (i) : (type##_GET_REGION(x, i, n, buf), buf))
 #endif
 
 #define ITERATE_BY_REGION_PARTIAL0(sx, px, idx, nb, etype, vtype,	\

--- a/src/include/Rinlinedfuns.h
+++ b/src/include/Rinlinedfuns.h
@@ -157,6 +157,10 @@ INLINE_FUN const void *DATAPTR_OR_NULL(SEXP x) {
     CHKVEC(x);
     if (ALTREP(x))
 	return ALTVEC_DATAPTR_OR_NULL(x);
+    else if (R_isWideInteger(x))
+	/* no 32-bit view exists; callers must use the region/ELT
+	   paths, which narrow with per-element range checks */
+	return NULL;
     else
 	return STDVEC_DATAPTR(x);
 }
@@ -193,6 +197,8 @@ INLINE_FUN const int *LOGICAL_OR_NULL(SEXP x) {
 
 INLINE_FUN const int *INTEGER_OR_NULL(SEXP x) {
     CHECK_VECTOR_INT(x);
+    if (R_isWideInteger(x))
+	return NULL; /* no 32-bit view of a wide vector exists */
     return ALTREP(x) ? ALTVEC_DATAPTR_OR_NULL(x) : STDVEC_DATAPTR(x);
 }
 
@@ -330,6 +336,14 @@ HIDDEN INLINE_FUN R_xlen_t XTRUELENGTH(SEXP x)
 # define CHECK_VECTOR_RAW_ELT(x, i) do { } while(0)
 #endif
 
+/* wide (64-bit) integer prototype support; defined in memory.c and
+   redeclared here since not every inclusion context sees the
+   Rinternals.h declarations */
+int R_isWideInteger(SEXP x);
+int R_wideIntegerElt32(SEXP x, R_xlen_t i);
+void R_wideIntegerSetElt32(SEXP x, R_xlen_t i, int v);
+int *R_INTEGER32chk0(SEXP x);
+
 /*HIDDEN (inlining)*/ INLINE_FUN int *LOGICAL0(SEXP x) {
     CHECK_STDVEC_LGL(x);
     return (int *) STDVEC_DATAPTR(x);
@@ -347,7 +361,7 @@ HIDDEN INLINE_FUN void SET_SCALAR_LVAL(SEXP x, int v) {
 
 /*HIDDEN (inlining)*/ INLINE_FUN int *INTEGER0(SEXP x) {
     CHECK_STDVEC_INT(x);
-    return (int *) STDVEC_DATAPTR(x);
+    return R_INTEGER32chk0(x); /* errors on wide integer vectors */
 }
 HIDDEN INLINE_FUN int SCALAR_IVAL(SEXP x) {
     CHECK_SCALAR_INT(x);
@@ -407,13 +421,17 @@ INLINE_FUN void R_set_altrep_data2(SEXP x, SEXP v) { SETCDR(x, v); }
 INLINE_FUN int INTEGER_ELT(SEXP x, R_xlen_t i)
 {
     CHECK_VECTOR_INT_ELT(x, i);
+    if (R_isWideInteger(x))
+	/* narrows when the value is representable, errors otherwise */
+	return R_wideIntegerElt32(x, i);
     return ALTREP(x) ? ALTINTEGER_ELT(x, i) : INTEGER0(x)[i];
 }
 
 INLINE_FUN void SET_INTEGER_ELT(SEXP x, R_xlen_t i, int v)
 {
     CHECK_VECTOR_INT_ELT(x, i);
-    if (ALTREP(x)) ALTINTEGER_SET_ELT(x, i, v);
+    if (R_isWideInteger(x)) R_wideIntegerSetElt32(x, i, v);
+    else if (ALTREP(x)) ALTINTEGER_SET_ELT(x, i, v);
     else INTEGER0(x)[i] = v;
 }
 

--- a/src/include/Rinlinedfuns.h
+++ b/src/include/Rinlinedfuns.h
@@ -406,11 +406,13 @@ HIDDEN INLINE_FUN void SET_SCALAR_LVAL(SEXP x, int v) {
 }
 HIDDEN INLINE_FUN int SCALAR_IVAL(SEXP x) {
     CHECK_SCALAR_INT(x);
-    return INTEGER(x)[0];
+    /* scalars are never wide (R_allocWideIntVector clears the scalar
+       bit), so bypass INTEGER()'s wide check on this hot path */
+    return ((int *) DATAPTR(x))[0];
 }
 /*HIDDEN (inlining)*/ INLINE_FUN void SET_SCALAR_IVAL(SEXP x, int v) {
     CHECK_SCALAR_INT(x);
-    INTEGER(x)[0] = v;
+    ((int *) DATAPTR(x))[0] = v;
 }
 
 /*HIDDEN*/ INLINE_FUN double *REAL0(SEXP x) {
@@ -465,7 +467,9 @@ INLINE_FUN int INTEGER_ELT(SEXP x, R_xlen_t i)
     if (R_isWideInteger(x))
 	/* narrows when the value is representable, errors otherwise */
 	return R_wideIntegerElt32(x, i);
-    return ALTREP(x) ? ALTINTEGER_ELT(x, i) : INTEGER0(x)[i];
+    /* wideness already ruled out: index the payload directly rather than
+       through INTEGER0(), which would repeat the wide check */
+    return ALTREP(x) ? ALTINTEGER_ELT(x, i) : ((int *) STDVEC_DATAPTR(x))[i];
 }
 
 INLINE_FUN void SET_INTEGER_ELT(SEXP x, R_xlen_t i, int v)
@@ -473,7 +477,7 @@ INLINE_FUN void SET_INTEGER_ELT(SEXP x, R_xlen_t i, int v)
     CHECK_VECTOR_INT_ELT(x, i);
     if (R_isWideInteger(x)) R_wideIntegerSetElt32(x, i, v);
     else if (ALTREP(x)) ALTINTEGER_SET_ELT(x, i, v);
-    else INTEGER0(x)[i] = v;
+    else ((int *) STDVEC_DATAPTR(x))[i] = v;
 }
 
 INLINE_FUN R_wideint_t INTEGER64_ELT(SEXP x, R_xlen_t i)

--- a/src/include/Rinlinedfuns.h
+++ b/src/include/Rinlinedfuns.h
@@ -127,6 +127,32 @@ SEXP CAR(SEXP e);
 # define CHKVEC(x) do {} while(0)
 #endif
 
+/* Wide (64-bit) integer helpers.  These sit on the hot path of every
+   integer accessor, so they are inlined within R itself; inlined.c
+   emits the extern copies that package code links against. */
+NORET void R_wideIntPtrError(void);
+
+INLINE_FUN int R_isWideInteger(SEXP x)
+{
+    return TYPEOF(x) == INTSXP && IS_WIDEINT(x);
+}
+
+INLINE_FUN int R_wideIntegerElt32(SEXP x, R_xlen_t i)
+{
+    R_wideint_t v = WIDEINT_PTR(x)[i];
+    if (v == NA_INTEGER64)
+	return NA_INTEGER;
+    if (v > INT_MIN && v <= INT_MAX)
+	return (int) v;
+    error("wide integer value %lld out of range for a 32-bit access",
+	  (long long) v);
+}
+
+INLINE_FUN void R_wideIntegerSetElt32(SEXP x, R_xlen_t i, int v)
+{
+    WIDEINT_PTR(x)[i] = (v == NA_INTEGER) ? NA_INTEGER64 : (R_wideint_t) v;
+}
+
 INLINE_FUN void *DATAPTR(SEXP x) {
     CHKVEC(x);
     if (ALTREP(x))
@@ -151,6 +177,29 @@ INLINE_FUN const void *DATAPTR_RO(SEXP x) {
 	return ALTVEC_DATAPTR_RO(x);
     else
 	return STDVEC_DATAPTR(x);
+}
+
+/* the INTEGER()/INTEGER_RO()/INTEGER0() macros in Defn.h expand to
+   these; they error on wide vectors, so no silent-misread path exists */
+INLINE_FUN int *R_INTEGER32chk(SEXP x)
+{
+    if (IS_WIDEINT(x))
+	R_wideIntPtrError();
+    return (int *) DATAPTR(x);
+}
+
+INLINE_FUN const int *R_INTEGER32chk_ro(SEXP x)
+{
+    if (IS_WIDEINT(x))
+	R_wideIntPtrError();
+    return (const int *) DATAPTR_RO(x);
+}
+
+INLINE_FUN int *R_INTEGER32chk0(SEXP x)
+{
+    if (IS_WIDEINT(x))
+	R_wideIntPtrError();
+    return (int *) STDVEC_DATAPTR(x);
 }
 
 INLINE_FUN const void *DATAPTR_OR_NULL(SEXP x) {
@@ -336,14 +385,6 @@ HIDDEN INLINE_FUN R_xlen_t XTRUELENGTH(SEXP x)
 # define CHECK_VECTOR_RAW_ELT(x, i) do { } while(0)
 #endif
 
-/* wide (64-bit) integer prototype support; defined in memory.c and
-   redeclared here since not every inclusion context sees the
-   Rinternals.h declarations */
-int R_isWideInteger(SEXP x);
-int R_wideIntegerElt32(SEXP x, R_xlen_t i);
-void R_wideIntegerSetElt32(SEXP x, R_xlen_t i, int v);
-int *R_INTEGER32chk0(SEXP x);
-
 /*HIDDEN (inlining)*/ INLINE_FUN int *LOGICAL0(SEXP x) {
     CHECK_STDVEC_LGL(x);
     return (int *) STDVEC_DATAPTR(x);
@@ -433,6 +474,37 @@ INLINE_FUN void SET_INTEGER_ELT(SEXP x, R_xlen_t i, int v)
     if (R_isWideInteger(x)) R_wideIntegerSetElt32(x, i, v);
     else if (ALTREP(x)) ALTINTEGER_SET_ELT(x, i, v);
     else INTEGER0(x)[i] = v;
+}
+
+INLINE_FUN R_wideint_t INTEGER64_ELT(SEXP x, R_xlen_t i)
+{
+    if (TYPEOF(x) != INTSXP)
+	error("%s() can only be applied to a '%s', not a '%s'",
+	      "INTEGER64_ELT", "integer", R_typeToChar(x));
+    if (IS_WIDEINT(x))
+	return WIDEINT_PTR(x)[i];
+
+    int v = INTEGER_ELT(x, i);
+    return v == NA_INTEGER ? NA_INTEGER64 : (R_wideint_t) v;
+}
+
+INLINE_FUN void SET_INTEGER64_ELT(SEXP x, R_xlen_t i, R_wideint_t v)
+{
+    if (TYPEOF(x) != INTSXP)
+	error("%s() can only be applied to a '%s', not a '%s'",
+	      "SET_INTEGER64_ELT", "integer", R_typeToChar(x));
+    if (IS_WIDEINT(x)) {
+	WIDEINT_PTR(x)[i] = v;
+	return;
+    }
+
+    if (v == NA_INTEGER64)
+	SET_INTEGER_ELT(x, i, NA_INTEGER);
+    else if (v > INT_MIN && v <= INT_MAX)
+	SET_INTEGER_ELT(x, i, (int) v);
+    else
+	error("value %lld cannot be stored in a narrow integer vector",
+	      (long long) v);
 }
 
 INLINE_FUN int LOGICAL_ELT(SEXP x, R_xlen_t i)

--- a/src/include/Rinternals.h
+++ b/src/include/Rinternals.h
@@ -1140,14 +1140,20 @@ void SET_COMPLEX_ELT(SEXP x, R_xlen_t i, Rcomplex v);
 void SET_RAW_ELT(SEXP x, R_xlen_t i, Rbyte v);
 
 /* Wide (64-bit) integer vector prototype.  The API is deliberately
-   element-based: there is no 64-bit data-pointer accessor. */
+   element-based: there is no 64-bit data-pointer accessor.  The
+   element type is abstracted as R_wideint_t; when printing a value
+   with "%lld", cast to long long explicitly. */
+#ifndef R_WIDEINT_T_DEFINED
+# define R_WIDEINT_T_DEFINED
+typedef long long R_wideint_t;
+#endif
 #ifndef NA_INTEGER64
-# define NA_INTEGER64 (-9223372036854775807LL - 1)
+# define NA_INTEGER64 ((R_wideint_t)(-9223372036854775807LL - 1))
 #endif
 int R_isWideInteger(SEXP x);
 SEXP allocWideIntVector(R_xlen_t length);
-long long INTEGER64_ELT(SEXP x, R_xlen_t i);
-void SET_INTEGER64_ELT(SEXP x, R_xlen_t i, long long v);
+R_wideint_t INTEGER64_ELT(SEXP x, R_xlen_t i);
+void SET_INTEGER64_ELT(SEXP x, R_xlen_t i, R_wideint_t v);
 int R_wideIntegerElt32(SEXP x, R_xlen_t i);
 void R_wideIntegerSetElt32(SEXP x, R_xlen_t i, int v);
 int *R_INTEGER32chk0(SEXP x);

--- a/src/include/Rinternals.h
+++ b/src/include/Rinternals.h
@@ -1139,6 +1139,19 @@ void SET_REAL_ELT(SEXP x, R_xlen_t i, double v);
 void SET_COMPLEX_ELT(SEXP x, R_xlen_t i, Rcomplex v);
 void SET_RAW_ELT(SEXP x, R_xlen_t i, Rbyte v);
 
+/* Wide (64-bit) integer vector prototype.  The API is deliberately
+   element-based: there is no 64-bit data-pointer accessor. */
+#ifndef NA_INTEGER64
+# define NA_INTEGER64 (-9223372036854775807LL - 1)
+#endif
+int R_isWideInteger(SEXP x);
+SEXP allocWideIntVector(R_xlen_t length);
+long long INTEGER64_ELT(SEXP x, R_xlen_t i);
+void SET_INTEGER64_ELT(SEXP x, R_xlen_t i, long long v);
+int R_wideIntegerElt32(SEXP x, R_xlen_t i);
+void R_wideIntegerSetElt32(SEXP x, R_xlen_t i, int v);
+int *R_INTEGER32chk0(SEXP x);
+
 /* ALTREP support */
 SEXP ALTREP_CLASS(SEXP x);
 SEXP R_altrep_data1(SEXP x);

--- a/src/include/Rinternals.h
+++ b/src/include/Rinternals.h
@@ -1142,7 +1142,9 @@ void SET_RAW_ELT(SEXP x, R_xlen_t i, Rbyte v);
 /* Wide (64-bit) integer vector prototype.  The API is deliberately
    element-based: there is no 64-bit data-pointer accessor.  The
    element type is abstracted as R_wideint_t; when printing a value
-   with "%lld", cast to long long explicitly. */
+   with "%lld", cast to long long explicitly.  The narrowing helpers
+   (R_wideIntegerElt32 etc.) are internal and declared in
+   Rinlinedfuns.h/Defn.h. */
 #ifndef R_WIDEINT_T_DEFINED
 # define R_WIDEINT_T_DEFINED
 typedef long long R_wideint_t;
@@ -1154,9 +1156,6 @@ int R_isWideInteger(SEXP x);
 SEXP allocWideIntVector(R_xlen_t length);
 R_wideint_t INTEGER64_ELT(SEXP x, R_xlen_t i);
 void SET_INTEGER64_ELT(SEXP x, R_xlen_t i, R_wideint_t v);
-int R_wideIntegerElt32(SEXP x, R_xlen_t i);
-void R_wideIntegerSetElt32(SEXP x, R_xlen_t i, int v);
-int *R_INTEGER32chk0(SEXP x);
 
 /* ALTREP support */
 SEXP ALTREP_CLASS(SEXP x);

--- a/src/include/Rinternals.h
+++ b/src/include/Rinternals.h
@@ -1153,7 +1153,7 @@ typedef long long R_wideint_t;
 # define NA_INTEGER64 ((R_wideint_t)(-9223372036854775807LL - 1))
 #endif
 int R_isWideInteger(SEXP x);
-SEXP allocWideIntVector(R_xlen_t length);
+SEXP R_allocWideIntVector(R_xlen_t length);
 R_wideint_t INTEGER64_ELT(SEXP x, R_xlen_t i);
 void SET_INTEGER64_ELT(SEXP x, R_xlen_t i, R_wideint_t v);
 

--- a/src/library/base/R/as.R
+++ b/src/library/base/R/as.R
@@ -56,6 +56,10 @@ as.list.environment <- function(x, all.names=FALSE, sorted=FALSE, ...)
 ## as.vector dispatches internally so no need for a generic
 as.vector <- function(x, mode = "any") .Internal(as.vector(x, mode))
 
+## wide (64-bit) integer vector prototype
+as.wideint <- function(x) .Internal(as.wideint(x))
+is.wideint <- function(x) .Internal(is.wideint(x))
+
 as.matrix <- function(x, ...) UseMethod("as.matrix")
 as.matrix.default <- function(x, ...) {
     if (is.matrix(x)) x

--- a/src/library/base/R/sort.R
+++ b/src/library/base/R/sort.R
@@ -96,7 +96,8 @@ sort.int <-
     method <- match.arg(method)
     if (method == "auto" && is.null(partial) &&
         (is.numeric(x) || is.factor(x) || is.logical(x)) &&
-        is.integer(length(x)))
+        is.integer(length(x)) &&
+        !is.wideint(x)) # radix sort works on 32-bit keys
         method <- "radix"
     if (method == "radix") {
         if (!is.null(partial)) {
@@ -211,7 +212,8 @@ order <- function(..., na.last = TRUE, decreasing = FALSE,
     if (method == "auto") {
         useRadix <- all(vapply(z, function(x) {
             (is.numeric(x) || is.factor(x) || is.logical(x)) &&
-                is.integer(length(x))
+                is.integer(length(x)) &&
+                !is.wideint(x) # radix sort works on 32-bit keys
         }, logical(1L)))
         method <- if (useRadix) "radix" else "shell"
     }

--- a/src/library/base/R/sort.R
+++ b/src/library/base/R/sort.R
@@ -257,7 +257,8 @@ sort.list <- function(x, partial = NULL, na.last = TRUE, decreasing = FALSE,
     method <- match.arg(method)
     if (method == "auto" &&
         (is.numeric(x) || is.factor(x) || is.logical(x) ||
-         (is.object(x) && !is.atomic(x))) && is.integer(length(x)))
+         (is.object(x) && !is.atomic(x))) && is.integer(length(x)) &&
+        !is.wideint(x)) # radix sort works on 32-bit keys
         method <- "radix"
     if(!is.null(partial))
         .NotYetUsed("partial != NULL")

--- a/src/library/base/R/sort.R
+++ b/src/library/base/R/sort.R
@@ -114,8 +114,9 @@ sort.int <-
         y <- .doSortWrap(y, decreasing, na.last)
         return(if (index.return) list(x = y, ix = o) else y)
     }
-    else if (method == "auto" || !is.numeric(x))
+    else if (method == "auto" || !is.numeric(x) || is.wideint(x))
           method <- "shell" # explicitly prevent 'quick' for non-numeric data
+                            # and for wide vectors (qsort is 32-bit)
 
     if(isfact <- is.factor(x)) {
         if(index.return) stop("'index.return' only for non-factors")
@@ -146,7 +147,10 @@ sort.int <-
 		    k <- sum(ina)
 		    partial[partial > k] - k
 		}
-        y <- if(length(partial) <= 10L) {
+        y <- if(is.wideint(x))
+                 ## psort/qsort are 32-bit; a full sort satisfies 'partial'
+                 .Internal(sort(x, FALSE))
+             else if(length(partial) <= 10L) {
 		 partial <- .Internal(qsort(partial, FALSE))
 		 .Internal(psort(x, partial))
 	     } else if(is.double(x))

--- a/src/library/utils/src/size.c
+++ b/src/library/utils/src/size.c
@@ -89,8 +89,12 @@ static R_size_t objectsize(SEXP s)
 	isVec = true;
 	break;
     case LGLSXP:
-    case INTSXP:
 	vcnt = INT2VEC(xlength(s));
+	isVec = true;
+	break;
+    case INTSXP:
+	/* wide integer vectors store 8-byte elements in the payload */
+	vcnt = R_isWideInteger(s) ? FLOAT2VEC(xlength(s)) : INT2VEC(xlength(s));
 	isVec = true;
 	break;
     case REALSXP:

--- a/src/main/Makefile.in
+++ b/src/main/Makefile.in
@@ -36,7 +36,8 @@ SOURCES_C = \
 	sprintf.c startup.c subassign.c subscript.c subset.c summary.c sysutils.c \
 	times.c \
 	unique.c util.c \
-	version.c wideint.c \
+	version.c \
+	wideint.c \
 	g_alab_her.c g_cntrlify.c g_fontdb.c g_her_glyph.c
 
 SOURCES_F =  xxxpr.f

--- a/src/main/Makefile.in
+++ b/src/main/Makefile.in
@@ -36,7 +36,7 @@ SOURCES_C = \
 	sprintf.c startup.c subassign.c subscript.c subset.c summary.c sysutils.c \
 	times.c \
 	unique.c util.c \
-	version.c \
+	version.c wideint.c \
 	g_alab_her.c g_cntrlify.c g_fontdb.c g_her_glyph.c
 
 SOURCES_F =  xxxpr.f

--- a/src/main/Makefile.win
+++ b/src/main/Makefile.win
@@ -34,6 +34,7 @@ CSOURCES = \
 	times.c \
 	unique.c util.c \
 	version.c \
+	wideint.c \
 	g_alab_her.c g_cntrlify.c g_fontdb.c g_her_glyph.c
 
 

--- a/src/main/altclasses.c
+++ b/src/main/altclasses.c
@@ -2018,6 +2018,11 @@ static SEXP wrap_meta(SEXP x, int srt, int no_na)
     default: return x;
     }
 
+    /* an ALTREP wrapper would hide the wide bit and present the
+       payload as 32-bit ints */
+    if (R_isWideInteger(x))
+	return x;
+
     /* avoid wrappers of wrappers, at least in some cases */
     if (is_wrapper(x) && srt == UNKNOWN_SORTEDNESS && no_na == FALSE)
 	return shallow_duplicate(x);

--- a/src/main/altrep.c
+++ b/src/main/altrep.c
@@ -691,6 +691,10 @@ static SEXP altrep_UnserializeEX_default(SEXP class, SEXP state, SEXP attr,
     SET_ATTRIB(val, attr);
     SET_OBJECT(val, objf);
     SETLEVELS(val, levs);
+    /* levs is stream-controlled: never let it stamp the wide bit onto
+       a materialized 32-bit payload (matches ReadItem in serialize.c) */
+    if (TYPEOF(val) == INTSXP || TYPEOF(val) == LGLSXP)
+	UNSET_WIDEINT(val);
     return val;
 }
 

--- a/src/main/altrep.c
+++ b/src/main/altrep.c
@@ -403,6 +403,15 @@ attribute_hidden int ALTINTEGER_ELT(SEXP x, R_xlen_t i)
 
 R_xlen_t INTEGER_GET_REGION(SEXP sx, R_xlen_t i, R_xlen_t n, int *buf)
 {
+    if (R_isWideInteger(sx)) {
+	/* narrow element-wise; errors on values outside 32-bit range */
+	R_xlen_t size = XLENGTH(sx);
+	R_xlen_t ncopy = size - i > n ? n : size - i;
+	for (R_xlen_t k = 0; k < ncopy; k++)
+	    buf[k] = R_wideIntegerElt32(sx, k + i);
+	return ncopy;
+    }
+
     const int *x = INTEGER_OR_NULL(sx);
     if (x != NULL) {
 	R_xlen_t size = XLENGTH(sx);

--- a/src/main/arithmetic.c
+++ b/src/main/arithmetic.c
@@ -1019,7 +1019,7 @@ static SEXP wideint_binary(ARITHOP_TYPE code, SEXP s1, SEXP s2, SEXP lcall)
     if (code == DIVOP || code == POWOP)
 	ans = allocVector(REALSXP, n);
     else
-	ans = allocWideIntVector(n);
+	ans = R_allocWideIntVector(n);
     if (n == 0) return(ans);
     PROTECT(ans);
 

--- a/src/main/arithmetic.c
+++ b/src/main/arithmetic.c
@@ -1665,7 +1665,14 @@ attribute_hidden SEXP do_abs(SEXP call, SEXP op, SEXP args, SEXP env)
     if (DispatchGroup("Math", call, op, args, env, &s))
 	return s;
 
-    if (isInteger(x) || isLogical(x)) {
+    if (R_isWideInteger(x)) {
+	R_xlen_t i, n = XLENGTH(x);
+	PROTECT(s = NO_REFERENCES(x) ? x : duplicate(x));
+	for(i = 0 ; i < n ; i++) {
+	    R_wideint_t xi = INTEGER64_ELT(x, i);
+	    WIDEINT_PTR(s)[i] = (xi == NA_INTEGER64 || xi >= 0) ? xi : -xi;
+	}
+    } else if (isInteger(x) || isLogical(x)) {
 	/* integer or logical ==> return integer,
 	   factor was covered by Math.factor. */
 	R_xlen_t i, n = XLENGTH(x);

--- a/src/main/arithmetic.c
+++ b/src/main/arithmetic.c
@@ -460,19 +460,19 @@ attribute_hidden SEXP do_arith(SEXP call, SEXP op, SEXP args, SEXP env)
 		    ans = ScalarValue2(arg1, arg2);
 		    SET_SCALAR_IVAL(ans, R_integer_plus(i1, i2, &naflag));
 		    if (naflag) /* 32-bit overflow: promote to wide */
-			return ScalarWideInt((long long) i1 + (long long) i2);
+			return ScalarWideInt((R_wideint_t) i1 + (R_wideint_t) i2);
 		    return ans;
 		case MINUSOP:
 		    ans = ScalarValue2(arg1, arg2);
 		    SET_SCALAR_IVAL(ans, R_integer_minus(i1, i2, &naflag));
 		    if (naflag)
-			return ScalarWideInt((long long) i1 - (long long) i2);
+			return ScalarWideInt((R_wideint_t) i1 - (R_wideint_t) i2);
 		    return ans;
 		case TIMESOP:
 		    ans = ScalarValue2(arg1, arg2);
 		    SET_SCALAR_IVAL(ans, R_integer_times(i1, i2, &naflag));
 		    if (naflag)
-			return ScalarWideInt((long long) i1 * (long long) i2);
+			return ScalarWideInt((R_wideint_t) i1 * (R_wideint_t) i2);
 		    return ans;
 		case DIVOP:
 		    return ScalarReal(R_integer_divide(i1, i2));
@@ -793,7 +793,7 @@ static SEXP integer_unary(ARITHOP_TYPE code, SEXP s1, SEXP call)
 	    ans = NO_REFERENCES(s1) ? s1 : duplicate(s1);
 	    n = XLENGTH(s1);
 	    for (i = 0; i < n; i++) {
-		long long x = INTEGER64_ELT(s1, i);
+		R_wideint_t x = INTEGER64_ELT(s1, i);
 		WIDEINT_PTR(ans)[i] = (x == NA_INTEGER64) ? x : -x;
 	    }
 	    return ans;
@@ -995,11 +995,11 @@ static SEXP integer_binary(ARITHOP_TYPE code, SEXP s1, SEXP s2, SEXP lcall)
    wide) or LGLSXP; mixes with REALSXP/CPLXSXP are handled by coercion
    in R_binary before this is reached. */
 
-static R_INLINE long long wideint_elt(SEXP x, R_xlen_t i)
+static R_INLINE R_wideint_t wideint_elt(SEXP x, R_xlen_t i)
 {
     if (TYPEOF(x) == LGLSXP) {
 	int v = LOGICAL_ELT(x, i);
-	return v == NA_LOGICAL ? NA_INTEGER64 : (long long) v;
+	return v == NA_LOGICAL ? NA_INTEGER64 : (R_wideint_t) v;
     }
     return INTEGER64_ELT(x, i);
 }
@@ -1026,9 +1026,9 @@ static SEXP wideint_binary(ARITHOP_TYPE code, SEXP s1, SEXP s2, SEXP lcall)
     switch (code) {
     case PLUSOP:
 	MOD_ITERATE2_CHECK(NINTERRUPT, n, n1, n2, i, i1, i2, {
-		long long x1 = wideint_elt(s1, i1);
-		long long x2 = wideint_elt(s2, i2);
-		long long r;
+		R_wideint_t x1 = wideint_elt(s1, i1);
+		R_wideint_t x2 = wideint_elt(s2, i2);
+		R_wideint_t r;
 		if (x1 == NA_INTEGER64 || x2 == NA_INTEGER64)
 		    r = NA_INTEGER64;
 		else if (__builtin_add_overflow(x1, x2, &r) ||
@@ -1040,9 +1040,9 @@ static SEXP wideint_binary(ARITHOP_TYPE code, SEXP s1, SEXP s2, SEXP lcall)
 	break;
     case MINUSOP:
 	MOD_ITERATE2_CHECK(NINTERRUPT, n, n1, n2, i, i1, i2, {
-		long long x1 = wideint_elt(s1, i1);
-		long long x2 = wideint_elt(s2, i2);
-		long long r;
+		R_wideint_t x1 = wideint_elt(s1, i1);
+		R_wideint_t x2 = wideint_elt(s2, i2);
+		R_wideint_t r;
 		if (x1 == NA_INTEGER64 || x2 == NA_INTEGER64)
 		    r = NA_INTEGER64;
 		else if (__builtin_sub_overflow(x1, x2, &r) ||
@@ -1054,9 +1054,9 @@ static SEXP wideint_binary(ARITHOP_TYPE code, SEXP s1, SEXP s2, SEXP lcall)
 	break;
     case TIMESOP:
 	MOD_ITERATE2_CHECK(NINTERRUPT, n, n1, n2, i, i1, i2, {
-		long long x1 = wideint_elt(s1, i1);
-		long long x2 = wideint_elt(s2, i2);
-		long long r;
+		R_wideint_t x1 = wideint_elt(s1, i1);
+		R_wideint_t x2 = wideint_elt(s2, i2);
+		R_wideint_t r;
 		if (x1 == NA_INTEGER64 || x2 == NA_INTEGER64)
 		    r = NA_INTEGER64;
 		else if (__builtin_mul_overflow(x1, x2, &r) ||
@@ -1070,8 +1070,8 @@ static SEXP wideint_binary(ARITHOP_TYPE code, SEXP s1, SEXP s2, SEXP lcall)
 	{
 	    double *pa = REAL(ans);
 	    MOD_ITERATE2_CHECK(NINTERRUPT, n, n1, n2, i, i1, i2, {
-		    long long x1 = wideint_elt(s1, i1);
-		    long long x2 = wideint_elt(s2, i2);
+		    R_wideint_t x1 = wideint_elt(s1, i1);
+		    R_wideint_t x2 = wideint_elt(s2, i2);
 		    if (x1 == NA_INTEGER64 || x2 == NA_INTEGER64)
 			pa[i] = NA_REAL;
 		    else
@@ -1083,8 +1083,8 @@ static SEXP wideint_binary(ARITHOP_TYPE code, SEXP s1, SEXP s2, SEXP lcall)
 	{
 	    double *pa = REAL(ans);
 	    MOD_ITERATE2_CHECK(NINTERRUPT, n, n1, n2, i, i1, i2, {
-		    long long x1 = wideint_elt(s1, i1);
-		    long long x2 = wideint_elt(s2, i2);
+		    R_wideint_t x1 = wideint_elt(s1, i1);
+		    R_wideint_t x2 = wideint_elt(s2, i2);
 		    if (x1 == 1 || x2 == 0)
 			pa[i] = 1.;
 		    else if (x1 == NA_INTEGER64 || x2 == NA_INTEGER64)
@@ -1096,9 +1096,9 @@ static SEXP wideint_binary(ARITHOP_TYPE code, SEXP s1, SEXP s2, SEXP lcall)
 	break;
     case MODOP:
 	MOD_ITERATE2_CHECK(NINTERRUPT, n, n1, n2, i, i1, i2, {
-		long long x1 = wideint_elt(s1, i1);
-		long long x2 = wideint_elt(s2, i2);
-		long long r;
+		R_wideint_t x1 = wideint_elt(s1, i1);
+		R_wideint_t x2 = wideint_elt(s2, i2);
+		R_wideint_t r;
 		if (x1 == NA_INTEGER64 || x2 == NA_INTEGER64 || x2 == 0)
 		    r = NA_INTEGER64;
 		else {
@@ -1111,9 +1111,9 @@ static SEXP wideint_binary(ARITHOP_TYPE code, SEXP s1, SEXP s2, SEXP lcall)
 	break;
     case IDIVOP:
 	MOD_ITERATE2_CHECK(NINTERRUPT, n, n1, n2, i, i1, i2, {
-		long long x1 = wideint_elt(s1, i1);
-		long long x2 = wideint_elt(s2, i2);
-		long long r;
+		R_wideint_t x1 = wideint_elt(s1, i1);
+		R_wideint_t x2 = wideint_elt(s2, i2);
+		R_wideint_t r;
 		if (x1 == NA_INTEGER64 || x2 == NA_INTEGER64 || x2 == 0)
 		    r = NA_INTEGER64;
 		else {

--- a/src/main/arithmetic.c
+++ b/src/main/arithmetic.c
@@ -283,6 +283,7 @@ static SEXP integer_unary(ARITHOP_TYPE, SEXP, SEXP);
 static SEXP real_unary(ARITHOP_TYPE, SEXP, SEXP);
 static SEXP real_binary(ARITHOP_TYPE, SEXP, SEXP);
 static SEXP integer_binary(ARITHOP_TYPE, SEXP, SEXP, SEXP);
+static SEXP wideint_binary(ARITHOP_TYPE, SEXP, SEXP, SEXP);
 
 #if 0
 static int naflag;
@@ -458,17 +459,20 @@ attribute_hidden SEXP do_arith(SEXP call, SEXP op, SEXP args, SEXP env)
 		case PLUSOP:
 		    ans = ScalarValue2(arg1, arg2);
 		    SET_SCALAR_IVAL(ans, R_integer_plus(i1, i2, &naflag));
-		    CHECK_INTEGER_OVERFLOW(call, ans, naflag);
+		    if (naflag) /* 32-bit overflow: promote to wide */
+			return ScalarWideInt((long long) i1 + (long long) i2);
 		    return ans;
 		case MINUSOP:
 		    ans = ScalarValue2(arg1, arg2);
 		    SET_SCALAR_IVAL(ans, R_integer_minus(i1, i2, &naflag));
-		    CHECK_INTEGER_OVERFLOW(call, ans, naflag);
+		    if (naflag)
+			return ScalarWideInt((long long) i1 - (long long) i2);
 		    return ans;
 		case TIMESOP:
 		    ans = ScalarValue2(arg1, arg2);
 		    SET_SCALAR_IVAL(ans, R_integer_times(i1, i2, &naflag));
-		    CHECK_INTEGER_OVERFLOW(call, ans, naflag);
+		    if (naflag)
+			return ScalarWideInt((long long) i1 * (long long) i2);
 		    return ans;
 		case DIVOP:
 		    return ScalarReal(R_integer_divide(i1, i2));
@@ -670,6 +674,17 @@ attribute_hidden SEXP R_binary(SEXP call, SEXP op, SEXP x, SEXP y)
 	COERCE_IF_NEEDED(y, CPLXSXP, ypi);
 	val = complex_binary(oper, x, y);
     }
+    else if (R_isWideInteger(x) || R_isWideInteger(y)) {
+	if (TYPEOF(x) == REALSXP || TYPEOF(y) == REALSXP) {
+	    /* mixed wide/double works in double precision, with a
+	       precision warning above 2^53 from the coercion */
+	    COERCE_IF_NEEDED(x, REALSXP, xpi);
+	    COERCE_IF_NEEDED(y, REALSXP, ypi);
+	    val = real_binary(oper, x, y);
+	}
+	else
+	    val = wideint_binary(oper, x, y, call);
+    }
     else if (TYPEOF(x) == REALSXP || TYPEOF(y) == REALSXP) {
 	/* real_binary can handle REALSXP or INTSXP operand, but not LGLSXP. */
 	/* Can get a LGLSXP. In base-Ex.R on 24 Oct '06, got 8 of these. */
@@ -770,6 +785,23 @@ static SEXP integer_unary(ARITHOP_TYPE code, SEXP s1, SEXP call)
     R_xlen_t i, n;
     SEXP ans;
 
+    if (R_isWideInteger(s1)) {
+	switch (code) {
+	case PLUSOP:
+	    return s1;
+	case MINUSOP:
+	    ans = NO_REFERENCES(s1) ? s1 : duplicate(s1);
+	    n = XLENGTH(s1);
+	    for (i = 0; i < n; i++) {
+		long long x = INTEGER64_ELT(s1, i);
+		WIDEINT_PTR(ans)[i] = (x == NA_INTEGER64) ? x : -x;
+	    }
+	    return ans;
+	default:
+	    errorcall(call, _("invalid unary operator"));
+	}
+    }
+
     switch (code) {
     case PLUSOP:
 	return s1;
@@ -825,6 +857,10 @@ static SEXP integer_binary(ARITHOP_TYPE code, SEXP s1, SEXP s2, SEXP lcall)
 
     if (code == DIVOP || code == POWOP)
 	ans = allocVector(REALSXP, n);
+    else if (code == PLUSOP || code == MINUSOP || code == TIMESOP)
+	/* never reuse an input: an overflow redo in wideint_binary
+	   needs the inputs pristine */
+	ans = allocVector(INTSXP, n);
     else
 	ans = R_allocOrReuseVector(s1, s2, INTSXP, n);
     if (n == 0) return(ans);
@@ -841,8 +877,6 @@ static SEXP integer_binary(ARITHOP_TYPE code, SEXP s1, SEXP s2, SEXP lcall)
 		    x2 = px2[i2];
 		    pa[i] = R_integer_plus(x1, x2, &naflag);
 		});
-	    if (naflag)
-		warningcall(lcall, INTEGER_OVERFLOW_WARNING);
 	}
 	break;
     case MINUSOP:
@@ -855,8 +889,6 @@ static SEXP integer_binary(ARITHOP_TYPE code, SEXP s1, SEXP s2, SEXP lcall)
 		    x2 = px2[i2];
 		    pa[i] = R_integer_minus(x1, x2, &naflag);
 		});
-	    if (naflag)
-		warningcall(lcall, INTEGER_OVERFLOW_WARNING);
 	}
 	break;
     case TIMESOP:
@@ -869,8 +901,6 @@ static SEXP integer_binary(ARITHOP_TYPE code, SEXP s1, SEXP s2, SEXP lcall)
 		    x2 = px2[i2];
 		    pa[i] = R_integer_times(x1, x2, &naflag);
 		});
-	    if (naflag)
-		warningcall(lcall, INTEGER_OVERFLOW_WARNING);
 	}
 	break;
     case DIVOP:
@@ -936,6 +966,15 @@ static SEXP integer_binary(ARITHOP_TYPE code, SEXP s1, SEXP s2, SEXP lcall)
 	}
 	break;
     }
+
+    if (naflag) {
+	/* some element overflowed 32 bits: redo the operation with a
+	   wide (64-bit) result; the inputs are pristine since ans
+	   was freshly allocated for the promotable operations */
+	UNPROTECT(1);
+	return wideint_binary(code, s1, s2, lcall);
+    }
+
     UNPROTECT(1);
 
     /* quick return if there are no attributes */
@@ -948,6 +987,158 @@ static SEXP integer_binary(ARITHOP_TYPE code, SEXP s1, SEXP s2, SEXP lcall)
 	copyMostAttrib(s2, ans);
     if (ans != s1 && n == n1 && ATTRIB(s1) != R_NilValue)
 	copyMostAttrib(s1, ans); /* Done 2nd so s1's attrs overwrite s2's */
+
+    return ans;
+}
+
+/* Wide (64-bit) integer arithmetic.  Operands are INTSXP (narrow or
+   wide) or LGLSXP; mixes with REALSXP/CPLXSXP are handled by coercion
+   in R_binary before this is reached. */
+
+static R_INLINE long long wideint_elt(SEXP x, R_xlen_t i)
+{
+    if (TYPEOF(x) == LGLSXP) {
+	int v = LOGICAL_ELT(x, i);
+	return v == NA_LOGICAL ? NA_INTEGER64 : (long long) v;
+    }
+    return INTEGER64_ELT(x, i);
+}
+
+#define WIDEINT_OVERFLOW_WARNING _("NAs produced by wide integer overflow")
+
+static SEXP wideint_binary(ARITHOP_TYPE code, SEXP s1, SEXP s2, SEXP lcall)
+{
+    R_xlen_t i, i1, i2, n, n1, n2;
+    SEXP ans;
+    bool naflag = false;
+
+    n1 = XLENGTH(s1);
+    n2 = XLENGTH(s2);
+    if (n1 == 0 || n2 == 0) n = 0; else n = (n1 > n2) ? n1 : n2;
+
+    if (code == DIVOP || code == POWOP)
+	ans = allocVector(REALSXP, n);
+    else
+	ans = allocWideIntVector(n);
+    if (n == 0) return(ans);
+    PROTECT(ans);
+
+    switch (code) {
+    case PLUSOP:
+	MOD_ITERATE2_CHECK(NINTERRUPT, n, n1, n2, i, i1, i2, {
+		long long x1 = wideint_elt(s1, i1);
+		long long x2 = wideint_elt(s2, i2);
+		long long r;
+		if (x1 == NA_INTEGER64 || x2 == NA_INTEGER64)
+		    r = NA_INTEGER64;
+		else if (__builtin_add_overflow(x1, x2, &r) ||
+			 r == NA_INTEGER64) {
+		    r = NA_INTEGER64; naflag = true;
+		}
+		WIDEINT_PTR(ans)[i] = r;
+	    });
+	break;
+    case MINUSOP:
+	MOD_ITERATE2_CHECK(NINTERRUPT, n, n1, n2, i, i1, i2, {
+		long long x1 = wideint_elt(s1, i1);
+		long long x2 = wideint_elt(s2, i2);
+		long long r;
+		if (x1 == NA_INTEGER64 || x2 == NA_INTEGER64)
+		    r = NA_INTEGER64;
+		else if (__builtin_sub_overflow(x1, x2, &r) ||
+			 r == NA_INTEGER64) {
+		    r = NA_INTEGER64; naflag = true;
+		}
+		WIDEINT_PTR(ans)[i] = r;
+	    });
+	break;
+    case TIMESOP:
+	MOD_ITERATE2_CHECK(NINTERRUPT, n, n1, n2, i, i1, i2, {
+		long long x1 = wideint_elt(s1, i1);
+		long long x2 = wideint_elt(s2, i2);
+		long long r;
+		if (x1 == NA_INTEGER64 || x2 == NA_INTEGER64)
+		    r = NA_INTEGER64;
+		else if (__builtin_mul_overflow(x1, x2, &r) ||
+			 r == NA_INTEGER64) {
+		    r = NA_INTEGER64; naflag = true;
+		}
+		WIDEINT_PTR(ans)[i] = r;
+	    });
+	break;
+    case DIVOP:
+	{
+	    double *pa = REAL(ans);
+	    MOD_ITERATE2_CHECK(NINTERRUPT, n, n1, n2, i, i1, i2, {
+		    long long x1 = wideint_elt(s1, i1);
+		    long long x2 = wideint_elt(s2, i2);
+		    if (x1 == NA_INTEGER64 || x2 == NA_INTEGER64)
+			pa[i] = NA_REAL;
+		    else
+			pa[i] = (double) x1 / (double) x2;
+		});
+	}
+	break;
+    case POWOP:
+	{
+	    double *pa = REAL(ans);
+	    MOD_ITERATE2_CHECK(NINTERRUPT, n, n1, n2, i, i1, i2, {
+		    long long x1 = wideint_elt(s1, i1);
+		    long long x2 = wideint_elt(s2, i2);
+		    if (x1 == 1 || x2 == 0)
+			pa[i] = 1.;
+		    else if (x1 == NA_INTEGER64 || x2 == NA_INTEGER64)
+			pa[i] = NA_REAL;
+		    else
+			pa[i] = R_POW((double) x1, (double) x2);
+		});
+	}
+	break;
+    case MODOP:
+	MOD_ITERATE2_CHECK(NINTERRUPT, n, n1, n2, i, i1, i2, {
+		long long x1 = wideint_elt(s1, i1);
+		long long x2 = wideint_elt(s2, i2);
+		long long r;
+		if (x1 == NA_INTEGER64 || x2 == NA_INTEGER64 || x2 == 0)
+		    r = NA_INTEGER64;
+		else {
+		    r = x1 % x2;
+		    if (r != 0 && (r < 0) != (x2 < 0))
+			r += x2;
+		}
+		WIDEINT_PTR(ans)[i] = r;
+	    });
+	break;
+    case IDIVOP:
+	MOD_ITERATE2_CHECK(NINTERRUPT, n, n1, n2, i, i1, i2, {
+		long long x1 = wideint_elt(s1, i1);
+		long long x2 = wideint_elt(s2, i2);
+		long long r;
+		if (x1 == NA_INTEGER64 || x2 == NA_INTEGER64 || x2 == 0)
+		    r = NA_INTEGER64;
+		else {
+		    r = x1 / x2;
+		    if ((x1 % x2) != 0 && (x1 < 0) != (x2 < 0))
+			r--;
+		}
+		WIDEINT_PTR(ans)[i] = r;
+	    });
+	break;
+    }
+
+    if (naflag)
+	warningcall(lcall, WIDEINT_OVERFLOW_WARNING);
+
+    UNPROTECT(1);
+
+    /* Copy attributes from longer argument, as integer_binary does. */
+    if (ATTRIB(s1) == R_NilValue && ATTRIB(s2) == R_NilValue)
+	return ans;
+
+    if (n == n2 && ATTRIB(s2) != R_NilValue)
+	copyMostAttrib(s2, ans);
+    if (n == n1 && ATTRIB(s1) != R_NilValue)
+	copyMostAttrib(s1, ans);
 
     return ans;
 }

--- a/src/main/arithmetic.c
+++ b/src/main/arithmetic.c
@@ -1010,7 +1010,7 @@ static SEXP wideint_binary(ARITHOP_TYPE code, SEXP s1, SEXP s2, SEXP lcall)
 {
     R_xlen_t i, i1, i2, n, n1, n2;
     SEXP ans;
-    bool naflag = false;
+    bool naflag = false, precflag = false;
 
     n1 = XLENGTH(s1);
     n2 = XLENGTH(s2);
@@ -1074,8 +1074,14 @@ static SEXP wideint_binary(ARITHOP_TYPE code, SEXP s1, SEXP s2, SEXP lcall)
 		    R_wideint_t x2 = wideint_elt(s2, i2);
 		    if (x1 == NA_INTEGER64 || x2 == NA_INTEGER64)
 			pa[i] = NA_REAL;
-		    else
+		    else {
+			if (x1 > R_WIDEINT_DBL_EXACT ||
+			    x1 < -R_WIDEINT_DBL_EXACT ||
+			    x2 > R_WIDEINT_DBL_EXACT ||
+			    x2 < -R_WIDEINT_DBL_EXACT)
+			    precflag = true;
 			pa[i] = (double) x1 / (double) x2;
+		    }
 		});
 	}
 	break;
@@ -1089,8 +1095,14 @@ static SEXP wideint_binary(ARITHOP_TYPE code, SEXP s1, SEXP s2, SEXP lcall)
 			pa[i] = 1.;
 		    else if (x1 == NA_INTEGER64 || x2 == NA_INTEGER64)
 			pa[i] = NA_REAL;
-		    else
+		    else {
+			if (x1 > R_WIDEINT_DBL_EXACT ||
+			    x1 < -R_WIDEINT_DBL_EXACT ||
+			    x2 > R_WIDEINT_DBL_EXACT ||
+			    x2 < -R_WIDEINT_DBL_EXACT)
+			    precflag = true;
 			pa[i] = R_POW((double) x1, (double) x2);
+		    }
 		});
 	}
 	break;
@@ -1128,6 +1140,8 @@ static SEXP wideint_binary(ARITHOP_TYPE code, SEXP s1, SEXP s2, SEXP lcall)
 
     if (naflag)
 	warningcall(lcall, WIDEINT_OVERFLOW_WARNING);
+    if (precflag)
+	warningcall(lcall, _("coercing wide integers above 2^53 loses precision"));
 
     UNPROTECT(1);
 

--- a/src/main/arithmetic.c
+++ b/src/main/arithmetic.c
@@ -1031,7 +1031,7 @@ static SEXP wideint_binary(ARITHOP_TYPE code, SEXP s1, SEXP s2, SEXP lcall)
 		R_wideint_t r;
 		if (x1 == NA_INTEGER64 || x2 == NA_INTEGER64)
 		    r = NA_INTEGER64;
-		else if (__builtin_add_overflow(x1, x2, &r) ||
+		else if (R_ovf_add(x1, x2, &r) ||
 			 r == NA_INTEGER64) {
 		    r = NA_INTEGER64; naflag = true;
 		}
@@ -1045,7 +1045,7 @@ static SEXP wideint_binary(ARITHOP_TYPE code, SEXP s1, SEXP s2, SEXP lcall)
 		R_wideint_t r;
 		if (x1 == NA_INTEGER64 || x2 == NA_INTEGER64)
 		    r = NA_INTEGER64;
-		else if (__builtin_sub_overflow(x1, x2, &r) ||
+		else if (R_ovf_sub(x1, x2, &r) ||
 			 r == NA_INTEGER64) {
 		    r = NA_INTEGER64; naflag = true;
 		}
@@ -1059,7 +1059,7 @@ static SEXP wideint_binary(ARITHOP_TYPE code, SEXP s1, SEXP s2, SEXP lcall)
 		R_wideint_t r;
 		if (x1 == NA_INTEGER64 || x2 == NA_INTEGER64)
 		    r = NA_INTEGER64;
-		else if (__builtin_mul_overflow(x1, x2, &r) ||
+		else if (R_ovf_mul(x1, x2, &r) ||
 			 r == NA_INTEGER64) {
 		    r = NA_INTEGER64; naflag = true;
 		}

--- a/src/main/array.c
+++ b/src/main/array.c
@@ -173,7 +173,7 @@ attribute_hidden SEXP do_matrix(SEXP call, SEXP op, SEXP args, SEXP rho)
 #endif
 
     if (R_isWideInteger(vals)) {
-	PROTECT(ans = allocWideIntVector((R_xlen_t) nr * nc));
+	PROTECT(ans = R_allocWideIntVector((R_xlen_t) nr * nc));
 	SEXP dim = allocVector(INTSXP, 2);
 	INTEGER(dim)[0] = nr; INTEGER(dim)[1] = nc;
 	setAttrib(ans, R_DimSymbol, dim);

--- a/src/main/array.c
+++ b/src/main/array.c
@@ -172,7 +172,14 @@ attribute_hidden SEXP do_matrix(SEXP call, SEXP op, SEXP args, SEXP rho)
 	error(_("too many elements specified"));
 #endif
 
-    PROTECT(ans = allocMatrix(TYPEOF(vals), nr, nc));
+    if (R_isWideInteger(vals)) {
+	PROTECT(ans = allocWideIntVector((R_xlen_t) nr * nc));
+	SEXP dim = allocVector(INTSXP, 2);
+	INTEGER(dim)[0] = nr; INTEGER(dim)[1] = nc;
+	setAttrib(ans, R_DimSymbol, dim);
+    }
+    else
+	PROTECT(ans = allocMatrix(TYPEOF(vals), nr, nc));
     if(lendat)
 	copyMatrix(ans, vals, byrow);
     else { /* fill with NAs */
@@ -187,6 +194,11 @@ attribute_hidden SEXP do_matrix(SEXP call, SEXP op, SEXP args, SEXP rho)
 		LOGICAL(ans)[i] = NA_LOGICAL;
 	    break;
 	case INTSXP:
+	    if (R_isWideInteger(ans)) {
+		for (i = 0; i < N; i++)
+		    WIDEINT_PTR(ans)[i] = NA_INTEGER64;
+		break;
+	    }
 	    for (i = 0; i < N; i++)
 		INTEGER(ans)[i] = NA_INTEGER;
 	    break;

--- a/src/main/bind.c
+++ b/src/main/bind.c
@@ -1447,6 +1447,14 @@ static SEXP cbind(SEXP call, SEXP args, SEXPTYPE mode, SEXP rho,
 			    n += idx;
 			}
 		    }
+		    else if (R_isWideInteger(u)) {
+			R_xlen_t i, i1;
+			MOD_ITERATE1(idx, k, i, i1, {
+			    R_wideint_t v = INTEGER64_ELT(u, i1);
+			    REAL(result)[n++] =
+				(v == NA_INTEGER64) ? NA_REAL : (double) v;
+			});
+		    }
 		    else {
 			R_xlen_t i, i1;
 			MOD_ITERATE1(idx, k, i, i1, {

--- a/src/main/bind.c
+++ b/src/main/bind.c
@@ -878,7 +878,7 @@ attribute_hidden SEXP do_c_dflt(SEXP call, SEXP op, SEXP args, SEXP env)
     /* the arguments filling in values of the returned object. */
 
     if (mode == INTSXP && data.ans_wide)
-	PROTECT(ans = allocWideIntVector(data.ans_length));
+	PROTECT(ans = R_allocWideIntVector(data.ans_length));
     else
 	PROTECT(ans = allocVector(mode, data.ans_length));
     data.ans_ptr = ans;
@@ -1006,7 +1006,7 @@ attribute_hidden SEXP do_unlist(SEXP call, SEXP op, SEXP args, SEXP env)
     /* the arguments filling in values of the returned object. */
 
     if (mode == INTSXP && data.ans_wide)
-	PROTECT(ans = allocWideIntVector(data.ans_length));
+	PROTECT(ans = R_allocWideIntVector(data.ans_length));
     else
 	PROTECT(ans = allocVector(mode, data.ans_length));
     data.ans_ptr = ans;
@@ -1332,7 +1332,7 @@ static SEXP cbind(SEXP call, SEXP args, SEXPTYPE mode, SEXP rho,
 		break;
 	    }
     if (anyWideBind) {
-	PROTECT(result = allocWideIntVector((R_xlen_t) rows * cols));
+	PROTECT(result = R_allocWideIntVector((R_xlen_t) rows * cols));
 	SEXP bdim = allocVector(INTSXP, 2);
 	INTEGER(bdim)[0] = rows; INTEGER(bdim)[1] = cols;
 	setAttrib(result, R_DimSymbol, bdim);
@@ -1640,7 +1640,7 @@ static SEXP rbind(SEXP call, SEXP args, SEXPTYPE mode, SEXP rho,
 		break;
 	    }
     if (anyWideBind) {
-	PROTECT(result = allocWideIntVector((R_xlen_t) rows * cols));
+	PROTECT(result = R_allocWideIntVector((R_xlen_t) rows * cols));
 	SEXP bdim = allocVector(INTSXP, 2);
 	INTEGER(bdim)[0] = rows; INTEGER(bdim)[1] = cols;
 	setAttrib(result, R_DimSymbol, bdim);

--- a/src/main/bind.c
+++ b/src/main/bind.c
@@ -189,6 +189,12 @@ ListAnswer(SEXP x, int recurse, struct BindData *data, SEXP call)
 	    LIST_ASSIGN(ScalarRaw(RAW(x)[i]));
 	break;
     case INTSXP:
+	if (R_isWideInteger(x)) {
+	    /* elements of a wide vector stay wide, as for subsetting */
+	    for (i = 0; i < XLENGTH(x); i++)
+		LIST_ASSIGN(ScalarWideInt(INTEGER64_ELT(x, i)));
+	    break;
+	}
 	for (i = 0; i < XLENGTH(x); i++)
 	    LIST_ASSIGN(ScalarInteger(INTEGER(x)[i]));
 	break;
@@ -461,6 +467,25 @@ ComplexAnswer(SEXP x, struct BindData *data, SEXP call)
 	}
 	break;
     case INTSXP:
+	if (R_isWideInteger(x)) {
+	    for (i = 0; i < XLENGTH(x); i++) {
+		R_wideint_t v = INTEGER64_ELT(x, i);
+		if (v == NA_INTEGER64) {
+		    COMPLEX(data->ans_ptr)[data->ans_length].r = NA_REAL;
+#ifdef NA_TO_COMPLEX_NA
+		    COMPLEX(data->ans_ptr)[data->ans_length].i = NA_REAL;
+#else
+		    COMPLEX(data->ans_ptr)[data->ans_length].i = 0.0;
+#endif
+		}
+		else {
+		    COMPLEX(data->ans_ptr)[data->ans_length].r = (double) v;
+		    COMPLEX(data->ans_ptr)[data->ans_length].i = 0.0;
+		}
+		data->ans_length++;
+	    }
+	    break;
+	}
 	for (i = 0; i < XLENGTH(x); i++) {
 	    xi = INTEGER(x)[i];
 	    if (xi == NA_INTEGER) {
@@ -1481,9 +1506,16 @@ static SEXP cbind(SEXP call, SEXP args, SEXPTYPE mode, SEXP rho,
 			});
 		    } else if (mode == INTSXP) {
 			R_xlen_t i, i1;
-			MOD_ITERATE1(idx, k, i, i1, {
-			    INTEGER(result)[n++] = (unsigned char) RAW(u)[i1];
-			});
+			if (R_isWideInteger(result)) {
+			    MOD_ITERATE1(idx, k, i, i1, {
+				WIDEINT_PTR(result)[n++] =
+				    (R_wideint_t)(unsigned char) RAW(u)[i1];
+			    });
+			} else {
+			    MOD_ITERATE1(idx, k, i, i1, {
+				INTEGER(result)[n++] = (unsigned char) RAW(u)[i1];
+			    });
+			}
 		    } else if (mode == REALSXP) {
 			R_xlen_t i, i1;
 			MOD_ITERATE1(idx, k, i, i1, {

--- a/src/main/bind.c
+++ b/src/main/bind.c
@@ -394,11 +394,17 @@ RealAnswer(SEXP x, struct BindData *data, SEXP call)
 	break;
     case INTSXP:
 	if (R_isWideInteger(x)) {
+	    bool prec = false;
 	    for (i = 0; i < XLENGTH(x); i++) {
 		R_wideint_t v = INTEGER64_ELT(x, i);
+		if (v != NA_INTEGER64 &&
+		    (v > R_WIDEINT_DBL_EXACT || v < -R_WIDEINT_DBL_EXACT))
+		    prec = true;
 		REAL(data->ans_ptr)[data->ans_length++] =
 		    v == NA_INTEGER64 ? NA_REAL : (double) v;
 	    }
+	    if (prec)
+		warning(_("coercing wide integers above 2^53 loses precision"));
 	    break;
 	}
 	for (i = 0; i < XLENGTH(x); i++) {
@@ -468,6 +474,7 @@ ComplexAnswer(SEXP x, struct BindData *data, SEXP call)
 	break;
     case INTSXP:
 	if (R_isWideInteger(x)) {
+	    bool prec = false;
 	    for (i = 0; i < XLENGTH(x); i++) {
 		R_wideint_t v = INTEGER64_ELT(x, i);
 		if (v == NA_INTEGER64) {
@@ -479,11 +486,15 @@ ComplexAnswer(SEXP x, struct BindData *data, SEXP call)
 #endif
 		}
 		else {
+		    if (v > R_WIDEINT_DBL_EXACT || v < -R_WIDEINT_DBL_EXACT)
+			prec = true;
 		    COMPLEX(data->ans_ptr)[data->ans_length].r = (double) v;
 		    COMPLEX(data->ans_ptr)[data->ans_length].i = 0.0;
 		}
 		data->ans_length++;
 	    }
+	    if (prec)
+		warning(_("coercing wide integers above 2^53 loses precision"));
 	    break;
 	}
 	for (i = 0; i < XLENGTH(x); i++) {
@@ -1474,11 +1485,18 @@ static SEXP cbind(SEXP call, SEXP args, SEXPTYPE mode, SEXP rho,
 		    }
 		    else if (R_isWideInteger(u)) {
 			R_xlen_t i, i1;
+			bool prec = false;
 			MOD_ITERATE1(idx, k, i, i1, {
 			    R_wideint_t v = INTEGER64_ELT(u, i1);
+			    if (v != NA_INTEGER64 &&
+				(v > R_WIDEINT_DBL_EXACT ||
+				 v < -R_WIDEINT_DBL_EXACT))
+				prec = true;
 			    REAL(result)[n++] =
 				(v == NA_INTEGER64) ? NA_REAL : (double) v;
 			});
+			if (prec)
+			    warning(_("coercing wide integers above 2^53 loses precision"));
 		    }
 		    else {
 			R_xlen_t i, i1;

--- a/src/main/bind.c
+++ b/src/main/bind.c
@@ -1324,7 +1324,21 @@ static SEXP cbind(SEXP call, SEXP args, SEXPTYPE mode, SEXP rho,
     if (mnames || nnames == rows)
 	have_rnames = true;
 
-    PROTECT(result = allocMatrix(mode, rows, cols));
+    bool anyWideBind = false;
+    if (mode == INTSXP)
+	for (t = args; t != R_NilValue; t = CDR(t))
+	    if (R_isWideInteger(PRVALUE(CAR(t)))) {
+		anyWideBind = true;
+		break;
+	    }
+    if (anyWideBind) {
+	PROTECT(result = allocWideIntVector((R_xlen_t) rows * cols));
+	SEXP bdim = allocVector(INTSXP, 2);
+	INTEGER(bdim)[0] = rows; INTEGER(bdim)[1] = cols;
+	setAttrib(result, R_DimSymbol, bdim);
+    }
+    else
+	PROTECT(result = allocMatrix(mode, rows, cols));
     R_xlen_t n = 0; // index, possibly of long vector
 
     if (mode == STRSXP) {
@@ -1411,9 +1425,27 @@ static SEXP cbind(SEXP call, SEXP args, SEXPTYPE mode, SEXP rho,
 		     * sometimes does.  But if cbind-ing a NULL, there
 		     * are zero rows and u is not a matrix, so nothing to do. */
 		    if (mode <= INTSXP) {
-			xcopyIntegerWithRecycle(INTEGER(result), INTEGER(u),
-						n, idx, k);
-			n += idx;
+			if (R_isWideInteger(result)) {
+			    if (k > 0) {
+				R_xlen_t i, i1;
+				MOD_ITERATE1(idx, k, i, i1, {
+				    R_wideint_t v;
+				    if (TYPEOF(u) == INTSXP)
+					v = INTEGER64_ELT(u, i1);
+				    else {
+					int lv = LOGICAL(u)[i1];
+					v = (lv == NA_LOGICAL)
+					    ? NA_INTEGER64 : (R_wideint_t) lv;
+				    }
+				    WIDEINT_PTR(result)[n++] = v;
+				});
+			    }
+			}
+			else {
+			    xcopyIntegerWithRecycle(INTEGER(result), INTEGER(u),
+						    n, idx, k);
+			    n += idx;
+			}
 		    }
 		    else {
 			R_xlen_t i, i1;
@@ -1600,7 +1632,21 @@ static SEXP rbind(SEXP call, SEXP args, SEXPTYPE mode, SEXP rho,
     if (mnames || nnames == cols)
 	have_cnames = true;
 
-    PROTECT(result = allocMatrix(mode, rows, cols));
+    bool anyWideBind = false;
+    if (mode == INTSXP)
+	for (t = args; t != R_NilValue; t = CDR(t))
+	    if (R_isWideInteger(PRVALUE(CAR(t)))) {
+		anyWideBind = true;
+		break;
+	    }
+    if (anyWideBind) {
+	PROTECT(result = allocWideIntVector((R_xlen_t) rows * cols));
+	SEXP bdim = allocVector(INTSXP, 2);
+	INTEGER(bdim)[0] = rows; INTEGER(bdim)[1] = cols;
+	setAttrib(result, R_DimSymbol, bdim);
+    }
+    else
+	PROTECT(result = allocMatrix(mode, rows, cols));
 
     R_xlen_t n = 0;
 
@@ -1665,7 +1711,13 @@ static SEXP rbind(SEXP call, SEXP args, SEXPTYPE mode, SEXP rho,
 		u = coerceVector(u, INTSXP);
 		R_xlen_t k = XLENGTH(u);
 		R_xlen_t idx = (isMatrix(u)) ? nrows(u) : (k > 0);
-		xfillIntegerMatrixWithRecycle(INTEGER(result), INTEGER(u), n, rows, idx,
+		if (R_isWideInteger(result)) {
+		    if (k > 0)
+			FILL_MATRIX_ITERATE(n, rows, idx, cols, k)
+			    WIDEINT_PTR(result)[didx] = INTEGER64_ELT(u, sidx);
+		}
+		else
+		    xfillIntegerMatrixWithRecycle(INTEGER(result), INTEGER(u), n, rows, idx,
 					  cols, k);
 		n += idx;
 	    }

--- a/src/main/bind.c
+++ b/src/main/bind.c
@@ -343,7 +343,7 @@ IntegerAnswer(SEXP x, struct BindData *data, SEXP call)
 	if (data->ans_wide) {
 	    for (i = 0; i < XLENGTH(x); i++)
 		SET_INTEGER64_ELT(data->ans_ptr, data->ans_length++,
-				  (long long) RAW(x)[i]);
+				  (R_wideint_t) RAW(x)[i]);
 	    break;
 	}
 	for (i = 0; i < XLENGTH(x); i++)
@@ -389,7 +389,7 @@ RealAnswer(SEXP x, struct BindData *data, SEXP call)
     case INTSXP:
 	if (R_isWideInteger(x)) {
 	    for (i = 0; i < XLENGTH(x); i++) {
-		long long v = INTEGER64_ELT(x, i);
+		R_wideint_t v = INTEGER64_ELT(x, i);
 		REAL(data->ans_ptr)[data->ans_length++] =
 		    v == NA_INTEGER64 ? NA_REAL : (double) v;
 	    }

--- a/src/main/bind.c
+++ b/src/main/bind.c
@@ -50,6 +50,7 @@ struct BindData {
  R_xlen_t ans_length;
  SEXP ans_names;
  R_xlen_t  ans_nnames;
+ int  ans_wide; /* some integer input is wide (64-bit) */
 /* int  deparse_level; Initialize to 1. */
 };
 
@@ -86,6 +87,8 @@ AnswerType(SEXP x, bool recurse, bool usenames, struct BindData *data, SEXP call
     case INTSXP:
 	data->ans_flags |= 16;
 	data->ans_length += XLENGTH(x);
+	if (R_isWideInteger(x))
+	    data->ans_wide = 1;
 	break;
     case REALSXP:
 	data->ans_flags |= 32;
@@ -315,14 +318,34 @@ IntegerAnswer(SEXP x, struct BindData *data, SEXP call)
 	    IntegerAnswer(VECTOR_ELT(x, i), data, call);
 	break;
     case LGLSXP:
+	if (data->ans_wide) {
+	    for (i = 0; i < XLENGTH(x); i++) {
+		int v = LOGICAL(x)[i];
+		SET_INTEGER64_ELT(data->ans_ptr, data->ans_length++,
+				  v == NA_LOGICAL ? NA_INTEGER64 : v);
+	    }
+	    break;
+	}
 	for (i = 0; i < XLENGTH(x); i++)
 	    INTEGER(data->ans_ptr)[data->ans_length++] = LOGICAL(x)[i];
 	break;
     case INTSXP:
+	if (data->ans_wide) {
+	    for (i = 0; i < XLENGTH(x); i++)
+		SET_INTEGER64_ELT(data->ans_ptr, data->ans_length++,
+				  INTEGER64_ELT(x, i));
+	    break;
+	}
 	for (i = 0; i < XLENGTH(x); i++)
 	    INTEGER(data->ans_ptr)[data->ans_length++] = INTEGER(x)[i];
 	break;
     case RAWSXP:
+	if (data->ans_wide) {
+	    for (i = 0; i < XLENGTH(x); i++)
+		SET_INTEGER64_ELT(data->ans_ptr, data->ans_length++,
+				  (long long) RAW(x)[i]);
+	    break;
+	}
 	for (i = 0; i < XLENGTH(x); i++)
 	    INTEGER(data->ans_ptr)[data->ans_length++] = (int)RAW(x)[i];
 	break;
@@ -364,6 +387,14 @@ RealAnswer(SEXP x, struct BindData *data, SEXP call)
 	}
 	break;
     case INTSXP:
+	if (R_isWideInteger(x)) {
+	    for (i = 0; i < XLENGTH(x); i++) {
+		long long v = INTEGER64_ELT(x, i);
+		REAL(data->ans_ptr)[data->ans_length++] =
+		    v == NA_INTEGER64 ? NA_REAL : (double) v;
+	    }
+	    break;
+	}
 	for (i = 0; i < XLENGTH(x); i++) {
 	    xi = INTEGER(x)[i];
 	    if (xi == NA_INTEGER)
@@ -818,6 +849,7 @@ attribute_hidden SEXP do_c_dflt(SEXP call, SEXP op, SEXP args, SEXP env)
     data.ans_flags  = 0;
     data.ans_length = 0;
     data.ans_nnames = 0;
+    data.ans_wide   = 0;
 
     SEXP t, ans;
     for (t = args; t != R_NilValue; t = CDR(t)) {
@@ -845,7 +877,10 @@ attribute_hidden SEXP do_c_dflt(SEXP call, SEXP op, SEXP args, SEXP env)
     /* Allocate the return value and set up to pass through */
     /* the arguments filling in values of the returned object. */
 
-    PROTECT(ans = allocVector(mode, data.ans_length));
+    if (mode == INTSXP && data.ans_wide)
+	PROTECT(ans = allocWideIntVector(data.ans_length));
+    else
+	PROTECT(ans = allocVector(mode, data.ans_length));
     data.ans_ptr = ans;
     data.ans_length = 0;
     t = args;
@@ -926,6 +961,7 @@ attribute_hidden SEXP do_unlist(SEXP call, SEXP op, SEXP args, SEXP env)
     data.ans_flags  = 0;
     data.ans_length = 0;
     data.ans_nnames = 0;
+    data.ans_wide   = 0;
 
     if (isNewList(args)) {
 	n = xlength(args);
@@ -969,7 +1005,10 @@ attribute_hidden SEXP do_unlist(SEXP call, SEXP op, SEXP args, SEXP env)
     /* Allocate the return value and set up to pass through */
     /* the arguments filling in values of the returned object. */
 
-    PROTECT(ans = allocVector(mode, data.ans_length));
+    if (mode == INTSXP && data.ans_wide)
+	PROTECT(ans = allocWideIntVector(data.ans_length));
+    else
+	PROTECT(ans = allocVector(mode, data.ans_length));
     data.ans_ptr = ans;
     data.ans_length = 0;
     t = args;
@@ -1138,6 +1177,7 @@ attribute_hidden SEXP do_bind(SEXP call, SEXP op, SEXP args, SEXP env)
     data.ans_flags = 0;
     data.ans_length = 0;
     data.ans_nnames = 0;
+    data.ans_wide = 0;
     for (SEXP t = args; t != R_NilValue; t = CDR(t))
 	AnswerType(PRVALUE(CAR(t)), 0, 0, &data, call);
 

--- a/src/main/coerce.c
+++ b/src/main/coerce.c
@@ -1175,6 +1175,10 @@ SEXP coerceVector(SEXP v, SEXPTYPE type)
     if (TYPEOF(v) == type)
 	return v;
 
+    /* wide integer vectors need 64-bit element access */
+    if (R_isWideInteger(v))
+	return R_wideIntCoerce(v, type);
+
     SEXP ans = R_NilValue;	/* -Wall */
     if (ALTREP(v)) {
 	PROTECT(v); /* the methods should protect, but ... */
@@ -2290,6 +2294,11 @@ attribute_hidden SEXP do_isna(SEXP call, SEXP op, SEXP args, SEXP rho)
 	   pa[i] = (LOGICAL_ELT(x, i) == NA_LOGICAL);
 	break;
     case INTSXP:
+	if (R_isWideInteger(x)) {
+	    for (i = 0; i < n; i++)
+		pa[i] = (INTEGER64_ELT(x, i) == NA_INTEGER64);
+	    break;
+	}
 	for (i = 0; i < n; i++)
 	    pa[i] = (INTEGER_ELT(x, i) == NA_INTEGER);
 	break;

--- a/src/main/coerce.c
+++ b/src/main/coerce.c
@@ -2433,6 +2433,12 @@ static bool anyNA(SEXP call, SEXP op, SEXP args, SEXP env)
     }
     case INTSXP:
     {
+	if (R_isWideInteger(x)) {
+	    for (i = 0; i < n; i++)
+		if (INTEGER64_ELT(x, i) == NA_INTEGER64)
+		    return true;
+	    break;
+	}
 	if(INTEGER_NO_NA(x))
 	    return false;
 	ITERATE_BY_REGION(x, xI, i, nbatch, int, INTEGER, {

--- a/src/main/coerce.c
+++ b/src/main/coerce.c
@@ -1953,7 +1953,12 @@ double asReal(SEXP x)
 	case INTSXP:
 	    if (R_isWideInteger(x)) {
 		R_wideint_t v = INTEGER64_ELT(x, 0);
-		return v == NA_INTEGER64 ? NA_REAL : (double) v;
+		if (v == NA_INTEGER64)
+		    return NA_REAL;
+		/* keep scalar coercion consistent with R_wideIntCoerce */
+		if (v > R_WIDEINT_DBL_EXACT || v < -R_WIDEINT_DBL_EXACT)
+		    warning(_("coercing wide integers above 2^53 loses precision"));
+		return (double) v;
 	    }
 	    res = RealFromInteger(INTEGER_ELT(x, 0), &warn);
 	    CoercionWarning(warn);

--- a/src/main/coerce.c
+++ b/src/main/coerce.c
@@ -1863,6 +1863,15 @@ int asInteger(SEXP x)
 	case LGLSXP:
 	    return IntegerFromLogical(LOGICAL_ELT(x, 0), &warn);
 	case INTSXP:
+	    if (R_isWideInteger(x)) {
+		R_wideint_t v = INTEGER64_ELT(x, 0);
+		if (v == NA_INTEGER64)
+		    return NA_INTEGER;
+		if (v > INT_MIN && v <= INT_MAX)
+		    return (int) v;
+		CoercionWarning(WARN_INT_NA); /* out of 32-bit range */
+		return NA_INTEGER;
+	    }
 	    return INTEGER_ELT(x, 0);
 	case REALSXP:
 	    res = IntegerFromReal(REAL_ELT(x, 0), &warn);
@@ -1896,6 +1905,12 @@ R_xlen_t asXLength(SEXP x)
 	switch (TYPEOF(x)) {
 	case INTSXP:
 	{
+	    if (R_isWideInteger(x)) {
+		R_wideint_t v = INTEGER64_ELT(x, 0);
+		if (v == NA_INTEGER64 || v < 0 || v > R_XLEN_T_MAX)
+		    return na;
+		return (R_xlen_t) v;
+	    }
 	    int res = INTEGER_ELT(x, 0);
 	    if (res == NA_INTEGER)
 		return na;
@@ -1932,6 +1947,10 @@ double asReal(SEXP x)
 	    CoercionWarning(warn);
 	    return res;
 	case INTSXP:
+	    if (R_isWideInteger(x)) {
+		R_wideint_t v = INTEGER64_ELT(x, 0);
+		return v == NA_INTEGER64 ? NA_REAL : (double) v;
+	    }
 	    res = RealFromInteger(INTEGER_ELT(x, 0), &warn);
 	    CoercionWarning(warn);
 	    return res;

--- a/src/main/coerce.c
+++ b/src/main/coerce.c
@@ -1794,6 +1794,10 @@ attribute_hidden int asLogical2(SEXP x, int checking, SEXP call)
 	case LGLSXP:
 	    return LOGICAL_ELT(x, 0);
 	case INTSXP:
+	    if (R_isWideInteger(x)) {
+		R_wideint_t v = INTEGER64_ELT(x, 0);
+		return (v == NA_INTEGER64) ? NA_LOGICAL : (v != 0);
+	    }
 	    return LogicalFromInteger(INTEGER_ELT(x, 0), &warn);
 	case REALSXP:
 	    return LogicalFromReal(REAL_ELT(x, 0), &warn);

--- a/src/main/cum.c
+++ b/src/main/cum.c
@@ -262,7 +262,7 @@ attribute_hidden SEXP do_cum(SEXP call, SEXP op, SEXP args, SEXP env)
 		R_wideint_t v = INTEGER64_ELT(t, i);
 		if (v == NA_INTEGER64)
 		    break;
-		if (__builtin_add_overflow(sum, v, &sum) ||
+		if (R_ovf_add(sum, v, &sum) ||
 		    sum == NA_INTEGER64) {
 		    warning(_("integer overflow in 'cumsum'; use 'cumsum(as.numeric(.))'"));
 		    break;

--- a/src/main/cum.c
+++ b/src/main/cum.c
@@ -241,6 +241,54 @@ attribute_hidden SEXP do_cum(SEXP call, SEXP op, SEXP args, SEXP env)
 	default:
 	    errorcall(call, "unknown cumxxx function");
 	}
+    } else if (R_isWideInteger(CAR(args)) &&
+	       (PRIMVAL(op) != 2 && PRIMVAL(op) != 5)) {
+	t = CAR(args);
+	PROTECT(t);
+	n = XLENGTH(t);
+	PROTECT(s = allocWideIntVector(n));
+	setAttrib(s, R_NamesSymbol, getAttrib(t, R_NamesSymbol));
+	if(n == 0) {
+	    UNPROTECT(2); /* t, s */
+	    return s;
+	}
+	for(i = 0 ; i < n ; i++)
+	    WIDEINT_PTR(s)[i] = NA_INTEGER64;
+
+	switch (PRIMVAL(op)) {
+	case 1: { /* cumsum */
+	    R_wideint_t sum = 0;
+	    for(i = 0 ; i < n ; i++) {
+		R_wideint_t v = INTEGER64_ELT(t, i);
+		if (v == NA_INTEGER64)
+		    break;
+		if (__builtin_add_overflow(sum, v, &sum) ||
+		    sum == NA_INTEGER64) {
+		    warning(_("integer overflow in 'cumsum'; use 'cumsum(as.numeric(.))'"));
+		    break;
+		}
+		WIDEINT_PTR(s)[i] = sum;
+	    }
+	    break;
+	}
+	case 3: /* cummax */
+	case 4: { /* cummin */
+	    R_wideint_t m = 0;
+	    for(i = 0 ; i < n ; i++) {
+		R_wideint_t v = INTEGER64_ELT(t, i);
+		if (v == NA_INTEGER64)
+		    break;
+		if (i == 0 || (PRIMVAL(op) == 3 ? v > m : v < m))
+		    m = v;
+		WIDEINT_PTR(s)[i] = m;
+	    }
+	    break;
+	}
+	default:
+	    errorcall(call, _("unknown cumxxx function"));
+	}
+	UNPROTECT(2); /* t, s */
+	return s;
     } else if( ( isInteger(CAR(args)) || isLogical(CAR(args)) ) &&
 	       (PRIMVAL(op) != 2 && PRIMVAL(op) != 5)) {
 	PROTECT(t = coerceVector(CAR(args), INTSXP));

--- a/src/main/cum.c
+++ b/src/main/cum.c
@@ -246,7 +246,7 @@ attribute_hidden SEXP do_cum(SEXP call, SEXP op, SEXP args, SEXP env)
 	t = CAR(args);
 	PROTECT(t);
 	n = XLENGTH(t);
-	PROTECT(s = allocWideIntVector(n));
+	PROTECT(s = R_allocWideIntVector(n));
 	setAttrib(s, R_NamesSymbol, getAttrib(t, R_NamesSymbol));
 	if(n == 0) {
 	    UNPROTECT(2); /* t, s */

--- a/src/main/deparse.c
+++ b/src/main/deparse.c
@@ -1631,7 +1631,7 @@ static void vector2buff(SEXP vector, LocalParseData *d)
 	quote = isString(vector) ? '"' : 0;
     bool surround = false, allNA,
 	intSeq = false; // := true iff integer sequence 'm:n' (up *or* down)
-    if(TYPEOF(vector) == INTSXP && tlen > 1) {
+    if(TYPEOF(vector) == INTSXP && !R_isWideInteger(vector) && tlen > 1) {
 	int *vec = INTEGER(vector);
 	// vec[1] - vec[0] could overflow, and does in package Rmpfr
 	double d_i = (double) vec[1] - (double)vec[0];
@@ -1682,6 +1682,28 @@ static void vector2buff(SEXP vector, LocalParseData *d)
 	case RAWSXP: print2buff("raw(0)", d); break;
 	default: UNIMPLEMENTED_TYPE("vector2buff", vector);
 	}
+    }
+    else if(TYPEOF(vector) == INTSXP && R_isWideInteger(vector)) {
+	/* wide integers deparse as L literals, which the parser now
+	   widens on 32-bit overflow; values round-trip exactly, and
+	   width (narrow vs wide storage) deliberately does not */
+	if(need_c) print2buff("c(", d);
+	for (i = 0; i < tlen; i++) {
+	    if(do_names) // put '<tag> = '
+		deparse2buf_name(nv, i, d);
+	    R_wideint_t v = INTEGER64_ELT(vector, i);
+	    if(v == NA_INTEGER64)
+		print2buff("NA_integer_", d);
+	    else {
+		char wbuf[24];
+		snprintf(wbuf, sizeof(wbuf), "%lldL", (long long) v);
+		print2buff(wbuf, d);
+	    }
+	    if (i < (tlen - 1)) print2buff(", ", d);
+	    if (tlen > 1 && d->len > d->cutoff) writeline(d);
+	    if (!d->active) break;
+	}
+	if(need_c) print2buff(")", d);
     }
     else if(TYPEOF(vector) == INTSXP) {
 	/* We treat integer separately, as S_compatible is relevant.

--- a/src/main/duplicate.c
+++ b/src/main/duplicate.c
@@ -348,7 +348,7 @@ static SEXP duplicate1(SEXP s, Rboolean deep)
 	if (IS_WIDEINT(s)) {
 	    n = XLENGTH(s);
 	    PROTECT(s);
-	    PROTECT(t = allocWideIntVector(n));
+	    PROTECT(t = R_allocWideIntVector(n));
 	    if (n > 0)
 		memcpy(STDVEC_DATAPTR(t), STDVEC_DATAPTR(s),
 		       n * sizeof(R_wideint_t));

--- a/src/main/duplicate.c
+++ b/src/main/duplicate.c
@@ -410,6 +410,12 @@ void copyVector(SEXP s, SEXP t)
 	xcopyLogicalWithRecycle(LOGICAL(s), LOGICAL_RO(t), 0, ns, nt);
 	break;
     case INTSXP:
+	if (R_isWideInteger(s) || R_isWideInteger(t)) {
+	    if (nt > 0)
+		for (R_xlen_t i = 0; i < ns; i++)
+		    SET_INTEGER64_ELT(s, i, INTEGER64_ELT(t, i % nt));
+	    break;
+	}
 	xcopyIntegerWithRecycle(INTEGER(s), INTEGER_RO(t), 0, ns, nt);
 	break;
     case REALSXP:
@@ -483,6 +489,11 @@ void copyMatrix(SEXP s, SEXP t, Rboolean byrow)
 		LOGICAL(s)[didx] = LOGICAL(t)[sidx];
 	    break;
 	case INTSXP:
+	    if (R_isWideInteger(s) || R_isWideInteger(t)) {
+		FILL_MATRIX_BYROW_ITERATE(0, nr, nc, nt)
+		    SET_INTEGER64_ELT(s, didx, INTEGER64_ELT(t, sidx));
+		break;
+	    }
 	    FILL_MATRIX_BYROW_ITERATE(0, nr, nc, nt)
 		INTEGER(s)[didx] = INTEGER(t)[sidx];
 	    break;

--- a/src/main/duplicate.c
+++ b/src/main/duplicate.c
@@ -351,7 +351,7 @@ static SEXP duplicate1(SEXP s, Rboolean deep)
 	    PROTECT(t = allocWideIntVector(n));
 	    if (n > 0)
 		memcpy(STDVEC_DATAPTR(t), STDVEC_DATAPTR(s),
-		       n * sizeof(long long));
+		       n * sizeof(R_wideint_t));
 	    DUPLICATE_ATTRIB(t, s, deep);
 	    COPY_TRUELENGTH(t, s);
 	    UNPROTECT(2);

--- a/src/main/duplicate.c
+++ b/src/main/duplicate.c
@@ -344,7 +344,20 @@ static SEXP duplicate1(SEXP s, Rboolean deep)
 	UNPROTECT(2);
 	break;
     case LGLSXP: DUPLICATE_ATOMIC_VECTOR(int, LOGICAL, LOGICAL_RO, t, s, deep); break;
-    case INTSXP: DUPLICATE_ATOMIC_VECTOR(int, INTEGER, INTEGER_RO, t, s, deep); break;
+    case INTSXP:
+	if (IS_WIDEINT(s)) {
+	    n = XLENGTH(s);
+	    PROTECT(s);
+	    PROTECT(t = allocWideIntVector(n));
+	    if (n > 0)
+		memcpy(STDVEC_DATAPTR(t), STDVEC_DATAPTR(s),
+		       n * sizeof(long long));
+	    DUPLICATE_ATTRIB(t, s, deep);
+	    COPY_TRUELENGTH(t, s);
+	    UNPROTECT(2);
+	    break;
+	}
+	DUPLICATE_ATOMIC_VECTOR(int, INTEGER, INTEGER_RO, t, s, deep); break;
     case REALSXP: DUPLICATE_ATOMIC_VECTOR(double, REAL, REAL_RO, t, s, deep); break;
     case CPLXSXP: DUPLICATE_ATOMIC_VECTOR(Rcomplex, COMPLEX, COMPLEX_RO, t, s, deep); break;
     case RAWSXP: DUPLICATE_ATOMIC_VECTOR(Rbyte, RAW, RAW_RO, t, s, deep); break;

--- a/src/main/eval.c
+++ b/src/main/eval.c
@@ -2850,6 +2850,10 @@ attribute_hidden SEXP do_for(SEXP call, SEXP op, SEXP args, SEXP rho)
 		SET_SCALAR_LVAL(v, LOGICAL_ELT(val, i));
 		break;
 	    case INTSXP:
+		if (R_isWideInteger(val)) {
+		    REPROTECT(v = ScalarWideInt(INTEGER64_ELT(val, i)), vpi);
+		    break;
+		}
 		ALLOC_LOOP_VAR(v, val_type, vpi);
 		SET_SCALAR_IVAL(v, INTEGER_ELT(val, i));
 		break;

--- a/src/main/eval.c
+++ b/src/main/eval.c
@@ -6336,6 +6336,7 @@ static R_INLINE SEXP mkVector1(SEXP s)
 	    return;						\
 	case INTSXP:						\
 	    if (i < 0 || XLENGTH(vec) <= i) break;		\
+	    if (R_isWideInteger(vec)) break; /* use default handler */	\
 	    SETSTACK_INTEGER_PTR(sv, INTEGER_ELT(vec, i));	\
 	    return;						\
 	case LGLSXP:						\
@@ -6411,6 +6412,7 @@ static R_INLINE void VECSUBSET_PTR(SEXP vec, R_bcstack_t *si,
 		    DFVE_NEXT();					\
 		case INTSXP:						\
 		    if (i <= 0 || XLENGTH(vec) < i) break;		\
+		    if (R_isWideInteger(vec)) break; /* default handler */ \
 		    SETSTACK_INTEGER_PTR(sx, INTEGER_ELT(vec, i - 1));	\
 		    DFVE_NEXT();					\
 		case LGLSXP:						\
@@ -7758,6 +7760,11 @@ static SEXP bcEval_loop(struct bcEval_locals *ploc)
 	    SET_FOR_LOOP_VAR(value, cell, loopinfo, rho);
 	    NEXT();
 	  case INTSXP:
+	    if (R_isWideInteger(seq)) {
+		value = ScalarWideInt(INTEGER64_ELT(seq, i));
+		SET_FOR_LOOP_VAR(value, cell, loopinfo, rho);
+		NEXT();
+	    }
 	    if (BNDCELL_TAG_WR(cell) == INTSXP) {
 		SET_BNDCELL_IVAL(cell, INTEGER_ELT(seq, i));
 		NEXT();

--- a/src/main/eval.c
+++ b/src/main/eval.c
@@ -1356,6 +1356,13 @@ static R_exprhash_t hashexpr1(SEXP e, R_exprhash_t h)
 	return h;
     case INTSXP:
 	SKIP_NONSCALAR;
+	if (R_isWideInteger(e)) {
+	    for (int i = 0; i < len; i++) {
+		R_wideint_t wval = INTEGER64_ELT(e, i);
+		h = HASH(wval, h);
+	    }
+	    return h;
+	}
 	for (int i = 0; i < len; i++) {
 	    int ival = INTEGER(e)[i];
 	    h = HASH(ival, h);
@@ -2668,7 +2675,13 @@ static R_INLINE Rboolean asLogicalNoNA(SEXP s, SEXP call)
 	    cond = LOGICAL(s)[0];
 	    break;
 	case INTSXP:
-	    cond = INTEGER(s)[0]; /* relies on NA_INTEGER == NA_LOGICAL */
+	    if (R_isWideInteger(s)) {
+		/* only nonzero-ness matters, so avoid the 32-bit narrowing
+		   that would error on a large wide value */
+		R_wideint_t wv = INTEGER64_ELT(s, 0);
+		cond = (wv == NA_INTEGER64) ? NA_LOGICAL : (wv != 0);
+	    } else
+		cond = INTEGER(s)[0]; /* relies on NA_INTEGER == NA_LOGICAL */
 	    break;
 	default:
 	    cond = asLogical(s);
@@ -6594,6 +6607,7 @@ static R_INLINE Rboolean setElementFromScalar(SEXP vec, R_xlen_t i,
 	switch(v->tag) {
 	case INTSXP:
 	    if (XLENGTH(vec) <= i) return FALSE;
+	    if (R_isWideInteger(vec)) return FALSE; /* default handler widens */
 	    INTEGER(vec)[i] = v->u.ival;
 	    return TRUE;
 	case LGLSXP:
@@ -6681,6 +6695,7 @@ static R_INLINE void VECSUBASSIGN_PTR(SEXP vec, R_bcstack_t *srhs,
 		    REAL(vec)[i - 1] = srhs->u.dval;			\
 		    DFVA_NEXT(sx, vec);					\
 		case INTSXP:						\
+		    if (R_isWideInteger(vec)) break; /* default handler */ \
 		    INTEGER(vec)[i - 1] = srhs->u.ival;			\
 		    DFVA_NEXT(sx, vec);					\
 		case LGLSXP:						\

--- a/src/main/gram.c
+++ b/src/main/gram.c
@@ -96,6 +96,8 @@
 #define R_USE_SIGNALS 1
 #include "IOStuff.h"		/*-> Defn.h */
 #include "Fileio.h"
+#include <errno.h>
+#include <stdlib.h>
 #include "Parse.h"
 #include <R_ext/Print.h>
 
@@ -4974,29 +4976,56 @@ static int NumericValue(int c)
 	
     YYTEXT_PUSH('\0', yyp);    
     /* Make certain that things are okay. */
+    int asWide = 0;
+    R_wideint_t wideval = 0;
     if(c == 'L') {
 	double a = R_atof(yytext);
 	int b = (int) a;
 	/* We are asked to create an integer via the L, so we check that the
-	   double and int values are the same. If not, this is a problem and we
-	   will not lose information and so use the numeric value.
+	   double and int values are the same. If not, we try a wide (64-bit)
+	   integer before falling back to the numeric value.
 	*/
 	if(a != (double) b) {
-	    if(GenerateCode) {
-		if(seendot == 1 && seenexp == 0)
-		    warning(_("integer literal %s contains decimal; using numeric value"), yytext);
-		else {
-		    /* hide the L for the warning message */
-		    warning(_("non-integer value %s qualified with L; using numeric value"), yytext);
+	    if(seendot == 0 && seenexp == 0) {
+		/* parse the digits directly: above 2^53 the double
+		   value is no longer exact */
+		char *endp;
+		errno = 0;
+		long long v =
+		    (yytext[0] == '0' && (yytext[1] == 'x' || yytext[1] == 'X'))
+		    ? strtoll(yytext, &endp, 16)
+		    : strtoll(yytext, &endp, 10);
+		if(errno == 0 && (*endp == '\0' ||
+				   (*endp == 'L' && endp[1] == '\0'))) {
+		    asWide = 1;
+		    wideval = (R_wideint_t) v;
 		}
 	    }
-	    asNumeric = 1;
-	    seenexp = 1;
+	    else if(seenexp == 1 && seendot != 1 &&
+		    a < 9223372036854775808.0 /* 2^63 */ &&
+		    a == (double)(R_wideint_t) a) {
+		asWide = 1;
+		wideval = (R_wideint_t) a;
+	    }
+	    if(!asWide) {
+		if(GenerateCode) {
+		    if(seendot == 1 && seenexp == 0)
+			warning(_("integer literal %s contains decimal; using numeric value"), yytext);
+		    else {
+			/* hide the L for the warning message */
+			warning(_("non-integer value %s qualified with L; using numeric value"), yytext);
+		    }
+		}
+		asNumeric = 1;
+		seenexp = 1;
+	    }
 	}
     }
 
     if(c == 'i') {
 	yylval = GenerateCode ? mkComplex(yytext) : R_NilValue;
+    } else if(c == 'L' && asWide) {
+	yylval = GenerateCode ? ScalarWideInt(wideval) : R_NilValue;
     } else if(c == 'L' && asNumeric == 0) {
 	if(GenerateCode && seendot == 1 && seenexp == 0)
 	    warning(_("integer literal %s contains unnecessary decimal point"), yytext);

--- a/src/main/gram.c
+++ b/src/main/gram.c
@@ -5002,7 +5002,7 @@ static int NumericValue(int c)
 		}
 	    }
 	    else if(seenexp == 1 && seendot != 1 &&
-		    a < 9223372036854775808.0 /* 2^63 */ &&
+		    a < R_WIDEINT_DBL_MAX &&
 		    a == (double)(R_wideint_t) a) {
 		asWide = 1;
 		wideval = (R_wideint_t) a;

--- a/src/main/gram.y
+++ b/src/main/gram.y
@@ -28,6 +28,8 @@
 #define R_USE_SIGNALS 1
 #include "IOStuff.h"		/*-> Defn.h */
 #include "Fileio.h"
+#include <errno.h>
+#include <stdlib.h>
 #include "Parse.h"
 #include <R_ext/Print.h>
 
@@ -2665,29 +2667,56 @@ static int NumericValue(int c)
 	
     YYTEXT_PUSH('\0', yyp);    
     /* Make certain that things are okay. */
+    int asWide = 0;
+    R_wideint_t wideval = 0;
     if(c == 'L') {
 	double a = R_atof(yytext);
 	int b = (int) a;
 	/* We are asked to create an integer via the L, so we check that the
-	   double and int values are the same. If not, this is a problem and we
-	   will not lose information and so use the numeric value.
+	   double and int values are the same. If not, we try a wide (64-bit)
+	   integer before falling back to the numeric value.
 	*/
 	if(a != (double) b) {
-	    if(GenerateCode) {
-		if(seendot == 1 && seenexp == 0)
-		    warning(_("integer literal %s contains decimal; using numeric value"), yytext);
-		else {
-		    /* hide the L for the warning message */
-		    warning(_("non-integer value %s qualified with L; using numeric value"), yytext);
+	    if(seendot == 0 && seenexp == 0) {
+		/* parse the digits directly: above 2^53 the double
+		   value is no longer exact */
+		char *endp;
+		errno = 0;
+		long long v =
+		    (yytext[0] == '0' && (yytext[1] == 'x' || yytext[1] == 'X'))
+		    ? strtoll(yytext, &endp, 16)
+		    : strtoll(yytext, &endp, 10);
+		if(errno == 0 && (*endp == '\0' ||
+				   (*endp == 'L' && endp[1] == '\0'))) {
+		    asWide = 1;
+		    wideval = (R_wideint_t) v;
 		}
 	    }
-	    asNumeric = 1;
-	    seenexp = 1;
+	    else if(seenexp == 1 && seendot != 1 &&
+		    a < 9223372036854775808.0 /* 2^63 */ &&
+		    a == (double)(R_wideint_t) a) {
+		asWide = 1;
+		wideval = (R_wideint_t) a;
+	    }
+	    if(!asWide) {
+		if(GenerateCode) {
+		    if(seendot == 1 && seenexp == 0)
+			warning(_("integer literal %s contains decimal; using numeric value"), yytext);
+		    else {
+			/* hide the L for the warning message */
+			warning(_("non-integer value %s qualified with L; using numeric value"), yytext);
+		    }
+		}
+		asNumeric = 1;
+		seenexp = 1;
+	    }
 	}
     }
 
     if(c == 'i') {
 	yylval = GenerateCode ? mkComplex(yytext) : R_NilValue;
+    } else if(c == 'L' && asWide) {
+	yylval = GenerateCode ? ScalarWideInt(wideval) : R_NilValue;
     } else if(c == 'L' && asNumeric == 0) {
 	if(GenerateCode && seendot == 1 && seenexp == 0)
 	    warning(_("integer literal %s contains unnecessary decimal point"), yytext);

--- a/src/main/gram.y
+++ b/src/main/gram.y
@@ -2693,7 +2693,7 @@ static int NumericValue(int c)
 		}
 	    }
 	    else if(seenexp == 1 && seendot != 1 &&
-		    a < 9223372036854775808.0 /* 2^63 */ &&
+		    a < R_WIDEINT_DBL_MAX &&
 		    a == (double)(R_wideint_t) a) {
 		asWide = 1;
 		wideval = (R_wideint_t) a;

--- a/src/main/identical.c
+++ b/src/main/identical.c
@@ -234,6 +234,15 @@ R_compute_identical(SEXP x, SEXP y, int flags)
 		      xlength(x) * sizeof(int)) == 0 ? TRUE : FALSE;
     case INTSXP:
 	if (XLENGTH(x) != XLENGTH(y)) return FALSE;
+	if (R_isWideInteger(x) || R_isWideInteger(y)) {
+	    /* wide-ness is a storage property, not a value property:
+	       compare element values */
+	    R_xlen_t n = XLENGTH(x);
+	    for (R_xlen_t i = 0; i < n; i++)
+		if (INTEGER64_ELT(x, i) != INTEGER64_ELT(y, i))
+		    return FALSE;
+	    return TRUE;
+	}
 	/* Use memcmp (which is ISO C90) to speed up the comparison */
 	return memcmp((const void *)INTEGER_RO(x), (const void *)INTEGER_RO(y),
 		      xlength(x) * sizeof(int)) == 0 ? TRUE : FALSE;

--- a/src/main/memory.c
+++ b/src/main/memory.c
@@ -1119,7 +1119,7 @@ static R_INLINE R_size_t getVecSizeInVEC(SEXP s)
     case LGLSXP:
     case INTSXP:
 	if (IS_WIDEINT(s))
-	    size = XLENGTH(s) * sizeof(long long);
+	    size = XLENGTH(s) * sizeof(R_wideint_t);
 	else
 	    size = XLENGTH(s) * sizeof(int);
 	break;
@@ -4233,7 +4233,7 @@ SEXP allocWideIntVector(R_xlen_t length)
     return s;
 }
 
-long long INTEGER64_ELT(SEXP x, R_xlen_t i)
+R_wideint_t INTEGER64_ELT(SEXP x, R_xlen_t i)
 {
     if (TYPEOF(x) != INTSXP)
 	error("%s() can only be applied to a '%s', not a '%s'",
@@ -4242,10 +4242,10 @@ long long INTEGER64_ELT(SEXP x, R_xlen_t i)
 	return WIDEINT_PTR(x)[i];
 
     int v = INTEGER_ELT(x, i);
-    return v == NA_INTEGER ? NA_INTEGER64 : (long long) v;
+    return v == NA_INTEGER ? NA_INTEGER64 : (R_wideint_t) v;
 }
 
-void SET_INTEGER64_ELT(SEXP x, R_xlen_t i, long long v)
+void SET_INTEGER64_ELT(SEXP x, R_xlen_t i, R_wideint_t v)
 {
     if (TYPEOF(x) != INTSXP)
 	error("%s() can only be applied to a '%s', not a '%s'",
@@ -4260,22 +4260,24 @@ void SET_INTEGER64_ELT(SEXP x, R_xlen_t i, long long v)
     else if (v > INT_MIN && v <= INT_MAX)
 	SET_INTEGER_ELT(x, i, (int) v);
     else
-	error("value %lld cannot be stored in a narrow integer vector", v);
+	error("value %lld cannot be stored in a narrow integer vector",
+	      (long long) v);
 }
 
 int R_wideIntegerElt32(SEXP x, R_xlen_t i)
 {
-    long long v = WIDEINT_PTR(x)[i];
+    R_wideint_t v = WIDEINT_PTR(x)[i];
     if (v == NA_INTEGER64)
 	return NA_INTEGER;
     if (v > INT_MIN && v <= INT_MAX)
 	return (int) v;
-    error("wide integer value %lld out of range for a 32-bit access", v);
+    error("wide integer value %lld out of range for a 32-bit access",
+	  (long long) v);
 }
 
 void R_wideIntegerSetElt32(SEXP x, R_xlen_t i, int v)
 {
-    WIDEINT_PTR(x)[i] = (v == NA_INTEGER) ? NA_INTEGER64 : (long long) v;
+    WIDEINT_PTR(x)[i] = (v == NA_INTEGER) ? NA_INTEGER64 : (R_wideint_t) v;
 }
 
 int *(LOGICAL)(SEXP x) {

--- a/src/main/memory.c
+++ b/src/main/memory.c
@@ -4196,12 +4196,12 @@ NORET void R_wideIntPtrError(void)
     error("32-bit integer accessor applied to a wide (64-bit) integer vector");
 }
 
-/* allocWideIntVector borrows the REALSXP payload for its 8-byte
+/* R_allocWideIntVector borrows the REALSXP payload for its 8-byte
    elements */
 _Static_assert(sizeof(R_wideint_t) == sizeof(double),
 	       "wide integer elements must have the same size as double");
 
-SEXP allocWideIntVector(R_xlen_t length)
+SEXP R_allocWideIntVector(R_xlen_t length)
 {
     /* allocate with an 8-byte payload, then relabel; the node class
        and heap accounting are those of the REALSXP-sized payload */

--- a/src/main/memory.c
+++ b/src/main/memory.c
@@ -4189,38 +4189,17 @@ void *(STDVEC_DATAPTR)(SEXP x)
 void *DATAPTR_RW(SEXP x) { return DATAPTR(x); }
 
 /* --- wide (64-bit) integer vector prototype support --- */
+/* the hot-path accessors are INLINE_FUNs in Rinlinedfuns.h */
 
-NORET static void wideint_ptr_error(void)
+NORET void R_wideIntPtrError(void)
 {
     error("32-bit integer accessor applied to a wide (64-bit) integer vector");
 }
 
-int R_isWideInteger(SEXP x)
-{
-    return TYPEOF(x) == INTSXP && IS_WIDEINT(x);
-}
-
-/* the INTEGER()/INTEGER_RO()/INTEGER0() macros expand to these */
-int *R_INTEGER32chk(SEXP x)
-{
-    if (IS_WIDEINT(x))
-	wideint_ptr_error();
-    return (int *) DATAPTR(x);
-}
-
-const int *R_INTEGER32chk_ro(SEXP x)
-{
-    if (IS_WIDEINT(x))
-	wideint_ptr_error();
-    return (const int *) DATAPTR_RO(x);
-}
-
-int *R_INTEGER32chk0(SEXP x)
-{
-    if (IS_WIDEINT(x))
-	wideint_ptr_error();
-    return (int *) STDVEC_DATAPTR(x);
-}
+/* allocWideIntVector borrows the REALSXP payload for its 8-byte
+   elements */
+_Static_assert(sizeof(R_wideint_t) == sizeof(double),
+	       "wide integer elements must have the same size as double");
 
 SEXP allocWideIntVector(R_xlen_t length)
 {
@@ -4231,53 +4210,6 @@ SEXP allocWideIntVector(R_xlen_t length)
     SET_WIDEINT(s);
     SETSCALAR(s, 0); /* keep wide vectors out of scalar fast paths */
     return s;
-}
-
-R_wideint_t INTEGER64_ELT(SEXP x, R_xlen_t i)
-{
-    if (TYPEOF(x) != INTSXP)
-	error("%s() can only be applied to a '%s', not a '%s'",
-	      "INTEGER64_ELT", "integer", R_typeToChar(x));
-    if (IS_WIDEINT(x))
-	return WIDEINT_PTR(x)[i];
-
-    int v = INTEGER_ELT(x, i);
-    return v == NA_INTEGER ? NA_INTEGER64 : (R_wideint_t) v;
-}
-
-void SET_INTEGER64_ELT(SEXP x, R_xlen_t i, R_wideint_t v)
-{
-    if (TYPEOF(x) != INTSXP)
-	error("%s() can only be applied to a '%s', not a '%s'",
-	      "SET_INTEGER64_ELT", "integer", R_typeToChar(x));
-    if (IS_WIDEINT(x)) {
-	WIDEINT_PTR(x)[i] = v;
-	return;
-    }
-
-    if (v == NA_INTEGER64)
-	SET_INTEGER_ELT(x, i, NA_INTEGER);
-    else if (v > INT_MIN && v <= INT_MAX)
-	SET_INTEGER_ELT(x, i, (int) v);
-    else
-	error("value %lld cannot be stored in a narrow integer vector",
-	      (long long) v);
-}
-
-int R_wideIntegerElt32(SEXP x, R_xlen_t i)
-{
-    R_wideint_t v = WIDEINT_PTR(x)[i];
-    if (v == NA_INTEGER64)
-	return NA_INTEGER;
-    if (v > INT_MIN && v <= INT_MAX)
-	return (int) v;
-    error("wide integer value %lld out of range for a 32-bit access",
-	  (long long) v);
-}
-
-void R_wideIntegerSetElt32(SEXP x, R_xlen_t i, int v)
-{
-    WIDEINT_PTR(x)[i] = (v == NA_INTEGER) ? NA_INTEGER64 : (R_wideint_t) v;
 }
 
 int *(LOGICAL)(SEXP x) {

--- a/src/main/memory.c
+++ b/src/main/memory.c
@@ -1118,7 +1118,10 @@ static R_INLINE R_size_t getVecSizeInVEC(SEXP s)
 	break;
     case LGLSXP:
     case INTSXP:
-	size = XLENGTH(s) * sizeof(int);
+	if (IS_WIDEINT(s))
+	    size = XLENGTH(s) * sizeof(long long);
+	else
+	    size = XLENGTH(s) * sizeof(int);
 	break;
     case REALSXP:
 	size = XLENGTH(s) * sizeof(double);
@@ -4184,6 +4187,96 @@ void *(STDVEC_DATAPTR)(SEXP x)
 
 /* nedded for implementing Dataptr ALTREP methods */
 void *DATAPTR_RW(SEXP x) { return DATAPTR(x); }
+
+/* --- wide (64-bit) integer vector prototype support --- */
+
+NORET static void wideint_ptr_error(void)
+{
+    error("32-bit integer accessor applied to a wide (64-bit) integer vector");
+}
+
+int R_isWideInteger(SEXP x)
+{
+    return TYPEOF(x) == INTSXP && IS_WIDEINT(x);
+}
+
+/* the INTEGER()/INTEGER_RO()/INTEGER0() macros expand to these */
+int *R_INTEGER32chk(SEXP x)
+{
+    if (IS_WIDEINT(x))
+	wideint_ptr_error();
+    return (int *) DATAPTR(x);
+}
+
+const int *R_INTEGER32chk_ro(SEXP x)
+{
+    if (IS_WIDEINT(x))
+	wideint_ptr_error();
+    return (const int *) DATAPTR_RO(x);
+}
+
+int *R_INTEGER32chk0(SEXP x)
+{
+    if (IS_WIDEINT(x))
+	wideint_ptr_error();
+    return (int *) STDVEC_DATAPTR(x);
+}
+
+SEXP allocWideIntVector(R_xlen_t length)
+{
+    /* allocate with an 8-byte payload, then relabel; the node class
+       and heap accounting are those of the REALSXP-sized payload */
+    SEXP s = allocVector(REALSXP, length);
+    SET_TYPEOF(s, INTSXP);
+    SET_WIDEINT(s);
+    SETSCALAR(s, 0); /* keep wide vectors out of scalar fast paths */
+    return s;
+}
+
+long long INTEGER64_ELT(SEXP x, R_xlen_t i)
+{
+    if (TYPEOF(x) != INTSXP)
+	error("%s() can only be applied to a '%s', not a '%s'",
+	      "INTEGER64_ELT", "integer", R_typeToChar(x));
+    if (IS_WIDEINT(x))
+	return WIDEINT_PTR(x)[i];
+
+    int v = INTEGER_ELT(x, i);
+    return v == NA_INTEGER ? NA_INTEGER64 : (long long) v;
+}
+
+void SET_INTEGER64_ELT(SEXP x, R_xlen_t i, long long v)
+{
+    if (TYPEOF(x) != INTSXP)
+	error("%s() can only be applied to a '%s', not a '%s'",
+	      "SET_INTEGER64_ELT", "integer", R_typeToChar(x));
+    if (IS_WIDEINT(x)) {
+	WIDEINT_PTR(x)[i] = v;
+	return;
+    }
+
+    if (v == NA_INTEGER64)
+	SET_INTEGER_ELT(x, i, NA_INTEGER);
+    else if (v > INT_MIN && v <= INT_MAX)
+	SET_INTEGER_ELT(x, i, (int) v);
+    else
+	error("value %lld cannot be stored in a narrow integer vector", v);
+}
+
+int R_wideIntegerElt32(SEXP x, R_xlen_t i)
+{
+    long long v = WIDEINT_PTR(x)[i];
+    if (v == NA_INTEGER64)
+	return NA_INTEGER;
+    if (v > INT_MIN && v <= INT_MAX)
+	return (int) v;
+    error("wide integer value %lld out of range for a 32-bit access", v);
+}
+
+void R_wideIntegerSetElt32(SEXP x, R_xlen_t i, int v)
+{
+    WIDEINT_PTR(x)[i] = (v == NA_INTEGER) ? NA_INTEGER64 : (long long) v;
+}
 
 int *(LOGICAL)(SEXP x) {
     if(TYPEOF(x) != LGLSXP)

--- a/src/main/names.c
+++ b/src/main/names.c
@@ -525,6 +525,8 @@ FUNTAB R_FunTab[] =
 {"asCharacterFactor",	do_asCharacterFactor,	0,	11,	1,	{PP_FUNCALL, PREC_FN,	0}},
 
 {"as.vector",	do_asvector,	0,	11,	2,	{PP_FUNCALL, PREC_FN,	0}},
+{"as.wideint",	do_aswideint,	0,	11,	1,	{PP_FUNCALL, PREC_FN,	0}},
+{"is.wideint",	do_iswideint,	0,	11,	1,	{PP_FUNCALL, PREC_FN,	0}},
 {"paste",	do_paste,	0,	11,	4,	{PP_FUNCALL, PREC_FN,	0}},
 {"paste0",	do_paste,	1,	11,	3,	{PP_FUNCALL, PREC_FN,	0}},
 {"file.path",	do_filepath,	0,	11,	2,	{PP_FUNCALL, PREC_FN,	0}},

--- a/src/main/paste.c
+++ b/src/main/paste.c
@@ -546,6 +546,22 @@ attribute_hidden SEXP do_format(SEXP call, SEXP op, SEXP args, SEXP env)
 	    break;
 
 	case INTSXP:
+	    if (R_isWideInteger(x)) {
+		PROTECT(y = allocVector(STRSXP, n));
+		w = 0;
+		if (!trim)
+		    for (i = 0; i < n; i++) {
+			int len =
+			    (int) strlen(EncodeWideInt(INTEGER64_ELT(x, i), 0));
+			if (len > w) w = len;
+		    }
+		w = imax2(w, wd);
+		for (i = 0; i < n; i++) {
+		    strp = EncodeWideInt(INTEGER64_ELT(x, i), w);
+		    SET_STRING_ELT(y, i, mkChar(strp));
+		}
+		break;
+	    }
 	    PROTECT(y = allocVector(STRSXP, n));
 	    if (trim) w = 0;
 	    else formatInteger(INTEGER(x), n, &w);

--- a/src/main/printarray.c
+++ b/src/main/printarray.c
@@ -359,6 +359,15 @@ void printMatrix(SEXP x, int offset, SEXP dim, int quote, int right,
 	printLogicalMatrix(x, offset, r_pr, r, c_pr, rl, cl, rn, cn, true);
 	break;
     case INTSXP:
+	if (R_isWideInteger(x)) {
+	    /* format wide values as fixed-width strings and reuse the
+	       string matrix layout */
+	    SEXP xs = PROTECT(R_formatWideInt(x));
+	    printStringMatrix(xs, offset, r_pr, r, c_pr, 0, 1,
+			      rl, cl, rn, cn, true);
+	    UNPROTECT(1);
+	    break;
+	}
 	printIntegerMatrix(x, offset, r_pr, r, c_pr, rl, cl, rn, cn, true);
 	break;
     case REALSXP:

--- a/src/main/printarray.c
+++ b/src/main/printarray.c
@@ -462,6 +462,13 @@ void printArray(SEXP x, SEXP dim, int quote, int right, SEXP dimnames)
 	    nc_last = nc;
 	    nr_last = nr;
 	}
+	/* wide integers print via the string layout, as in printMatrix;
+	   format once, not per slice */
+	SEXP xw = NULL;
+	if (TYPEOF(x) == INTSXP && R_isWideInteger(x)) {
+	    PROTECT(xw = R_formatWideInt(x));
+	    nprotect++;
+	}
 	for (i = 0; i < nb_pr; i++) {
 	    bool do_ij = nb > 0,
 		i_last = (i == nb_pr - 1); /* for the last slice */
@@ -495,7 +502,11 @@ void printArray(SEXP x, SEXP dim, int quote, int right, SEXP dimnames)
 		printLogicalMatrix(x, i * b, use_nr, nr, use_nc, dn0, dn1, rn, cn, do_ij);
 		break;
 	    case INTSXP:
-		printIntegerMatrix(x, i * b, use_nr, nr, use_nc, dn0, dn1, rn, cn, do_ij);
+		if (xw != NULL)
+		    printStringMatrix (xw, i * b, use_nr, nr, use_nc,
+				       0, 1, dn0, dn1, rn, cn, do_ij);
+		else
+		    printIntegerMatrix(x, i * b, use_nr, nr, use_nc, dn0, dn1, rn, cn, do_ij);
 		break;
 	    case REALSXP:
 		printRealMatrix   (x, i * b, use_nr, nr, use_nc, dn0, dn1, rn, cn, do_ij);

--- a/src/main/printutils.c
+++ b/src/main/printutils.c
@@ -150,6 +150,18 @@ const char *EncodeInteger(int x, int w)
 }
 
 attribute_hidden
+const char *EncodeWideInt(R_wideint_t x, int w)
+{
+    static char buff[NB];
+    if(x == NA_INTEGER64)
+	snprintf(buff, NB, "%*s", min(w, (NB-1)), CHAR(R_print.na_string));
+    else
+	snprintf(buff, NB, "%*lld", min(w, (NB-1)), (long long) x);
+    buff[NB-1] = '\0';
+    return buff;
+}
+
+attribute_hidden
 const char *EncodeRaw(Rbyte x, const char * prefix)
 {
     static char buff[10];
@@ -857,6 +869,10 @@ const char *EncodeElement0(SEXP x, R_xlen_t indx, int quote, const char *dec)
 	res = EncodeLogical(LOGICAL_RO(x)[indx], w);
 	break;
     case INTSXP:
+	if (R_isWideInteger(x)) {
+	    res = EncodeWideInt(INTEGER64_ELT(x, indx), 0);
+	    break;
+	}
 	formatInteger(&INTEGER_RO(x)[indx], 1, &w);
 	res = EncodeInteger(INTEGER_RO(x)[indx], w);
 	break;

--- a/src/main/printvector.c
+++ b/src/main/printvector.c
@@ -332,6 +332,14 @@ attribute_hidden void printVector(SEXP x, int indx, int quote)
 	    printLogicalVectorS(x, n_pr, indx);
 	    break;
 	case INTSXP:
+	    if (R_isWideInteger(x)) {
+		/* format wide values as right-justified strings and
+		   reuse the string layout machinery */
+		SEXP xs = PROTECT(R_formatWideInt(x));
+		printStringVectorS(xs, n_pr, 0, indx);
+		UNPROTECT(1);
+		break;
+	    }
 	    printIntegerVectorS(x, n_pr, indx);
 	    break;
 	case REALSXP:

--- a/src/main/printvector.c
+++ b/src/main/printvector.c
@@ -492,6 +492,12 @@ void printNamedVector(SEXP x, SEXP names, int quote, const char *title)
 	    printNamedLogicalVectorS(x, n_pr, names);
 	    break;
 	case INTSXP:
+	    if (R_isWideInteger(x)) {
+		SEXP xs = PROTECT(R_formatWideInt(x));
+		printNamedStringVectorS(xs, n_pr, 0, names);
+		UNPROTECT(1);
+		break;
+	    }
 	    printNamedIntegerVectorS(x, n_pr, names);
 	    break;
 	case REALSXP:

--- a/src/main/radixsort.c
+++ b/src/main/radixsort.c
@@ -1586,6 +1586,11 @@ attribute_hidden SEXP do_radixsort(SEXP call, SEXP op, SEXP args, SEXP rho)
     for (SEXP ap = args; ap != R_NilValue; ap = CDR(ap), narg++) {
 	if (!isVector(CAR(ap)))
 	    error(_("argument %d is not a vector"), narg + 1);
+	/* radix sort works on 32-bit keys; the R-level wrappers exclude
+	   wide integers from method="auto", but method="radix" reaches
+	   here directly, so refuse rather than misread the payload */
+	if (R_isWideInteger(CAR(ap)))
+	    error(_("radix sort is not supported for wide integer vectors"));
         //Rprintf("%d, %d\n", XLENGTH(CAR(ap)), nl);
 	if (XLENGTH(CAR(ap)) != nl)
 	    error(_("argument lengths differ"));

--- a/src/main/relop.c
+++ b/src/main/relop.c
@@ -821,6 +821,15 @@ static SEXP bitwiseNot(SEXP a)
 
     switch(TYPEOF(a)) {
     case INTSXP:
+	if (R_isWideInteger(a)) {
+	    R_xlen_t m = XLENGTH(a);
+	    ans = allocWideIntVector(m);
+	    for(R_xlen_t i = 0; i < m; i++) {
+		R_wideint_t aa = INTEGER64_ELT(a, i);
+		WIDEINT_PTR(ans)[i] = (aa == NA_INTEGER64) ? aa : ~aa;
+	    }
+	    break;
+	}
 	{
 	    R_xlen_t m = XLENGTH(a);
 	    ans = allocVector(INTSXP, m);
@@ -850,6 +859,20 @@ static SEXP bitwiseNot(SEXP a)
 	error(_("'a' and 'b' must have the same type"));		\
     switch(TYPEOF(a)) {							\
     case INTSXP:							\
+	if (R_isWideInteger(a) || R_isWideInteger(b)) {			\
+	    R_xlen_t i, ia, ib;						\
+	    R_xlen_t m = XLENGTH(a), n = XLENGTH(b),			\
+		mn = (m && n) ? mymax(m, n) : 0;			\
+	    ans = allocWideIntVector(mn);				\
+	    MOD_ITERATE2(mn, m, n, i, ia, ib, {				\
+		    R_wideint_t aa = INTEGER64_ELT(a, ia);		\
+		    R_wideint_t bb = INTEGER64_ELT(b, ib);		\
+		    WIDEINT_PTR(ans)[i] =				\
+			(aa == NA_INTEGER64 || bb == NA_INTEGER64) ?	\
+			NA_INTEGER64 : aa op bb;			\
+		});							\
+	    break;							\
+	}								\
 	{								\
 	    R_xlen_t i, ia, ib;						\
 	    R_xlen_t m = XLENGTH(a), n = XLENGTH(b),			\

--- a/src/main/relop.c
+++ b/src/main/relop.c
@@ -474,9 +474,9 @@ static R_INLINE R_wideint_t wide_relop_elt64(SEXP x, R_xlen_t i)
 /* exact comparison of a wide integer with a double */
 static int wide_cmp_ll_d(R_wideint_t x, double y)
 {
-    if (y >= 9223372036854775808.0 /* 2^63 */)
+    if (y >= R_WIDEINT_DBL_MAX)
 	return -1;
-    if (y < -9223372036854775808.0)
+    if (y < -R_WIDEINT_DBL_MAX)
 	return 1;
 
     double fy = floor(y);

--- a/src/main/relop.c
+++ b/src/main/relop.c
@@ -462,17 +462,17 @@ attribute_hidden SEXP do_relop_dflt(SEXP call, SEXP op, SEXP x, SEXP y)
 
 /* comparison support for wide (64-bit) integer vectors */
 
-static R_INLINE long long wide_relop_elt64(SEXP x, R_xlen_t i)
+static R_INLINE R_wideint_t wide_relop_elt64(SEXP x, R_xlen_t i)
 {
     if (TYPEOF(x) == LGLSXP) {
 	int v = LOGICAL_ELT(x, i);
-	return v == NA_LOGICAL ? NA_INTEGER64 : (long long) v;
+	return v == NA_LOGICAL ? NA_INTEGER64 : (R_wideint_t) v;
     }
     return INTEGER64_ELT(x, i);
 }
 
-/* exact comparison of a long long with a double */
-static int wide_cmp_ll_d(long long x, double y)
+/* exact comparison of a wide integer with a double */
+static int wide_cmp_ll_d(R_wideint_t x, double y)
 {
     if (y >= 9223372036854775808.0 /* 2^63 */)
 	return -1;
@@ -480,7 +480,7 @@ static int wide_cmp_ll_d(long long x, double y)
 	return 1;
 
     double fy = floor(y);
-    long long ly = (long long) fy;
+    R_wideint_t ly = (R_wideint_t) fy;
     if (x < ly) return -1;
     if (x > ly) return 1;
     return (y > fy) ? -1 : 0;
@@ -491,7 +491,7 @@ static int wide_relop_cmp(SEXP x, R_xlen_t ix, SEXP y, R_xlen_t iy, int *na)
 {
     if (TYPEOF(x) == REALSXP) {
 	double dx = REAL_ELT(x, ix);
-	long long ly = wide_relop_elt64(y, iy);
+	R_wideint_t ly = wide_relop_elt64(y, iy);
 	if (ISNAN(dx) || ly == NA_INTEGER64) {
 	    *na = 1;
 	    return 0;
@@ -499,7 +499,7 @@ static int wide_relop_cmp(SEXP x, R_xlen_t ix, SEXP y, R_xlen_t iy, int *na)
 	return -wide_cmp_ll_d(ly, dx);
     }
     if (TYPEOF(y) == REALSXP) {
-	long long lx = wide_relop_elt64(x, ix);
+	R_wideint_t lx = wide_relop_elt64(x, ix);
 	double dy = REAL_ELT(y, iy);
 	if (lx == NA_INTEGER64 || ISNAN(dy)) {
 	    *na = 1;
@@ -508,8 +508,8 @@ static int wide_relop_cmp(SEXP x, R_xlen_t ix, SEXP y, R_xlen_t iy, int *na)
 	return wide_cmp_ll_d(lx, dy);
     }
 
-    long long lx = wide_relop_elt64(x, ix);
-    long long ly = wide_relop_elt64(y, iy);
+    R_wideint_t lx = wide_relop_elt64(x, ix);
+    R_wideint_t ly = wide_relop_elt64(y, iy);
     if (lx == NA_INTEGER64 || ly == NA_INTEGER64) {
 	*na = 1;
 	return 0;

--- a/src/main/relop.c
+++ b/src/main/relop.c
@@ -460,6 +460,63 @@ attribute_hidden SEXP do_relop_dflt(SEXP call, SEXP op, SEXP x, SEXP y)
     }                                                                   \
 } while(0)
 
+/* comparison support for wide (64-bit) integer vectors */
+
+static R_INLINE long long wide_relop_elt64(SEXP x, R_xlen_t i)
+{
+    if (TYPEOF(x) == LGLSXP) {
+	int v = LOGICAL_ELT(x, i);
+	return v == NA_LOGICAL ? NA_INTEGER64 : (long long) v;
+    }
+    return INTEGER64_ELT(x, i);
+}
+
+/* exact comparison of a long long with a double */
+static int wide_cmp_ll_d(long long x, double y)
+{
+    if (y >= 9223372036854775808.0 /* 2^63 */)
+	return -1;
+    if (y < -9223372036854775808.0)
+	return 1;
+
+    double fy = floor(y);
+    long long ly = (long long) fy;
+    if (x < ly) return -1;
+    if (x > ly) return 1;
+    return (y > fy) ? -1 : 0;
+}
+
+/* returns -1/0/1, or sets *na */
+static int wide_relop_cmp(SEXP x, R_xlen_t ix, SEXP y, R_xlen_t iy, int *na)
+{
+    if (TYPEOF(x) == REALSXP) {
+	double dx = REAL_ELT(x, ix);
+	long long ly = wide_relop_elt64(y, iy);
+	if (ISNAN(dx) || ly == NA_INTEGER64) {
+	    *na = 1;
+	    return 0;
+	}
+	return -wide_cmp_ll_d(ly, dx);
+    }
+    if (TYPEOF(y) == REALSXP) {
+	long long lx = wide_relop_elt64(x, ix);
+	double dy = REAL_ELT(y, iy);
+	if (lx == NA_INTEGER64 || ISNAN(dy)) {
+	    *na = 1;
+	    return 0;
+	}
+	return wide_cmp_ll_d(lx, dy);
+    }
+
+    long long lx = wide_relop_elt64(x, ix);
+    long long ly = wide_relop_elt64(y, iy);
+    if (lx == NA_INTEGER64 || ly == NA_INTEGER64) {
+	*na = 1;
+	return 0;
+    }
+    return (lx < ly) ? -1 : (lx > ly) ? 1 : 0;
+}
+
 static SEXP numeric_relop(RELOP_TYPE code, SEXP s1, SEXP s2)
 {
     R_xlen_t i, i1, i2, n, n1, n2;
@@ -471,6 +528,26 @@ static SEXP numeric_relop(RELOP_TYPE code, SEXP s1, SEXP s2)
     PROTECT(s1);
     PROTECT(s2);
     ans = allocVector(LGLSXP, n);
+
+    if (R_isWideInteger(s1) || R_isWideInteger(s2)) {
+	int *pa = LOGICAL(ans);
+	MOD_ITERATE2(n, n1, n2, i, i1, i2, {
+	    int na = 0;
+	    int c = wide_relop_cmp(s1, i1, s2, i2, &na);
+	    if (na)
+		pa[i] = NA_LOGICAL;
+	    else switch (code) {
+	    case EQOP: pa[i] = (c == 0); break;
+	    case NEOP: pa[i] = (c != 0); break;
+	    case LTOP: pa[i] = (c < 0); break;
+	    case GTOP: pa[i] = (c > 0); break;
+	    case LEOP: pa[i] = (c <= 0); break;
+	    case GEOP: pa[i] = (c >= 0); break;
+	    }
+	});
+	UNPROTECT(2);
+	return ans;
+    }
 
     if (isInteger(s1) || isLogical(s1)) {
         if (isInteger(s2) || isLogical(s2)) {

--- a/src/main/relop.c
+++ b/src/main/relop.c
@@ -823,7 +823,7 @@ static SEXP bitwiseNot(SEXP a)
     case INTSXP:
 	if (R_isWideInteger(a)) {
 	    R_xlen_t m = XLENGTH(a);
-	    ans = allocWideIntVector(m);
+	    ans = R_allocWideIntVector(m);
 	    for(R_xlen_t i = 0; i < m; i++) {
 		R_wideint_t aa = INTEGER64_ELT(a, i);
 		WIDEINT_PTR(ans)[i] = (aa == NA_INTEGER64) ? aa : ~aa;
@@ -863,7 +863,7 @@ static SEXP bitwiseNot(SEXP a)
 	    R_xlen_t i, ia, ib;						\
 	    R_xlen_t m = XLENGTH(a), n = XLENGTH(b),			\
 		mn = (m && n) ? mymax(m, n) : 0;			\
-	    ans = allocWideIntVector(mn);				\
+	    ans = R_allocWideIntVector(mn);				\
 	    MOD_ITERATE2(mn, m, n, i, ia, ib, {				\
 		    R_wideint_t aa = INTEGER64_ELT(a, ia);		\
 		    R_wideint_t bb = INTEGER64_ELT(b, ib);		\

--- a/src/main/relop.c
+++ b/src/main/relop.c
@@ -527,7 +527,9 @@ static SEXP numeric_relop(RELOP_TYPE code, SEXP s1, SEXP s2)
     n = (n1 > n2) ? n1 : n2;
     PROTECT(s1);
     PROTECT(s2);
-    ans = allocVector(LGLSXP, n);
+    /* protect ans: the wide loop below dispatches ALTREP Elt methods,
+       which may allocate */
+    PROTECT(ans = allocVector(LGLSXP, n));
 
     if (R_isWideInteger(s1) || R_isWideInteger(s2)) {
 	int *pa = LOGICAL(ans);
@@ -545,7 +547,7 @@ static SEXP numeric_relop(RELOP_TYPE code, SEXP s1, SEXP s2)
 	    case GEOP: pa[i] = (c >= 0); break;
 	    }
 	});
-	UNPROTECT(2);
+	UNPROTECT(3);
 	return ans;
     }
 
@@ -561,7 +563,7 @@ static SEXP numeric_relop(RELOP_TYPE code, SEXP s1, SEXP s2)
         NUMERIC_RELOP(double, REAL, ISNAN, double, REAL, ISNAN);
     }
 
-    UNPROTECT(2);
+    UNPROTECT(3);
     return ans;
 }
 
@@ -863,7 +865,10 @@ static SEXP bitwiseNot(SEXP a)
 	    R_xlen_t i, ia, ib;						\
 	    R_xlen_t m = XLENGTH(a), n = XLENGTH(b),			\
 		mn = (m && n) ? mymax(m, n) : 0;			\
+	    /* protect ans: INTEGER64_ELT dispatches ALTREP Elt		\
+	       methods for a narrow operand, which may allocate */	\
 	    ans = R_allocWideIntVector(mn);				\
+	    PROTECT(ans); np++;						\
 	    MOD_ITERATE2(mn, m, n, i, ia, ib, {				\
 		    R_wideint_t aa = INTEGER64_ELT(a, ia);		\
 		    R_wideint_t bb = INTEGER64_ELT(b, ib);		\

--- a/src/main/saveload.c
+++ b/src/main/saveload.c
@@ -592,6 +592,9 @@ static void RestoreSEXP(SEXP s, FILE *fp, InputRoutines *m, NodeInfo *node, int 
 
     SET_OBJECT(s, m->InInteger(fp, d));
     SETLEVELS(s, m->InInteger(fp, d));
+    /* the wide-int bit must never arrive via serialized flags: this
+       legacy format stores a 32-bit payload */
+    if (TYPEOF(s) == INTSXP || TYPEOF(s) == LGLSXP) UNSET_WIDEINT(s);
     SET_ATTRIB(s, OffsetToNode(m->InInteger(fp, d), node));
     switch (TYPEOF(s)) {
     case LISTSXP:
@@ -1301,6 +1304,9 @@ static SEXP NewReadItem (SEXP sym_table, SEXP env_table, FILE *fp,
 	error(_("NewReadItem: unknown type %i"), type);
     }
     SETLEVELS(s, (unsigned short) levs);
+    /* the wide-int bit must never arrive via serialized flags: this
+       legacy format stores a 32-bit payload */
+    if (TYPEOF(s) == INTSXP || TYPEOF(s) == LGLSXP) UNSET_WIDEINT(s);
     SET_OBJECT(s, objf);
     SET_ATTRIB(s, NewReadItem(sym_table, env_table, fp, m, d));
     UNPROTECT(1); /* s */

--- a/src/main/seq.c
+++ b/src/main/seq.c
@@ -183,6 +183,12 @@ static SEXP rep2(SEXP s, SEXP ncopy)
 	} \
 	break; \
     case INTSXP: \
+	if (R_isWideInteger(s)) { \
+	    for (i = 0; i < nc; i++) \
+		for (j = (R_xlen_t) it[i]; j > 0; j--) \
+		    WIDEINT_PTR(a)[n++] = INTEGER64_ELT(s, i); \
+	    break; \
+	} \
 	for (i = 0; i < nc; i++) { \
 /*	    if ((i+1) % ni == 0) R_CheckUserInterrupt();*/ \
 	    for (j = (R_xlen_t) it[i]; j > 0; j--) \
@@ -265,7 +271,8 @@ static SEXP rep2(SEXP s, SEXP ncopy)
 	ratio = na/nc; // average no of replications
 	if (ratio > 1000U) ni = 1000U;
 	} */
-    PROTECT(a = allocVector(TYPEOF(s), na));
+    PROTECT(a = R_isWideInteger(s) ? allocWideIntVector(na)
+		: allocVector(TYPEOF(s), na));
     n = 0;
     if (TYPEOF(t) == REALSXP)
 	R2_SWITCH_LOOP(REAL(t))
@@ -282,7 +289,8 @@ static SEXP rep3(SEXP s, R_xlen_t ns, R_xlen_t na)
     R_xlen_t i, j;
     SEXP a;
 
-    PROTECT(a = allocVector(TYPEOF(s), na));
+    PROTECT(a = R_isWideInteger(s) ? allocWideIntVector(na)
+		: allocVector(TYPEOF(s), na));
 
     switch (TYPEOF(s)) {
     case LGLSXP:
@@ -292,6 +300,12 @@ static SEXP rep3(SEXP s, R_xlen_t ns, R_xlen_t na)
 	});
 	break;
     case INTSXP:
+	if (R_isWideInteger(s)) {
+	    MOD_ITERATE1(na, ns, i, j, {
+		WIDEINT_PTR(a)[i] = INTEGER64_ELT(s, j);
+	    });
+	    break;
+	}
 	MOD_ITERATE1(na, ns, i, j, {
 //	    if ((i+1) % NINTERRUPT == 0) R_CheckUserInterrupt();
 	    INTEGER(a)[i] = INTEGER(s)[j];
@@ -487,7 +501,8 @@ static SEXP rep4(SEXP x, SEXP times, R_xlen_t len, R_xlen_t each, R_xlen_t nt)
     // faster code for common special case
     if (each == 1 && nt == 1) return rep3(x, lx, len);
 
-    PROTECT(a = allocVector(TYPEOF(x), len));
+    PROTECT(a = R_isWideInteger(x) ? allocWideIntVector(len)
+		: allocVector(TYPEOF(x), len));
 
 #define R4_SWITCH_LOOP(itimes)						\
     switch (TYPEOF(x)) {						\
@@ -502,6 +517,16 @@ static SEXP rep4(SEXP x, SEXP times, R_xlen_t len, R_xlen_t each, R_xlen_t nt)
 	}								\
 	break;								\
     case INTSXP:							\
+	if (R_isWideInteger(x)) {					\
+	    for(i = 0, k = 0, k2 = 0; i < lx; i++) {			\
+		for(j = 0, sum = 0; j < each; j++) sum += (R_xlen_t) itimes[k++]; \
+		for(k3 = 0; k3 < sum; k3++) {				\
+		    WIDEINT_PTR(a)[k2++] = INTEGER64_ELT(x, i);		\
+		    if(k2 == len) goto done;				\
+		}							\
+	    }								\
+	    break;							\
+	}								\
 	for(i = 0, k = 0, k2 = 0; i < lx; i++) {			\
 	    /*		if ((i+1) % NINTERRUPT == 0) R_CheckUserInterrupt();*/ \
 	    for(j = 0, sum = 0; j < each; j++) sum += (R_xlen_t) itimes[k++]; \
@@ -576,6 +601,11 @@ static SEXP rep4(SEXP x, SEXP times, R_xlen_t len, R_xlen_t each, R_xlen_t nt)
 	    }
 	    break;
 	case INTSXP:
+	    if (R_isWideInteger(x)) {
+		for(i = 0; i < len; i++)
+		    WIDEINT_PTR(a)[i] = INTEGER64_ELT(x, (i/each) % lx);
+		break;
+	    }
 	    for(i = 0; i < len; i++) {
 //		if ((i+1) % NINTERRUPT == 0) R_CheckUserInterrupt();
 		INTEGER(a)[i] = INTEGER(x)[(i/each) % lx];

--- a/src/main/seq.c
+++ b/src/main/seq.c
@@ -271,7 +271,7 @@ static SEXP rep2(SEXP s, SEXP ncopy)
 	ratio = na/nc; // average no of replications
 	if (ratio > 1000U) ni = 1000U;
 	} */
-    PROTECT(a = R_isWideInteger(s) ? allocWideIntVector(na)
+    PROTECT(a = R_isWideInteger(s) ? R_allocWideIntVector(na)
 		: allocVector(TYPEOF(s), na));
     n = 0;
     if (TYPEOF(t) == REALSXP)
@@ -289,7 +289,7 @@ static SEXP rep3(SEXP s, R_xlen_t ns, R_xlen_t na)
     R_xlen_t i, j;
     SEXP a;
 
-    PROTECT(a = R_isWideInteger(s) ? allocWideIntVector(na)
+    PROTECT(a = R_isWideInteger(s) ? R_allocWideIntVector(na)
 		: allocVector(TYPEOF(s), na));
 
     switch (TYPEOF(s)) {
@@ -501,7 +501,7 @@ static SEXP rep4(SEXP x, SEXP times, R_xlen_t len, R_xlen_t each, R_xlen_t nt)
     // faster code for common special case
     if (each == 1 && nt == 1) return rep3(x, lx, len);
 
-    PROTECT(a = R_isWideInteger(x) ? allocWideIntVector(len)
+    PROTECT(a = R_isWideInteger(x) ? R_allocWideIntVector(len)
 		: allocVector(TYPEOF(x), len));
 
 #define R4_SWITCH_LOOP(itimes)						\

--- a/src/main/serialize.c
+++ b/src/main/serialize.c
@@ -1203,6 +1203,8 @@ static void WriteItem (SEXP s, SEXP ref_table, R_outpstream_t stream)
 	    break;
 	case LGLSXP:
 	case INTSXP:
+	    if (R_isWideInteger(s))
+		error("serialization of wide integer vectors is not supported in this prototype");
 	    len = XLENGTH(s);
 	    WriteLENGTH(stream, s);
 	    OutIntegerVec(stream, s, len);
@@ -2107,6 +2109,9 @@ static SEXP ReadItem_Recursive (int flags, SEXP ref_table, R_inpstream_t stream)
 	    error(_("ReadItem: unknown type %i, perhaps written by later version of R"), type);
 	}
 	if (type != CHARSXP) SETLEVELS(s, levs);
+	/* the wide-int bit must never arrive via serialized flags: the
+	   payload read above is 32-bit */
+	if (type == INTSXP || type == LGLSXP) UNSET_WIDEINT(s);
 	SET_OBJECT(s, objf);
 	if (TYPEOF(s) == CHARSXP) {
 	    /* With the CHARSXP cache maintained through the ATTRIB

--- a/src/main/sort.c
+++ b/src/main/sort.c
@@ -42,6 +42,16 @@ static int icmp(int x, int y, bool nalast)
     return 0;
 }
 
+static int wcmp(R_wideint_t x, R_wideint_t y, bool nalast)
+{
+    if (x == NA_INTEGER64 && y == NA_INTEGER64) return 0;
+    if (x == NA_INTEGER64)	return nalast ? 1 : -1;
+    if (y == NA_INTEGER64)	return nalast ? -1 : 1;
+    if (x < y)		return -1;
+    if (x > y)		return 1;
+    return 0;
+}
+
 static int rcmp(double x, double y, bool nalast)
 {
     int nax = ISNAN(x), nay = ISNAN(y);
@@ -109,6 +119,19 @@ Rboolean isUnsorted(SEXP x, Rboolean strictly)
 	       outside of the tight loop and be ALTREP safe. */
 	case LGLSXP:
 	case INTSXP:
+	    if (R_isWideInteger(x)) {
+		const R_wideint_t *wx = WIDEINT_PTR(x);
+		if (strictly) {
+		    for (R_xlen_t k = 0; k < n - 1; k++)
+			if (wx[k] >= wx[k+1])
+			    return TRUE;
+		} else {
+		    for (R_xlen_t k = 0; k < n - 1; k++)
+			if (wx[k] > wx[k+1])
+			    return TRUE;
+		}
+		break;
+	    }
 	    if(strictly) {
 		ITERATE_BY_REGION(x, xptr, i, nbatch, int, INTEGER, {
 			/* itmp initialized to INT_MIN which is < all
@@ -471,7 +494,8 @@ static bool fastpass_sortcheck(SEXP x, int wanted) {
     /* Increasing, usually fairly short, sequences of integers often
        arise as levels in as.factor.  A quick check here allows a fast
        return in sort.int. */
-    if (! done && TYPEOF(x) == INTSXP && wanted > 0 && ! ALTREP(x)) {
+    if (! done && TYPEOF(x) == INTSXP && wanted > 0 && ! ALTREP(x) &&
+	! R_isWideInteger(x)) {
 	R_xlen_t len = XLENGTH(x);
 	if (len > 0) {
 	    int *px = INTEGER(x);
@@ -567,6 +591,23 @@ static void R_isort2(int *x, R_xlen_t n, bool decreasing)
 #undef less
 }
 
+static void R_wsort2(R_wideint_t *x, R_xlen_t n, bool decreasing)
+{
+    R_wideint_t v;
+    R_xlen_t i, j, h, t;
+
+    if (n < 2) error("'n >= 2' is required");
+    for (t = 0; incs[t] > n; t++);
+    if(decreasing)
+#define less <
+	sort2_body
+#undef less
+    else
+#define less >
+	sort2_body
+#undef less
+}
+
 static void R_rsort2(double *x, R_xlen_t n, bool decreasing)
 {
     double v;
@@ -639,6 +680,10 @@ void sortVector(SEXP s, bool decreasing)
 	switch (TYPEOF(s)) {
 	case LGLSXP:
 	case INTSXP:
+	    if (R_isWideInteger(s)) {
+		R_wsort2(WIDEINT_PTR(s), n, decreasing);
+		break;
+	    }
 	    R_isort2(INTEGER(s), n, decreasing);
 	    break;
 	case REALSXP:
@@ -847,7 +892,10 @@ static int equal(R_xlen_t i, R_xlen_t j, SEXP x, bool nalast, SEXP rho)
 	switch (TYPEOF(x)) {
 	case LGLSXP:
 	case INTSXP:
-	    c = icmp(INTEGER(x)[i], INTEGER(x)[j], nalast);
+	    if (R_isWideInteger(x))
+		c = wcmp(INTEGER64_ELT(x, i), INTEGER64_ELT(x, j), nalast);
+	    else
+		c = icmp(INTEGER(x)[i], INTEGER(x)[j], nalast);
 	    break;
 	case REALSXP:
 	    c = rcmp(REAL(x)[i], REAL(x)[j], nalast);
@@ -885,7 +933,10 @@ static int greater(R_xlen_t i, R_xlen_t j, SEXP x, bool nalast,
 	switch (TYPEOF(x)) {
 	case LGLSXP:
 	case INTSXP:
-	    c = icmp(INTEGER(x)[i], INTEGER(x)[j], nalast);
+	    if (R_isWideInteger(x))
+		c = wcmp(INTEGER64_ELT(x, i), INTEGER64_ELT(x, j), nalast);
+	    else
+		c = icmp(INTEGER(x)[i], INTEGER(x)[j], nalast);
 	    break;
 	case REALSXP:
 	    c = rcmp(REAL(x)[i], REAL(x)[j], nalast);
@@ -917,7 +968,10 @@ static int listgreater(int i, int j, SEXP key, bool nalast,
 	switch (TYPEOF(x)) {
 	case LGLSXP:
 	case INTSXP:
-	    c = icmp(INTEGER(x)[i], INTEGER(x)[j], nalast);
+	    if (R_isWideInteger(x))
+		c = wcmp(INTEGER64_ELT(x, i), INTEGER64_ELT(x, j), nalast);
+	    else
+		c = icmp(INTEGER(x)[i], INTEGER(x)[j], nalast);
 	    break;
 	case REALSXP:
 	    c = rcmp(REAL(x)[i], REAL(x)[j], nalast);
@@ -1014,7 +1068,10 @@ static int listgreaterl(R_xlen_t i, R_xlen_t j, SEXP key, bool nalast,
 	switch (TYPEOF(x)) {
 	case LGLSXP:
 	case INTSXP:
-	    c = icmp(INTEGER(x)[i], INTEGER(x)[j], nalast);
+	    if (R_isWideInteger(x))
+		c = wcmp(INTEGER64_ELT(x, i), INTEGER64_ELT(x, j), nalast);
+	    else
+		c = icmp(INTEGER(x)[i], INTEGER(x)[j], nalast);
 	    break;
 	case REALSXP:
 	    c = rcmp(REAL(x)[i], REAL(x)[j], nalast);
@@ -1157,12 +1214,16 @@ orderVector1(int *indx, int n, SEXP key, bool nalast, bool decreasing, SEXP rho)
     double *x = NULL /* -Wall */;
     Rcomplex *cx = NULL /* -Wall */;
     const SEXP *sx = NULL /* -Wall */;
+    R_wideint_t *wx = NULL;
 
     if (n < 2) return;
     switch (TYPEOF(key)) {
     case LGLSXP:
     case INTSXP:
-	ix = INTEGER(key);
+	if (R_isWideInteger(key))
+	    wx = WIDEINT_PTR(key);
+	else
+	    ix = INTEGER(key);
 	break;
     case REALSXP:
 	x = REAL(key);
@@ -1181,7 +1242,10 @@ orderVector1(int *indx, int n, SEXP key, bool nalast, bool decreasing, SEXP rho)
 	switch (TYPEOF(key)) {
 	case LGLSXP:
 	case INTSXP:
-	    for (i = 0; i < n; i++) isna[i] = (ix[i] == NA_INTEGER);
+	    if (wx)
+		for (i = 0; i < n; i++) isna[i] = (wx[i] == NA_INTEGER64);
+	    else
+		for (i = 0; i < n; i++) isna[i] = (ix[i] == NA_INTEGER);
 	    break;
 	case REALSXP:
 	    for (i = 0; i < n; i++) isna[i] = ISNAN(x[i]);
@@ -1230,6 +1294,18 @@ orderVector1(int *indx, int n, SEXP key, bool nalast, bool decreasing, SEXP rho)
 	switch (TYPEOF(key)) {
 	case LGLSXP:
 	case INTSXP:
+	    if (wx) {
+		if (decreasing) {
+#define less(a, b) (wx[a] < wx[b] || (wx[a] == wx[b] && a > b))
+		    sort2_with_index
+#undef less
+		} else {
+#define less(a, b) (wx[a] > wx[b] || (wx[a] == wx[b] && a > b))
+		    sort2_with_index
+#undef less
+		}
+		break;
+	    }
 	    if (decreasing) {
 #define less(a, b) (ix[a] < ix[b] || (ix[a] == ix[b] && a > b))
 		sort2_with_index
@@ -1293,13 +1369,17 @@ orderVector1l(R_xlen_t *indx, R_xlen_t n, SEXP key, bool nalast,
     double *x = NULL /* -Wall */;
     Rcomplex *cx = NULL /* -Wall */;
     const SEXP *sx = NULL /* -Wall */;
+    R_wideint_t *wx = NULL;
     R_xlen_t itmp;
 
     if (n < 2) return;
     switch (TYPEOF(key)) {
     case LGLSXP:
     case INTSXP:
-	ix = INTEGER(key);
+	if (R_isWideInteger(key))
+	    wx = WIDEINT_PTR(key);
+	else
+	    ix = INTEGER(key);
 	break;
     case REALSXP:
 	x = REAL(key);
@@ -1318,7 +1398,10 @@ orderVector1l(R_xlen_t *indx, R_xlen_t n, SEXP key, bool nalast,
 	switch (TYPEOF(key)) {
 	case LGLSXP:
 	case INTSXP:
-	    for (i = 0; i < n; i++) isna[i] = (ix[i] == NA_INTEGER);
+	    if (wx)
+		for (i = 0; i < n; i++) isna[i] = (wx[i] == NA_INTEGER64);
+	    else
+		for (i = 0; i < n; i++) isna[i] = (ix[i] == NA_INTEGER);
 	    break;
 	case REALSXP:
 	    for (i = 0; i < n; i++) isna[i] = ISNAN(x[i]);
@@ -1367,6 +1450,18 @@ orderVector1l(R_xlen_t *indx, R_xlen_t n, SEXP key, bool nalast,
 	switch (TYPEOF(key)) {
 	case LGLSXP:
 	case INTSXP:
+	    if (wx) {
+		if (decreasing) {
+#define less(a, b) (wx[a] < wx[b] || (wx[a] == wx[b] && a > b))
+		    sort2_with_index
+#undef less
+		} else {
+#define less(a, b) (wx[a] > wx[b] || (wx[a] == wx[b] && a > b))
+		    sort2_with_index
+#undef less
+		}
+		break;
+	    }
 	    if (decreasing) {
 #define less(a, b) (ix[a] < ix[b] || (ix[a] == ix[b] && a > b))
 		sort2_with_index

--- a/src/main/sprintf.c
+++ b/src/main/sprintf.c
@@ -373,6 +373,25 @@ attribute_hidden SEXP do_sprintf(SEXP call, SEXP op, SEXP args, SEXP env)
 			    }
 			case INTSXP:
 			    {
+				if (R_isWideInteger(_this)) {
+				    R_wideint_t x =
+					INTEGER64_ELT(_this, ns % thislen);
+				    if (checkfmt(fmtp, "dioxX"))
+					error(_("invalid format '%s'; %s"), fmtp,
+					      _("use format %d, %i, %o, %x or %X for integer objects"));
+				    if (x == NA_INTEGER64) {
+					fmtp[strlen(fmtp)-1] = 's';
+					_my_sprintf("NA")
+				    } else {
+					/* splice in the ll length modifier */
+					size_t fl = strlen(fmtp);
+					char conv = fmtp[fl-1];
+					fmtp[fl-1] = 'l'; fmtp[fl] = 'l';
+					fmtp[fl+1] = conv; fmtp[fl+2] = '\0';
+					_my_sprintf((long long) x)
+				    }
+				    break;
+				}
 				int x = INTEGER(_this)[ns % thislen];
 				if (checkfmt(fmtp, "dioxX"))
 				    error(_("invalid format '%s'; %s"), fmtp,

--- a/src/main/sprintf.c
+++ b/src/main/sprintf.c
@@ -383,8 +383,13 @@ attribute_hidden SEXP do_sprintf(SEXP call, SEXP op, SEXP args, SEXP env)
 					fmtp[strlen(fmtp)-1] = 's';
 					_my_sprintf("NA")
 				    } else {
-					/* splice in the ll length modifier */
+					/* splice in the ll length modifier; the
+					   two extra bytes must stay within fmt/
+					   fmt2 (fmt is only MAXLINE+1 long) */
 					size_t fl = strlen(fmtp);
+					if (fl + 2 > MAXLINE)
+					    error(_("'fmt' length exceeds maximal format length %d"),
+						  MAXLINE);
 					char conv = fmtp[fl-1];
 					fmtp[fl-1] = 'l'; fmtp[fl] = 'l';
 					fmtp[fl+1] = conv; fmtp[fl+2] = '\0';

--- a/src/main/subassign.c
+++ b/src/main/subassign.c
@@ -213,7 +213,7 @@ static SEXP EnlargeVector(SEXP x, R_xlen_t newlen)
 */
     PROTECT(x);
     if (R_isWideInteger(x))
-	PROTECT(newx = allocWideIntVector(newtruelen));
+	PROTECT(newx = R_allocWideIntVector(newtruelen));
     else
 	PROTECT(newx = allocVector(TYPEOF(x), newtruelen));
 

--- a/src/main/subassign.c
+++ b/src/main/subassign.c
@@ -212,12 +212,22 @@ static SEXP EnlargeVector(SEXP x, R_xlen_t newlen)
     if (newtruelen > R_LEN_T_MAX) newtruelen = newlen;
 */
     PROTECT(x);
-    PROTECT(newx = allocVector(TYPEOF(x), newtruelen));
+    if (R_isWideInteger(x))
+	PROTECT(newx = allocWideIntVector(newtruelen));
+    else
+	PROTECT(newx = allocVector(TYPEOF(x), newtruelen));
 
     /* Copy the elements into place. */
     switch(TYPEOF(x)) {
     case LGLSXP:
     case INTSXP:
+	if (R_isWideInteger(x)) {
+	    for (R_xlen_t i = 0; i < len; i++)
+		WIDEINT_PTR(newx)[i] = INTEGER64_ELT(x, i);
+	    for (R_xlen_t i = len; i < newtruelen; i++)
+		WIDEINT_PTR(newx)[i] = NA_INTEGER64;
+	    break;
+	}
 	for (R_xlen_t i = 0; i < len; i++)
 	    INTEGER0(newx)[i] = INTEGER_ELT(x, i);
 	for (R_xlen_t i = len; i < newtruelen; i++)
@@ -326,6 +336,19 @@ static int SubassignTypeFix(SEXP *x, SEXP *y, R_xlen_t stretch,
 			    int level,
 			    SEXP call, SEXP rho)
 {
+    /* A wide integer value forces a wide integer target: a narrow
+       target cannot represent it, and width is not part of the type
+       lattice below. */
+    if (R_isWideInteger(*y)) {
+	if (TYPEOF(*x) == LGLSXP) {
+	    PROTECT(*x = coerceVector(*x, INTSXP));
+	    *x = R_widenInteger(*x);
+	    UNPROTECT(1);
+	}
+	else if (TYPEOF(*x) == INTSXP && !R_isWideInteger(*x))
+	    *x = R_widenInteger(*x);
+    }
+
     /* A rather pointless optimization, but level 2 used to be handled
        differently */
     bool redo_which = true;
@@ -723,6 +746,20 @@ static SEXP VectorAssign(SEXP call, SEXP rho, SEXP x, SEXP s, SEXP y)
     /* case 1013:  logical   <- integer	  */
     case 1313:	/* integer   <- integer	  */
 
+	if (R_isWideInteger(x)) {
+	    if (TYPEOF(y) == INTSXP) {
+		VECTOR_ASSIGN_LOOP(
+		    WIDEINT_PTR(x)[ii] = INTEGER64_ELT(y, iny););
+	    }
+	    else { /* logical y */
+		VECTOR_ASSIGN_LOOP({
+			int iy = LOGICAL_ELT(y, iny);
+			WIDEINT_PTR(x)[ii] = (iy == NA_LOGICAL)
+			    ? NA_INTEGER64 : (R_wideint_t) iy;
+		    });
+	    }
+	    break;
+	}
 	{
 	    int *px = INTEGER(x);
 	    VECTOR_ASSIGN_LOOP(px[ii] = INTEGER_ELT(y, iny););
@@ -732,6 +769,14 @@ static SEXP VectorAssign(SEXP call, SEXP rho, SEXP x, SEXP s, SEXP y)
     case 1410:	/* real	     <- logical	  */
     case 1413:	/* real	     <- integer	  */
 
+	if (R_isWideInteger(y)) {
+	    double *px = REAL(x);
+	    VECTOR_ASSIGN_LOOP({
+		    R_wideint_t iy = INTEGER64_ELT(y, iny);
+		    px[ii] = (iy == NA_INTEGER64) ? NA_REAL : (double) iy;
+		});
+	    break;
+	}
 	{
 	    double *px = REAL(x);
 	    VECTOR_ASSIGN_LOOP({
@@ -1024,6 +1069,18 @@ static SEXP MatrixAssign(SEXP call, SEXP rho, SEXP x, SEXP s, SEXP y)
     /* case 1013: logical   <- integer	  */
     case 1313:	/* integer   <- integer	  */
 
+	if (R_isWideInteger(x)) {
+	    if (TYPEOF(y) == INTSXP)
+		MATRIX_ASSIGN_LOOP(
+		    WIDEINT_PTR(x)[ij] = INTEGER64_ELT(y, k););
+	    else
+		MATRIX_ASSIGN_LOOP({
+			int iy = LOGICAL_ELT(y, k);
+			WIDEINT_PTR(x)[ij] = (iy == NA_LOGICAL)
+			    ? NA_INTEGER64 : (R_wideint_t) iy;
+		    });
+	    break;
+	}
 	{
 	    int *px = INTEGER(x);
 	    if (ALTREP(y))
@@ -1038,6 +1095,14 @@ static SEXP MatrixAssign(SEXP call, SEXP rho, SEXP x, SEXP s, SEXP y)
     case 1410:	/* real	     <- logical	  */
     case 1413:	/* real	     <- integer	  */
 
+	if (R_isWideInteger(y)) {
+	    double *px = REAL(x);
+	    MATRIX_ASSIGN_LOOP({
+		    R_wideint_t iy = INTEGER64_ELT(y, k);
+		    px[ij] = (iy == NA_INTEGER64) ? NA_REAL : (double) iy;
+		});
+	    break;
+	}
 	{
 	    double *px = REAL(x);
 	    MATRIX_ASSIGN_LOOP({
@@ -1267,6 +1332,18 @@ static SEXP ArrayAssign(SEXP call, SEXP rho, SEXP x, SEXP s, SEXP y)
 		/* case 1013:	   logical   <- integer	  */
     case 1313:	/* integer   <- integer	  */
 
+	if (R_isWideInteger(x)) {
+	    if (TYPEOF(y) == INTSXP)
+		ARRAY_ASSIGN_LOOP(
+		    WIDEINT_PTR(x)[ii] = INTEGER64_ELT(y, iny););
+	    else
+		ARRAY_ASSIGN_LOOP({
+			int iy = LOGICAL_ELT(y, iny);
+			WIDEINT_PTR(x)[ii] = (iy == NA_LOGICAL)
+			    ? NA_INTEGER64 : (R_wideint_t) iy;
+		    });
+	    break;
+	}
 	{
 	    int *px = INTEGER(x);
 	    ARRAY_ASSIGN_LOOP(px[ii] = INTEGER_ELT(y, iny););
@@ -1930,12 +2007,27 @@ do_subassign2_dflt(SEXP call, SEXP op, SEXP args, SEXP rho)
 	/* case 1013:	   logical   <- integer	  */
 	case 1313:	/* integer   <- integer	  */
 
+	    if (R_isWideInteger(x)) {
+		if (TYPEOF(y) == INTSXP)
+		    WIDEINT_PTR(x)[offset] = INTEGER64_ELT(y, 0);
+		else {
+		    int iy = LOGICAL_ELT(y, 0);
+		    WIDEINT_PTR(x)[offset] = (iy == NA_LOGICAL)
+			? NA_INTEGER64 : (R_wideint_t) iy;
+		}
+		break;
+	    }
 	    INTEGER(x)[offset] = INTEGER_ELT(y, 0);
 	    break;
 
 	case 1410:	/* real	     <- logical	  */
 	case 1413:	/* real	     <- integer	  */
 
+	    if (R_isWideInteger(y)) {
+		R_wideint_t iy = INTEGER64_ELT(y, 0);
+		REAL(x)[offset] = (iy == NA_INTEGER64) ? NA_REAL : (double) iy;
+		break;
+	    }
 	    if (INTEGER_ELT(y, 0) == NA_INTEGER)
 		REAL(x)[offset] = NA_REAL;
 	    else

--- a/src/main/subset.c
+++ b/src/main/subset.c
@@ -335,11 +335,18 @@ static SEXP MatrixSubset(SEXP x, SEXP s, SEXP call, int drop)
 	error(_("dimensions would exceed maximum size of array"));
     PROTECT(sr);
     PROTECT(sc);
-    result = allocVector(TYPEOF(x), (R_xlen_t) nrs * (R_xlen_t) ncs);
+    if (R_isWideInteger(x))
+	result = allocWideIntVector((R_xlen_t) nrs * (R_xlen_t) ncs);
+    else
+	result = allocVector(TYPEOF(x), (R_xlen_t) nrs * (R_xlen_t) ncs);
     const int *psr = INTEGER_RO(sr);
     const int *psc = INTEGER_RO(sc);
     PROTECT(result);
-    switch(TYPEOF(x)) {
+    if (R_isWideInteger(x)) {
+	MATRIX_SUBSET_LOOP(WIDEINT_PTR(result)[ij] = INTEGER64_ELT(x, iijj),
+			   WIDEINT_PTR(result)[ij] = NA_INTEGER64);
+    }
+    else switch(TYPEOF(x)) {
     case LGLSXP:
 	MATRIX_SUBSET_LOOP(LOGICAL0(result)[ij] = LOGICAL_ELT(x, iijj),
 			   LOGICAL0(result)[ij] = NA_LOGICAL);
@@ -509,6 +516,12 @@ static SEXP ArraySubset(SEXP x, SEXP s, SEXP call, int drop)
 	}
 
     /* Transfer the subset elements from "x" to "a". */
+    if (R_isWideInteger(x)) {
+	PROTECT(result = allocWideIntVector(n));
+	ARRAY_SUBSET_LOOP(WIDEINT_PTR(result)[i] = INTEGER64_ELT(x, ii),
+			  WIDEINT_PTR(result)[i] = NA_INTEGER64);
+    }
+    else {
     PROTECT(result = allocVector(mode, n));
     switch (mode) {
     case LGLSXP:
@@ -548,6 +561,7 @@ static SEXP ArraySubset(SEXP x, SEXP s, SEXP call, int drop)
 	errorcall(call, _("array subscripting not handled for this type"));
 	break;
     }
+    } /* !R_isWideInteger(x) */
 
     SEXP new_dim = PROTECT(allocVector(INTSXP, k));
     for(int i = 0 ; i < k ; i++)

--- a/src/main/subset.c
+++ b/src/main/subset.c
@@ -131,7 +131,7 @@ attribute_hidden SEXP ExtractSubset(SEXP x, SEXP indx, SEXP call)
     int mode = TYPEOF(x);
 
     if (R_isWideInteger(x)) {
-	PROTECT(result = allocWideIntVector(n));
+	PROTECT(result = R_allocWideIntVector(n));
 	EXTRACT_SUBSET_LOOP(WIDEINT_PTR(result)[i] = INTEGER64_ELT(x, ii),
 			    WIDEINT_PTR(result)[i] = NA_INTEGER64);
 	UNPROTECT(1); /* result */
@@ -336,7 +336,7 @@ static SEXP MatrixSubset(SEXP x, SEXP s, SEXP call, int drop)
     PROTECT(sr);
     PROTECT(sc);
     if (R_isWideInteger(x))
-	result = allocWideIntVector((R_xlen_t) nrs * (R_xlen_t) ncs);
+	result = R_allocWideIntVector((R_xlen_t) nrs * (R_xlen_t) ncs);
     else
 	result = allocVector(TYPEOF(x), (R_xlen_t) nrs * (R_xlen_t) ncs);
     const int *psr = INTEGER_RO(sr);
@@ -517,7 +517,7 @@ static SEXP ArraySubset(SEXP x, SEXP s, SEXP call, int drop)
 
     /* Transfer the subset elements from "x" to "a". */
     if (R_isWideInteger(x)) {
-	PROTECT(result = allocWideIntVector(n));
+	PROTECT(result = R_allocWideIntVector(n));
 	ARRAY_SUBSET_LOOP(WIDEINT_PTR(result)[i] = INTEGER64_ELT(x, ii),
 			  WIDEINT_PTR(result)[i] = NA_INTEGER64);
     }

--- a/src/main/subset.c
+++ b/src/main/subset.c
@@ -130,6 +130,14 @@ attribute_hidden SEXP ExtractSubset(SEXP x, SEXP indx, SEXP call)
     nx = xlength(x);
     int mode = TYPEOF(x);
 
+    if (R_isWideInteger(x)) {
+	PROTECT(result = allocWideIntVector(n));
+	EXTRACT_SUBSET_LOOP(WIDEINT_PTR(result)[i] = INTEGER64_ELT(x, ii),
+			    WIDEINT_PTR(result)[i] = NA_INTEGER64);
+	UNPROTECT(1); /* result */
+	return result;
+    }
+
     /* protect allocation in case _ELT operations need to allocate */
     PROTECT(result = allocVector(mode, n));
     switch(mode) {
@@ -743,8 +751,11 @@ attribute_hidden SEXP do_subset_dflt(SEXP call, SEXP op, SEXP args, SEXP rho)
 		    return ScalarReal( REAL_ELT(x, i-1) );
 		break;
 	    case INTSXP:
-		if (i >= 1 && i <= XLENGTH(x))
+		if (i >= 1 && i <= XLENGTH(x)) {
+		    if (R_isWideInteger(x))
+			return ScalarWideInt(INTEGER64_ELT(x, i-1));
 		    return ScalarInteger( INTEGER_ELT(x, i-1) );
+		}
 		break;
 	    case LGLSXP:
 		if (i >= 1 && i <= XLENGTH(x))
@@ -787,8 +798,11 @@ attribute_hidden SEXP do_subset_dflt(SEXP call, SEXP op, SEXP args, SEXP rho)
 			    return ScalarReal( REAL_ELT(x, k) );
 			break;
 		    case INTSXP:
-			if (k < XLENGTH(x))
+			if (k < XLENGTH(x)) {
+			    if (R_isWideInteger(x))
+				return ScalarWideInt(INTEGER64_ELT(x, k));
 			    return ScalarInteger( INTEGER_ELT(x, k) );
+			}
 			break;
 		    case LGLSXP:
 			if (k < XLENGTH(x))
@@ -1118,6 +1132,8 @@ attribute_hidden SEXP do_subset2_dflt(SEXP call, SEXP op, SEXP args, SEXP rho)
 #ifndef SWITCH_TO_REFCNT
 	RAISE_NAMED(ans, named_x);
 #endif
+    } else if (R_isWideInteger(x)) {
+	ans = ScalarWideInt(INTEGER64_ELT(x, offset));
     } else {
 	ans = PROTECT(allocVector(TYPEOF(x), 1));
 	switch (TYPEOF(x)) {

--- a/src/main/summary.c
+++ b/src/main/summary.c
@@ -55,17 +55,18 @@ static int isum(SEXP sx, isum_INT *value, bool narm, SEXP call)
     int updated = 0;
 
     if (R_isWideInteger(sx)) {
+	R_wideint_t ws = 0;
 	R_xlen_t n = XLENGTH(sx);
 	for (R_xlen_t k = 0; k < n; k++) {
 	    R_wideint_t v = INTEGER64_ELT(sx, k);
 	    if (v != NA_INTEGER64) {
 		if (!updated) updated = 1;
-		if (__builtin_add_overflow(s, (isum_INT) v, &s))
+		if (R_ovf_add(ws, v, &ws))
 		    return 42; /* overflow: caller switches to risum() */
 	    } else if (!narm)
 		return NA_INTEGER;
 	}
-	*value = s;
+	*value = ws;
 	return updated;
     }
 #ifdef LONG_VECTOR_SUPPORT
@@ -142,6 +143,25 @@ static bool risum(SEXP sx, double *value, bool narm)
 {
     LDOUBLE s = 0.0;
     bool updated = false;
+
+    if (R_isWideInteger(sx)) {
+	R_xlen_t n = XLENGTH(sx);
+	for (R_xlen_t k = 0; k < n; k++) {
+	    R_wideint_t v = INTEGER64_ELT(sx, k);
+	    if (v != NA_INTEGER64) {
+		if (!updated) updated = true;
+		s += (double) v;
+	    } else if (!narm) {
+		if (!updated) updated = true;
+		*value = NA_REAL;
+		return updated;
+	    }
+	}
+	if (s > DBL_MAX) *value = R_PosInf;
+	else if (s < -DBL_MAX) *value = R_NegInf;
+	else *value = (double) s;
+	return updated;
+    }
 
     /**** assumes INTEGER(sx) and LOGICAL(sx) are identical!! */
     ITERATE_BY_REGION(sx, x, i, nbatch, int, INTEGER, {
@@ -298,6 +318,56 @@ static bool imax(SEXP sx, int *value, bool narm)
     return updated;
 }
 
+/* min()/max() over a wide integer argument mixed with a non-integer
+   argument: the generic accumulator is int/double/string-typed and a
+   wide value need not fit in int, so accumulate as a double (matching
+   the documented wide-to-double coercion for values above 2^53). */
+static bool wimin(SEXP sx, double *value, bool narm)
+{
+    double s = 0.0;
+    bool updated = false;
+    R_xlen_t n = XLENGTH(sx);
+
+    for (R_xlen_t k = 0; k < n; k++) {
+	R_wideint_t v = INTEGER64_ELT(sx, k);
+	if (v != NA_INTEGER64) {
+	    double dv = (double) v;
+	    if (!updated || dv < s) {
+		s = dv;
+		if (!updated) updated = true;
+	    }
+	} else if (!narm) {
+	    *value = NA_REAL;
+	    return true;
+	}
+    }
+    *value = s;
+    return updated;
+}
+
+static bool wimax(SEXP sx, double *value, bool narm)
+{
+    double s = 0.0;
+    bool updated = false;
+    R_xlen_t n = XLENGTH(sx);
+
+    for (R_xlen_t k = 0; k < n; k++) {
+	R_wideint_t v = INTEGER64_ELT(sx, k);
+	if (v != NA_INTEGER64) {
+	    double dv = (double) v;
+	    if (!updated || dv > s) {
+		s = dv;
+		if (!updated) updated = true;
+	    }
+	} else if (!narm) {
+	    *value = NA_REAL;
+	    return true;
+	}
+    }
+    *value = s;
+    return updated;
+}
+
 static bool rmax(SEXP sx, double *value, bool narm)
 {
     double s = 0.0 /* -Wall */;
@@ -350,6 +420,29 @@ static bool iprod(SEXP sx, double *value, bool narm)
 {
     LDOUBLE s = 1.0;
     bool updated = false;
+
+    if (R_isWideInteger(sx)) {
+	R_xlen_t n = XLENGTH(sx);
+	for (R_xlen_t k = 0; k < n; k++) {
+	    R_wideint_t v = INTEGER64_ELT(sx, k);
+	    if (v != NA_INTEGER64) {
+		s *= (double) v;
+		if (!updated) updated = true;
+	    } else if (!narm) {
+		if (!updated) updated = true;
+		*value = NA_REAL;
+		return updated;
+	    }
+	    if (ISNAN(s)) {
+		*value = NA_REAL;
+		return updated;
+	    }
+	}
+	if (s > DBL_MAX) *value = R_PosInf;
+	else if (s < -DBL_MAX) *value = R_NegInf;
+	else *value = (double) s;
+	return updated;
+    }
 
     /**** assumes INTEGER(sx) and LOGICAL(sx) are identical!! */
     ITERATE_BY_REGION(sx, x, i, nbatch, int, INTEGER, {
@@ -796,6 +889,19 @@ attribute_hidden SEXP do_summary(SEXP call, SEXP op, SEXP args, SEXP env)
 		switch(TYPEOF(a)) {
 		case LGLSXP:
 		case INTSXP:
+		    if (R_isWideInteger(a)) {
+			/* a wide value may not fit in int; accumulate as a
+			   double (reached only when a non-integer argument
+			   is also present) */
+			real_a = true;
+			if(ans_type == INTSXP) {
+			    ans_type = REALSXP;
+			    if(!empty) zcum.r = Int2Real(icum);
+			}
+			if (iop == 2) updated = wimin(a, &tmp, narm);
+			else	      updated = wimax(a, &tmp, narm);
+			break;
+		    }
 		    int_a = true;
 		    if (iop == 2) updated = imin(a, &itmp, narm);
 		    else	  updated = imax(a, &itmp, narm);

--- a/src/main/summary.c
+++ b/src/main/summary.c
@@ -325,12 +325,14 @@ static bool imax(SEXP sx, int *value, bool narm)
 static bool wimin(SEXP sx, double *value, bool narm)
 {
     double s = 0.0;
-    bool updated = false;
+    bool updated = false, prec = false;
     R_xlen_t n = XLENGTH(sx);
 
     for (R_xlen_t k = 0; k < n; k++) {
 	R_wideint_t v = INTEGER64_ELT(sx, k);
 	if (v != NA_INTEGER64) {
+	    if (v > R_WIDEINT_DBL_EXACT || v < -R_WIDEINT_DBL_EXACT)
+		prec = true;
 	    double dv = (double) v;
 	    if (!updated || dv < s) {
 		s = dv;
@@ -341,6 +343,8 @@ static bool wimin(SEXP sx, double *value, bool narm)
 	    return true;
 	}
     }
+    if (prec)
+	warning(_("coercing wide integers above 2^53 loses precision"));
     *value = s;
     return updated;
 }
@@ -348,12 +352,14 @@ static bool wimin(SEXP sx, double *value, bool narm)
 static bool wimax(SEXP sx, double *value, bool narm)
 {
     double s = 0.0;
-    bool updated = false;
+    bool updated = false, prec = false;
     R_xlen_t n = XLENGTH(sx);
 
     for (R_xlen_t k = 0; k < n; k++) {
 	R_wideint_t v = INTEGER64_ELT(sx, k);
 	if (v != NA_INTEGER64) {
+	    if (v > R_WIDEINT_DBL_EXACT || v < -R_WIDEINT_DBL_EXACT)
+		prec = true;
 	    double dv = (double) v;
 	    if (!updated || dv > s) {
 		s = dv;
@@ -364,6 +370,8 @@ static bool wimax(SEXP sx, double *value, bool narm)
 	    return true;
 	}
     }
+    if (prec)
+	warning(_("coercing wide integers above 2^53 loses precision"));
     *value = s;
     return updated;
 }
@@ -739,7 +747,8 @@ attribute_hidden SEXP do_summary(SEXP call, SEXP op, SEXP args, SEXP env)
 	    SEXP av = CAR(t);
 	    if (R_isWideInteger(av))
 		any_wide = true;
-	    else if (TYPEOF(av) != INTSXP && TYPEOF(av) != LGLSXP)
+	    else if (TYPEOF(av) != INTSXP && TYPEOF(av) != LGLSXP &&
+		     TYPEOF(av) != NILSXP) /* NULL == integer(0) here */
 		all_intish = false;
 	}
 	if (any_wide && all_intish) {
@@ -752,7 +761,7 @@ attribute_hidden SEXP do_summary(SEXP call, SEXP op, SEXP args, SEXP env)
 
 	    for (SEXP t = args; t != R_NilValue && !na; t = CDR(t)) {
 		SEXP av = CAR(t);
-		R_xlen_t n = XLENGTH(av);
+		R_xlen_t n = xlength(av); /* av may be NULL */
 		for (R_xlen_t i = 0; i < n; i++) {
 		    R_wideint_t v;
 		    if (TYPEOF(av) == LGLSXP) {

--- a/src/main/summary.c
+++ b/src/main/summary.c
@@ -744,8 +744,9 @@ attribute_hidden SEXP do_summary(SEXP call, SEXP op, SEXP args, SEXP env)
 	}
 	if (any_wide && all_intish) {
 	    int iop = PRIMVAL(op);
-	    bool na = false, seen = false;
+	    bool na = false, seen = false, p_exact = true;
 	    LDOUBLE p = 1.0;
+	    R_wideint_t wp = 1;
 	    R_wideint_t cum =
 		(iop == 2) ? R_WIDEINT_MAX : -R_WIDEINT_MAX;
 
@@ -769,16 +770,29 @@ attribute_hidden SEXP do_summary(SEXP call, SEXP op, SEXP args, SEXP env)
 			continue;
 		    }
 		    seen = true;
-		    if (iop == 4)
+		    if (iop == 4) {
 			p *= (double) v;
+			if (p_exact && (R_ovf_mul(wp, v, &wp) ||
+					wp == NA_INTEGER64))
+			    p_exact = false;
+		    }
 		    else if (iop == 2 ? v < cum : v > cum)
 			cum = v;
 		}
 	    }
 
 	    UNPROTECT(1); /* args */
-	    if (iop == 4)
-		return ScalarReal(na ? NA_REAL : (double) p);
+	    if (iop == 4) {
+		/* prod() returns double even for integer args; track the
+		   exact 64-bit product so precision loss is at least loud */
+		if (na)
+		    return ScalarReal(NA_REAL);
+		if (!p_exact ||
+		    wp > R_WIDEINT_DBL_EXACT || wp < -R_WIDEINT_DBL_EXACT)
+		    warningcall(call,
+			_("product of wide integers above 2^53 loses precision"));
+		return ScalarReal(p_exact ? (double) wp : (double) p);
+	    }
 	    if (na)
 		return ScalarWideInt(NA_INTEGER64);
 	    if (!seen) {
@@ -799,7 +813,10 @@ attribute_hidden SEXP do_summary(SEXP call, SEXP op, SEXP args, SEXP env)
 	   updated != 0 , as soon as (i)tmp (do_summary),
 	   or *value ([ir]min / max) is assigned;  */
     SEXP a;
-    double tmp = 0.0, s;
+    double tmp = 0.0;
+#ifndef LONG_INT
+    double s;
+#endif
     Rcomplex ztmp, zcum={.r = 0.0, .i = 0.0} /* -Wall */;
     int itmp = 0, icum = 0, warn = 0 /* dummy */;
     bool use_isum = true; // indicating if isum() should used; otherwise irsum()
@@ -998,26 +1015,29 @@ attribute_hidden SEXP do_summary(SEXP call, SEXP op, SEXP args, SEXP env)
 			// re-sum() 'a' (a waste, rare; FIXME ?) :
 			risum(a, &tmp, narm);
 			zcum.r = (double) iLcum + tmp;
+			if (R_isWideInteger(a))
+			    warningcall(call, _("sum() of wide integers exceeds the 64-bit range; returning an inexact double"));
 			DbgP3(" .. switching type to REAL, tmp=%g, zcum.r=%g",
 			      tmp, zcum.r);
 		    }
 		    else if(updated) {
 			// iLtmp is LONG_INT i.e. at least 64bit
 			if(ans_type == INTSXP) {
-			    s = (double) iLcum + (double) iLtmp;
-			    if(s > INT_MAX || s < R_INT_MIN ||
-			       iLtmp < -LONG_INT_MAX || LONG_INT_MAX < iLtmp) {
-				ans_type = REALSXP;
-				zcum.r = s;
-				DbgP2(" int_1 switch: zcum.r = s = %g\n", s);
-			    } else if(s < -(double)LONG_INT_MAX || (double)LONG_INT_MAX < s) {
+			    /* accumulate exactly while the total fits in 64
+			       bits; the final answer widens past INT_MAX */
+			    R_wideint_t ws;
+			    if (R_ovf_add((R_wideint_t) iLcum,
+					  (R_wideint_t) iLtmp, &ws) ||
+				ws == NA_INTEGER64) {
 				use_isum = false;
 				ans_type = REALSXP;
-				zcum.r = s;
-				DbgP2(" int_2 switch: zcum.r = s = %g\n", s);
+				zcum.r = (double) iLcum + (double) iLtmp;
+				if (R_isWideInteger(a))
+				    warningcall(call, _("sum() of wide integers exceeds the 64-bit range; returning an inexact double"));
+				DbgP2(" int_1 switch: zcum.r = %g\n", zcum.r);
 			    }
 			    else {
-				iLcum += iLtmp;
+				iLcum = ws;
 				DbgP3(" int_3: (iLtmp,iLcum) = (%ld,%ld)\n",
 				      iLtmp, iLcum);
 			    }
@@ -1047,7 +1067,9 @@ attribute_hidden SEXP do_summary(SEXP call, SEXP op, SEXP args, SEXP env)
 		case REALSXP:
 		    if(ans_type == INTSXP) {
 			ans_type = REALSXP;
-			if(!empty) zcum.r = Int2Real(iLcum);
+			/* plain cast: iLcum is an exact 64-bit total, not
+			   an int, so must not hit the NA sentinel */
+			if(!empty) zcum.r = (double) iLcum;
 		    }
 		    updated = rsum(a, &tmp, narm);
 		    if(updated) {
@@ -1057,7 +1079,7 @@ attribute_hidden SEXP do_summary(SEXP call, SEXP op, SEXP args, SEXP env)
 		case CPLXSXP:
 		    if(ans_type == INTSXP) {
 			ans_type = CPLXSXP;
-			if(!empty) zcum.r = Int2Real(iLcum);
+			if(!empty) zcum.r = (double) iLcum;
 		    } else if (ans_type == REALSXP)
 			ans_type = CPLXSXP;
 		    updated = csum(a, &ztmp, narm);
@@ -1158,6 +1180,15 @@ attribute_hidden SEXP do_summary(SEXP call, SEXP op, SEXP args, SEXP env)
 		warningcall(call, _("no non-missing arguments to max; returning -Inf"));
 	    ans_type = REALSXP;
 	}
+    }
+
+    /* an exact integer sum beyond the 32-bit range widens, matching
+       the narrow-arithmetic overflow promotion */
+    if (iop == 0 && ans_type == INTSXP &&
+	((R_wideint_t) iLcum > INT_MAX || (R_wideint_t) iLcum < R_INT_MIN)) {
+	ans = ScalarWideInt((R_wideint_t) iLcum);
+	UNPROTECT(2); /* scum, args */
+	return ans;
     }
 
     ans = allocVector(ans_type, 1);

--- a/src/main/summary.c
+++ b/src/main/summary.c
@@ -747,7 +747,7 @@ attribute_hidden SEXP do_summary(SEXP call, SEXP op, SEXP args, SEXP env)
 	    bool na = false, seen = false;
 	    LDOUBLE p = 1.0;
 	    R_wideint_t cum =
-		(iop == 2) ? 9223372036854775807LL : -9223372036854775807LL;
+		(iop == 2) ? R_WIDEINT_MAX : -R_WIDEINT_MAX;
 
 	    for (SEXP t = args; t != R_NilValue && !na; t = CDR(t)) {
 		SEXP av = CAR(t);

--- a/src/main/summary.c
+++ b/src/main/summary.c
@@ -57,7 +57,7 @@ static int isum(SEXP sx, isum_INT *value, bool narm, SEXP call)
     if (R_isWideInteger(sx)) {
 	R_xlen_t n = XLENGTH(sx);
 	for (R_xlen_t k = 0; k < n; k++) {
-	    long long v = INTEGER64_ELT(sx, k);
+	    R_wideint_t v = INTEGER64_ELT(sx, k);
 	    if (v != NA_INTEGER64) {
 		if (!updated) updated = 1;
 		if (__builtin_add_overflow(s, (isum_INT) v, &s))

--- a/src/main/summary.c
+++ b/src/main/summary.c
@@ -53,6 +53,21 @@ static int isum(SEXP sx, isum_INT *value, bool narm, SEXP call)
 {
     LONG_INT s = 0;  // at least 64-bit
     int updated = 0;
+
+    if (R_isWideInteger(sx)) {
+	R_xlen_t n = XLENGTH(sx);
+	for (R_xlen_t k = 0; k < n; k++) {
+	    long long v = INTEGER64_ELT(sx, k);
+	    if (v != NA_INTEGER64) {
+		if (!updated) updated = 1;
+		if (__builtin_add_overflow(s, (isum_INT) v, &s))
+		    return 42; /* overflow: caller switches to risum() */
+	    } else if (!narm)
+		return NA_INTEGER;
+	}
+	*value = s;
+	return updated;
+    }
 #ifdef LONG_VECTOR_SUPPORT
     int ii = R_INT_MIN; // need > 2^32 entries to overflow; checking earlier is a waste
 /* NOTE: cannot use 64-bit *value to pass NA_INTEGER: that is "regular" 64bit int

--- a/src/main/summary.c
+++ b/src/main/summary.c
@@ -482,6 +482,15 @@ static R_INLINE SEXP integer_mean(SEXP x)
 {
     R_xlen_t n = XLENGTH(x);
     LDOUBLE s = 0.0;
+    if (R_isWideInteger(x)) {
+	for (R_xlen_t i = 0; i < n; i++) {
+	    R_wideint_t xi = INTEGER64_ELT(x, i);
+	    if(xi == NA_INTEGER64)
+		return ScalarReal(R_NaReal);
+	    s += (double) xi;
+	}
+	return ScalarReal((double) (s/n));
+    }
     for (R_xlen_t i = 0; i < n; i++) {
 	int xi = INTEGER_ELT(x, i);
 	if(xi == NA_INTEGER)
@@ -625,6 +634,68 @@ attribute_hidden SEXP do_summary(SEXP call, SEXP op, SEXP args, SEXP env)
 	if(toret != NULL) {
 	    UNPROTECT(1); /* args */
 	    return toret;
+	}
+    }
+
+    /* Wide (64-bit) integer early path for min/max/prod over
+       integer-ish arguments: the generic accumulator machinery below
+       is three-typed (int/double/string). */
+    if (PRIMVAL(op) == 2 || PRIMVAL(op) == 3 || PRIMVAL(op) == 4) {
+	bool any_wide = false, all_intish = true;
+	for (SEXP t = args; t != R_NilValue; t = CDR(t)) {
+	    SEXP av = CAR(t);
+	    if (R_isWideInteger(av))
+		any_wide = true;
+	    else if (TYPEOF(av) != INTSXP && TYPEOF(av) != LGLSXP)
+		all_intish = false;
+	}
+	if (any_wide && all_intish) {
+	    int iop = PRIMVAL(op);
+	    bool na = false, seen = false;
+	    LDOUBLE p = 1.0;
+	    R_wideint_t cum =
+		(iop == 2) ? 9223372036854775807LL : -9223372036854775807LL;
+
+	    for (SEXP t = args; t != R_NilValue && !na; t = CDR(t)) {
+		SEXP av = CAR(t);
+		R_xlen_t n = XLENGTH(av);
+		for (R_xlen_t i = 0; i < n; i++) {
+		    R_wideint_t v;
+		    if (TYPEOF(av) == LGLSXP) {
+			int lv = LOGICAL_ELT(av, i);
+			v = (lv == NA_LOGICAL) ? NA_INTEGER64
+			    : (R_wideint_t) lv;
+		    } else
+			v = INTEGER64_ELT(av, i);
+
+		    if (v == NA_INTEGER64) {
+			if (!narm) {
+			    na = true;
+			    break;
+			}
+			continue;
+		    }
+		    seen = true;
+		    if (iop == 4)
+			p *= (double) v;
+		    else if (iop == 2 ? v < cum : v > cum)
+			cum = v;
+		}
+	    }
+
+	    UNPROTECT(1); /* args */
+	    if (iop == 4)
+		return ScalarReal(na ? NA_REAL : (double) p);
+	    if (na)
+		return ScalarWideInt(NA_INTEGER64);
+	    if (!seen) {
+		/* mimic min(integer(0)) etc */
+		warningcall(call, iop == 2
+		    ? _("no non-missing arguments to min; returning Inf")
+		    : _("no non-missing arguments to max; returning -Inf"));
+		return ScalarReal(iop == 2 ? R_PosInf : R_NegInf);
+	    }
+	    return ScalarWideInt(cum);
 	}
     }
 
@@ -1078,6 +1149,22 @@ attribute_hidden SEXP do_first_min(SEXP call, SEXP op, SEXP args, SEXP rho)
     break;
 
     case INTSXP:
+    if (R_isWideInteger(sx))
+    {
+	R_wideint_t s = 0;
+	for (i = 0; i < n; i++) {
+	    R_wideint_t v = INTEGER64_ELT(sx, i);
+	    if (v == NA_INTEGER64)
+		continue;
+	    if (indx == -1 ||
+		(PRIMVAL(op) == 0 ? v < s : v > s)) {
+		s = v;
+		indx = i;
+	    }
+	}
+	break;
+    }
+    else
     {
 	int s, *r = INTEGER(sx);
 	if(PRIMVAL(op) == 0) { /* which.min */

--- a/src/main/unique.c
+++ b/src/main/unique.c
@@ -123,9 +123,17 @@ static hlen lhash(SEXP x, R_xlen_t indx, HashData *d)
    picks per vector and intHashWiden() upgrades for two-vector uses. */
 /* Raw 32-bit read for the narrow scheme: skips INTEGER_ELT's wideness
    checks, which scheme selection has already established cannot fire.
-   HashLookup guards the invariant once per call. */
+   HashLookup guards the lookup path once per call; the STRICT_TYPECHECK
+   assert below catches the other way in: a direct data.equal()/hash on a
+   wide vector without a preceding intHashWiden().  Reading a wide payload
+   as int32 here would silently corrupt, so make the invariant violation
+   loud in checked builds (it is compiled out otherwise). */
 static R_INLINE int IELT32(SEXP x, R_xlen_t i)
 {
+#ifdef STRICT_TYPECHECK
+    if (R_isWideInteger(x))
+	error("narrow integer hash scheme applied to a wide integer vector");
+#endif
     return ALTREP(x) ? ALTINTEGER_ELT(x, i) : ((int *) STDVEC_DATAPTR(x))[i];
 }
 

--- a/src/main/unique.c
+++ b/src/main/unique.c
@@ -1209,7 +1209,7 @@ attribute_hidden SEXP do_duplicated(SEXP call, SEXP op, SEXP args, SEXP env)
 		if(duptr[j] == 0) k++;
 	});
 
-    SEXP ans = PROTECT(R_isWideInteger(x) ? allocWideIntVector(k)
+    SEXP ans = PROTECT(R_isWideInteger(x) ? R_allocWideIntVector(k)
 					  : allocVector(TYPEOF(x), k));
 
     k = 0;

--- a/src/main/unique.c
+++ b/src/main/unique.c
@@ -1083,6 +1083,9 @@ static SEXP duplicated3(SEXP x, SEXP incomp, Rboolean from_last, int nmax)
 
     if(length(incomp)) {
 	PROTECT(incomp = coerceVector(incomp, TYPEOF(x)));
+	/* incomp may be wide even when x is narrow: use the
+	   width-agnostic comparator so data.equal reads it correctly */
+	intHashWiden(&data, incomp);
 	m = length(incomp);
 	for (i = 0; i < n; i++)
 	    if(v[i]) {
@@ -1108,6 +1111,9 @@ R_xlen_t any_duplicated3(SEXP x, SEXP incomp, Rboolean from_last)
     if(!m) error(_("any_duplicated3(., <0-length incomp>)"));
 
     PROTECT(incomp = coerceVector(incomp, TYPEOF(x)));
+    /* widen the scheme before any hashing so both the table lookups and
+       the direct incomp comparisons read a wide incomp correctly */
+    intHashWiden(&data, incomp);
     m = length(incomp);
 
     if(from_last)

--- a/src/main/unique.c
+++ b/src/main/unique.c
@@ -115,10 +115,29 @@ static hlen lhash(SEXP x, R_xlen_t indx, HashData *d)
     return (hlen) xi;
 }
 
-static R_INLINE hlen ihash(SEXP x, R_xlen_t indx, HashData *d)
+/* Two integer hash schemes: ihash32 is the narrow fast path, ihash64
+   is width-agnostic (INTEGER64_ELT reads narrow and wide vectors, so
+   a mixed narrow/wide x-vs-table hashes consistently).  They disagree
+   for negative values (sign extension changes u ^ (u >> 32)), so a
+   table must keep one scheme for its whole lifetime: HashTableSetup
+   picks per vector and intHashWiden() upgrades for two-vector uses. */
+/* Raw 32-bit read for the narrow scheme: skips INTEGER_ELT's wideness
+   checks, which scheme selection has already established cannot fire.
+   HashLookup guards the invariant once per call. */
+static R_INLINE int IELT32(SEXP x, R_xlen_t i)
 {
-    /* width-agnostic: INTEGER64_ELT reads narrow and wide vectors, so
-       a mixed narrow/wide x-vs-table hashes consistently */
+    return ALTREP(x) ? ALTINTEGER_ELT(x, i) : ((int *) STDVEC_DATAPTR(x))[i];
+}
+
+static R_INLINE hlen ihash32(SEXP x, R_xlen_t indx, HashData *d)
+{
+    int xi = IELT32(x, indx);
+    if (xi == NA_INTEGER) return 0;
+    return scatter((unsigned int) xi, d);
+}
+
+static R_INLINE hlen ihash64(SEXP x, R_xlen_t indx, HashData *d)
+{
     R_wideint_t xi = INTEGER64_ELT(x, indx);
     if (xi == NA_INTEGER64) return 0;
     unsigned long long u = (unsigned long long) xi;
@@ -246,10 +265,16 @@ static int lequal(SEXP x, R_xlen_t i, SEXP y, R_xlen_t j)
 }
 
 
-static R_INLINE int iequal(SEXP x, R_xlen_t i, SEXP y, R_xlen_t j)
+static R_INLINE int iequal32(SEXP x, R_xlen_t i, SEXP y, R_xlen_t j)
 {
     if (i < 0 || j < 0) return 0;
-    /* width-agnostic, as for ihash */
+    return (IELT32(x, i) == IELT32(y, j));
+}
+
+static R_INLINE int iequal64(SEXP x, R_xlen_t i, SEXP y, R_xlen_t j)
+{
+    if (i < 0 || j < 0) return 0;
+    /* width-agnostic, as for ihash64 */
     return (INTEGER64_ELT(x, i) == INTEGER64_ELT(y, j));
 }
 
@@ -346,7 +371,8 @@ static hlen vhash_one(SEXP _this, HashData *d)
 	break;
     case INTSXP:
 	for(i = 0; i < LENGTH(_this); i++) {
-	    key ^= ihash(_this, i, d);
+	    /* always width-agnostic: list elements may be wide */
+	    key ^= ihash64(_this, i, d);
 	    key *= 97;
 	}
 	break;
@@ -477,8 +503,14 @@ static void HashTableSetup(SEXP x, HashData *d, R_xlen_t nmax)
 	break;
     case INTSXP:
     {
-	d->hash = ihash;
-	d->equal = iequal;
+	if (R_isWideInteger(x) || d->inHashtab) {
+	    d->hash = ihash64;
+	    d->equal = iequal64;
+	}
+	else {
+	    d->hash = ihash32;
+	    d->equal = iequal32;
+	}
 #ifdef LONG_VECTOR_SUPPORT
 	R_xlen_t nn = XLENGTH(x);
 	if (nn > IMAX) nn = IMAX;
@@ -528,6 +560,17 @@ static void HashTableSetup(SEXP x, HashData *d, R_xlen_t nmax)
     {
 	d->HashTable = allocVector(INTSXP, (R_xlen_t) d->M);
 	for (R_xlen_t i = 0; i < d->M; i++) HTDATA_INT(d)[i] = NIL;
+    }
+}
+
+/* Upgrade an integer hash table to the width-agnostic scheme.  Call
+   before any hashing, for every vector that will be hashed into or
+   compared against a table set up on another vector. */
+static R_INLINE void intHashWiden(HashData *d, SEXP x)
+{
+    if (d->hash == ihash32 && R_isWideInteger(x)) {
+	d->hash = ihash64;
+	d->equal = iequal64;
     }
 }
 
@@ -1257,7 +1300,8 @@ static void UndoHashing(SEXP x, SEXP table, HashData *d)
     }
 
 /* definitions to help the C compiler to inline of most important cases */
-DEFLOOKUP(iLookup, ihash, iequal)
+DEFLOOKUP(iLookup32, ihash32, iequal32)
+DEFLOOKUP(iLookup64, ihash64, iequal64)
 DEFLOOKUP(rLookup, rhash, requal)
 DEFLOOKUP(sLookup, shash, sequal)
 
@@ -1276,8 +1320,19 @@ static SEXP HashLookup(SEXP table, SEXP x, HashData *d)
 
     switch (TYPEOF(x)) {
     case INTSXP:
-	for (i = 0; i < n; i++)
-	    pa[i] = iLookup(table, x, i, d);
+	/* branch on the scheme the table was built with, so lookups
+	   always agree with insertions */
+	if (d->hash == ihash64)
+	    for (i = 0; i < n; i++)
+		pa[i] = iLookup64(table, x, i, d);
+	else {
+	    /* the narrow scheme reads raw 32-bit payloads: a wide
+	       vector here means a call site failed to intHashWiden() */
+	    if (R_isWideInteger(x) || R_isWideInteger(table))
+		error("internal error: narrow hash scheme applied to a wide integer vector");
+	    for (i = 0; i < n; i++)
+		pa[i] = iLookup32(table, x, i, d);
+	}
 	break;
     case REALSXP:
 	for (i = 0; i < n; i++)
@@ -1478,6 +1533,8 @@ SEXP match5(SEXP itable, SEXP ix, int nmatch, SEXP incomp, SEXP env)
 	data.nomatch = nmatch;
 	HashTableSetup(table, &data, NA_INTEGER);
 	PROTECT(data.HashTable); nprot++;
+	intHashWiden(&data, x);
+	if (incomp) intHashWiden(&data, incomp);
 	if(type == STRSXP) {
 	    Rboolean useBytes = FALSE;
 	    Rboolean useUTF8 = FALSE;
@@ -2014,6 +2071,7 @@ rowsum(SEXP x, SEXP g, SEXP uniqueg, SEXP snarm, SEXP rn)
 
     HashTableSetup(uniqueg, &data, NA_INTEGER);
     PROTECT(data.HashTable);
+    intHashWiden(&data, g);
     DoHashing(uniqueg, &data);
     PROTECT(matches = HashLookup(uniqueg, g, &data));
     int *pmatches = INTEGER(matches);
@@ -2088,6 +2146,7 @@ rowsum_df(SEXP x, SEXP g, SEXP uniqueg, SEXP snarm, SEXP rn)
 
     HashTableSetup(uniqueg, &data, NA_INTEGER);
     PROTECT(data.HashTable);
+    intHashWiden(&data, g);
     DoHashing(uniqueg, &data);
     PROTECT(matches = HashLookup(uniqueg, g, &data));
     int *pmatches = INTEGER(matches);

--- a/src/main/unique.c
+++ b/src/main/unique.c
@@ -574,6 +574,16 @@ static void HashTableSetup(SEXP x, HashData *d, R_xlen_t nmax)
 /* Upgrade an integer hash table to the width-agnostic scheme.  Call
    before any hashing, for every vector that will be hashed into or
    compared against a table set up on another vector. */
+/* Coerce 'incomparables' to the type of the data.  When the data is
+   wide, a double incomparable must widen rather than narrow so a
+   wide-range value (e.g. 5e9) is not silently turned into NA. */
+static SEXP coerceIncomparables(SEXP incomp, SEXPTYPE type, bool wide)
+{
+    if (wide && TYPEOF(incomp) == REALSXP)
+	return R_asWideInteger(incomp);
+    return coerceVector(incomp, type);
+}
+
 static R_INLINE void intHashWiden(HashData *d, SEXP x)
 {
     if (d->hash == ihash32 && R_isWideInteger(x)) {
@@ -1090,7 +1100,8 @@ static SEXP duplicated3(SEXP x, SEXP incomp, Rboolean from_last, int nmax)
 	}
 
     if(length(incomp)) {
-	PROTECT(incomp = coerceVector(incomp, TYPEOF(x)));
+	PROTECT(incomp = coerceIncomparables(incomp, TYPEOF(x),
+					     R_isWideInteger(x)));
 	/* incomp may be wide even when x is narrow: use the
 	   width-agnostic comparator so data.equal reads it correctly */
 	intHashWiden(&data, incomp);
@@ -1118,7 +1129,8 @@ R_xlen_t any_duplicated3(SEXP x, SEXP incomp, Rboolean from_last)
 
     if(!m) error(_("any_duplicated3(., <0-length incomp>)"));
 
-    PROTECT(incomp = coerceVector(incomp, TYPEOF(x)));
+    PROTECT(incomp = coerceIncomparables(incomp, TYPEOF(x),
+					 R_isWideInteger(x)));
     /* widen the scheme before any hashing so both the table lookups and
        the direct incomp comparisons read a wide incomp correctly */
     intHashWiden(&data, incomp);
@@ -1543,7 +1555,12 @@ SEXP match5(SEXP itable, SEXP ix, int nmatch, SEXP incomp, SEXP env)
     }
     else { // regular case
 	HashData data = { 0 };
-	if (incomp) { PROTECT(incomp = coerceVector(incomp, type)); nprot++; }
+	if (incomp) {
+	    PROTECT(incomp = coerceIncomparables(incomp, type,
+						 R_isWideInteger(x) ||
+						 R_isWideInteger(table)));
+	    nprot++;
+	}
 	data.nomatch = nmatch;
 	HashTableSetup(table, &data, NA_INTEGER);
 	PROTECT(data.HashTable); nprot++;

--- a/src/main/unique.c
+++ b/src/main/unique.c
@@ -117,9 +117,12 @@ static hlen lhash(SEXP x, R_xlen_t indx, HashData *d)
 
 static R_INLINE hlen ihash(SEXP x, R_xlen_t indx, HashData *d)
 {
-    int xi = INTEGER_ELT(x, indx);
-    if (xi == NA_INTEGER) return 0;
-    return scatter((unsigned int) xi, d);
+    /* width-agnostic: INTEGER64_ELT reads narrow and wide vectors, so
+       a mixed narrow/wide x-vs-table hashes consistently */
+    R_wideint_t xi = INTEGER64_ELT(x, indx);
+    if (xi == NA_INTEGER64) return 0;
+    unsigned long long u = (unsigned long long) xi;
+    return scatter((unsigned int)(u ^ (u >> 32)), d);
 }
 
 /* We use unions here because Solaris gcc -O2 has trouble with
@@ -246,7 +249,8 @@ static int lequal(SEXP x, R_xlen_t i, SEXP y, R_xlen_t j)
 static R_INLINE int iequal(SEXP x, R_xlen_t i, SEXP y, R_xlen_t j)
 {
     if (i < 0 || j < 0) return 0;
-    return (INTEGER_ELT(x, i) == INTEGER_ELT(y, j));
+    /* width-agnostic, as for ihash */
+    return (INTEGER64_ELT(x, i) == INTEGER64_ELT(y, j));
 }
 
 /* BDR 2002-1-17  We don't want NA and other NaNs to be equal */
@@ -1162,7 +1166,8 @@ attribute_hidden SEXP do_duplicated(SEXP call, SEXP op, SEXP args, SEXP env)
 		if(duptr[j] == 0) k++;
 	});
 
-    SEXP ans = PROTECT(allocVector(TYPEOF(x), k));
+    SEXP ans = PROTECT(R_isWideInteger(x) ? allocWideIntVector(k)
+					  : allocVector(TYPEOF(x), k));
 
     k = 0;
     switch (TYPEOF(x)) {
@@ -1172,6 +1177,12 @@ attribute_hidden SEXP do_duplicated(SEXP call, SEXP op, SEXP args, SEXP env)
 		LOGICAL0(ans)[k++] = LOGICAL_ELT(x, i);
 	break;
     case INTSXP:
+	if (R_isWideInteger(x)) {
+	    for (i = 0; i < n; i++)
+		if (LOGICAL_ELT(dup, i) == 0)
+		    WIDEINT_PTR(ans)[k++] = INTEGER64_ELT(x, i);
+	    break;
+	}
 	ITERATE_BY_REGION(dup, duptr, idx, nb, int, LOGICAL, {
 		for(R_xlen_t j = 0; j < nb; j++) {
 		    if(duptr[j] == 0)
@@ -1406,6 +1417,15 @@ SEXP match5(SEXP itable, SEXP ix, int nmatch, SEXP incomp, SEXP env)
 	  break; }
       case LGLSXP:
       case INTSXP: {
+	  if (type == INTSXP &&
+	      (R_isWideInteger(x) || R_isWideInteger(table))) {
+	      R_wideint_t x_val = INTEGER64_ELT(x, 0);
+	      for (int i=0; i < ntable; i++)
+		  if (INTEGER64_ELT(table, i) == x_val) {
+		      val = i + 1; break;
+		  }
+	      break;
+	  }
 	  int x_val = INTEGER_ELT(x, 0),
 	      *table_p = INTEGER(table);
 	  for (int i=0; i < ntable; i++) if (table_p[i] == x_val) {

--- a/src/main/wideint.c
+++ b/src/main/wideint.c
@@ -55,6 +55,10 @@ static R_wideint_t wideFromString(SEXP ch)
 	error("value '%s' is out of range for a wide integer", s);
     if (endp == s || *endp != '\0')
 	error("cannot coerce '%s' to a wide integer", s);
+    if (v == NA_INTEGER64)
+	/* -2^63 parses in range but is the NA sentinel; reject it rather
+	   than silently returning NA (wideFromDouble errors here too) */
+	error("value '%s' is out of range for a wide integer", s);
 
     return v;
 }

--- a/src/main/wideint.c
+++ b/src/main/wideint.c
@@ -62,12 +62,11 @@ static R_wideint_t wideFromString(SEXP ch)
     return v;
 }
 
-/* .Internal(as.wideint(x)) */
-attribute_hidden SEXP do_aswideint(SEXP call, SEXP op, SEXP args, SEXP env)
+/* Coerce any coercible vector to a wide integer vector, preserving
+   attributes.  Errors on fractional or out-of-range doubles and on
+   non-numeric strings, matching as.wideint(). */
+attribute_hidden SEXP R_asWideInteger(SEXP x)
 {
-    checkArity(op, args);
-    SEXP x = CAR(args);
-
     if (R_isWideInteger(x))
 	return x;
 
@@ -102,6 +101,13 @@ attribute_hidden SEXP do_aswideint(SEXP call, SEXP op, SEXP args, SEXP env)
     SHALLOW_DUPLICATE_ATTRIB(ans, x);
     UNPROTECT(1);
     return ans;
+}
+
+/* .Internal(as.wideint(x)) */
+attribute_hidden SEXP do_aswideint(SEXP call, SEXP op, SEXP args, SEXP env)
+{
+    checkArity(op, args);
+    return R_asWideInteger(CAR(args));
 }
 
 /* .Internal(is.wideint(x)) */

--- a/src/main/wideint.c
+++ b/src/main/wideint.c
@@ -35,8 +35,7 @@ static R_wideint_t wideFromDouble(double v)
 	return NA_INTEGER64;
     if (v != floor(v))
 	error("cannot coerce fractional value %g to a wide integer", v);
-    if (v >= 9223372036854775808.0 /* 2^63 */ ||
-	v <= -9223372036854775808.0)
+    if (v >= R_WIDEINT_DBL_MAX || v <= -R_WIDEINT_DBL_MAX)
 	error("value %g is out of range for a wide integer", v);
 
     return (R_wideint_t) v;
@@ -154,7 +153,7 @@ attribute_hidden SEXP R_wideIntCoerce(SEXP v, SEXPTYPE type)
 	    if (x == NA_INTEGER64)
 		SET_REAL_ELT(ans, i, NA_REAL);
 	    else {
-		if (x > 9007199254740992LL || x < -9007199254740992LL)
+		if (x > R_WIDEINT_DBL_EXACT || x < -R_WIDEINT_DBL_EXACT)
 		    warn_precision = 1;
 		SET_REAL_ELT(ans, i, (double) x);
 	    }
@@ -182,7 +181,7 @@ attribute_hidden SEXP R_wideIntCoerce(SEXP v, SEXPTYPE type)
 		z.r = NA_REAL; z.i = NA_REAL;
 	    }
 	    else {
-		if (x > 9007199254740992LL || x < -9007199254740992LL)
+		if (x > R_WIDEINT_DBL_EXACT || x < -R_WIDEINT_DBL_EXACT)
 		    warn_precision = 1;
 		z.r = (double) x; z.i = 0.0;
 	    }

--- a/src/main/wideint.c
+++ b/src/main/wideint.c
@@ -1,0 +1,220 @@
+/*
+ *  R : A Computer Language for Statistical Data Analysis
+ *
+ *  wideint.c -- prototype support for wide (64-bit) integer vectors.
+ *
+ *  A wide integer vector is a standard INTSXP whose payload holds
+ *  long long elements, marked with the WIDEINT gp bit.  There is
+ *  deliberately no 64-bit data-pointer accessor; all access is
+ *  element-based (INTEGER64_ELT / SET_INTEGER64_ELT).
+ */
+
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
+#include <Defn.h>
+#include <Internal.h>
+
+#include <errno.h>
+#include <math.h>
+#include <stdlib.h>
+#include <string.h>
+
+SEXP ScalarWideInt(long long v)
+{
+    SEXP ans = allocWideIntVector(1);
+    SET_INTEGER64_ELT(ans, 0, v);
+    return ans;
+}
+
+static long long wideFromDouble(double v)
+{
+    if (ISNAN(v))
+	return NA_INTEGER64;
+    if (v != floor(v))
+	error("cannot coerce fractional value %g to a wide integer", v);
+    if (v >= 9223372036854775808.0 /* 2^63 */ ||
+	v <= -9223372036854775808.0)
+	error("value %g is out of range for a wide integer", v);
+
+    return (long long) v;
+}
+
+static long long wideFromString(SEXP ch)
+{
+    if (ch == NA_STRING)
+	return NA_INTEGER64;
+
+    const char *s = CHAR(ch);
+    char *endp;
+    errno = 0;
+    long long v = strtoll(s, &endp, 10);
+    if (errno == ERANGE)
+	error("value '%s' is out of range for a wide integer", s);
+    if (endp == s || *endp != '\0')
+	error("cannot coerce '%s' to a wide integer", s);
+
+    return v;
+}
+
+/* .Internal(as.wideint(x)) */
+attribute_hidden SEXP do_aswideint(SEXP call, SEXP op, SEXP args, SEXP env)
+{
+    checkArity(op, args);
+    SEXP x = CAR(args);
+
+    if (R_isWideInteger(x))
+	return x;
+
+    R_xlen_t n = XLENGTH(x);
+    SEXP ans = PROTECT(allocWideIntVector(n));
+
+    switch (TYPEOF(x)) {
+    case LGLSXP:
+	for (R_xlen_t i = 0; i < n; i++) {
+	    int v = LOGICAL_ELT(x, i);
+	    SET_INTEGER64_ELT(ans, i,
+			      v == NA_LOGICAL ? NA_INTEGER64 : (long long) v);
+	}
+	break;
+    case INTSXP:
+	for (R_xlen_t i = 0; i < n; i++)
+	    SET_INTEGER64_ELT(ans, i, INTEGER64_ELT(x, i));
+	break;
+    case REALSXP:
+	for (R_xlen_t i = 0; i < n; i++)
+	    SET_INTEGER64_ELT(ans, i, wideFromDouble(REAL_ELT(x, i)));
+	break;
+    case STRSXP:
+	for (R_xlen_t i = 0; i < n; i++)
+	    SET_INTEGER64_ELT(ans, i, wideFromString(STRING_ELT(x, i)));
+	break;
+    default:
+	error("cannot coerce type '%s' to a wide integer vector",
+	      R_typeToChar(x));
+    }
+
+    SHALLOW_DUPLICATE_ATTRIB(ans, x);
+    UNPROTECT(1);
+    return ans;
+}
+
+/* .Internal(is.wideint(x)) */
+attribute_hidden SEXP do_iswideint(SEXP call, SEXP op, SEXP args, SEXP env)
+{
+    checkArity(op, args);
+    return ScalarLogical(R_isWideInteger(CAR(args)));
+}
+
+/* Coercion of a wide integer vector to other atomic types; called
+   from coerceVector().  Coercing to INTSXP is the identity there and
+   never reaches this function. */
+attribute_hidden SEXP R_wideIntCoerce(SEXP v, SEXPTYPE type)
+{
+    R_xlen_t n = XLENGTH(v);
+    SEXP ans;
+    int warn_precision = 0;
+
+    PROTECT(v);
+    switch (type) {
+    case LGLSXP:
+	ans = PROTECT(allocVector(LGLSXP, n));
+	for (R_xlen_t i = 0; i < n; i++) {
+	    long long x = INTEGER64_ELT(v, i);
+	    SET_LOGICAL_ELT(ans, i,
+			    x == NA_INTEGER64 ? NA_LOGICAL : (x != 0));
+	}
+	break;
+    case REALSXP:
+	ans = PROTECT(allocVector(REALSXP, n));
+	for (R_xlen_t i = 0; i < n; i++) {
+	    long long x = INTEGER64_ELT(v, i);
+	    if (x == NA_INTEGER64)
+		SET_REAL_ELT(ans, i, NA_REAL);
+	    else {
+		if (x > 9007199254740992LL || x < -9007199254740992LL)
+		    warn_precision = 1;
+		SET_REAL_ELT(ans, i, (double) x);
+	    }
+	}
+	break;
+    case STRSXP:
+	ans = PROTECT(allocVector(STRSXP, n));
+	for (R_xlen_t i = 0; i < n; i++) {
+	    long long x = INTEGER64_ELT(v, i);
+	    if (x == NA_INTEGER64)
+		SET_STRING_ELT(ans, i, NA_STRING);
+	    else {
+		char buf[32];
+		snprintf(buf, sizeof(buf), "%lld", x);
+		SET_STRING_ELT(ans, i, mkChar(buf));
+	    }
+	}
+	break;
+    case CPLXSXP:
+	ans = PROTECT(allocVector(CPLXSXP, n));
+	for (R_xlen_t i = 0; i < n; i++) {
+	    long long x = INTEGER64_ELT(v, i);
+	    Rcomplex z;
+	    if (x == NA_INTEGER64) {
+		z.r = NA_REAL; z.i = NA_REAL;
+	    }
+	    else {
+		if (x > 9007199254740992LL || x < -9007199254740992LL)
+		    warn_precision = 1;
+		z.r = (double) x; z.i = 0.0;
+	    }
+	    SET_COMPLEX_ELT(ans, i, z);
+	}
+	break;
+    case VECSXP:
+	ans = PROTECT(allocVector(VECSXP, n));
+	for (R_xlen_t i = 0; i < n; i++)
+	    SET_VECTOR_ELT(ans, i, ScalarWideInt(INTEGER64_ELT(v, i)));
+	break;
+    default:
+	error("cannot coerce a wide integer vector to type '%s'",
+	      type2char(type));
+    }
+
+    if (warn_precision)
+	warning("coercing wide integers above 2^53 loses precision");
+
+    SHALLOW_DUPLICATE_ATTRIB(ans, v);
+    UNPROTECT(2);
+    return ans;
+}
+
+/* Format a wide integer vector as a right-justified character vector,
+   used by printing. */
+attribute_hidden SEXP R_formatWideInt(SEXP x)
+{
+    R_xlen_t n = XLENGTH(x);
+    int w = 0;
+
+    for (R_xlen_t i = 0; i < n; i++) {
+	long long v = INTEGER64_ELT(x, i);
+	char buf[32];
+	int len;
+	if (v == NA_INTEGER64)
+	    len = 2; /* NA */
+	else
+	    len = snprintf(buf, sizeof(buf), "%lld", v);
+	if (len > w)
+	    w = len;
+    }
+
+    SEXP ans = PROTECT(allocVector(STRSXP, n));
+    for (R_xlen_t i = 0; i < n; i++) {
+	long long v = INTEGER64_ELT(x, i);
+	char buf[40];
+	if (v == NA_INTEGER64)
+	    snprintf(buf, sizeof(buf), "%*s", w, "NA");
+	else
+	    snprintf(buf, sizeof(buf), "%*lld", w, v);
+	SET_STRING_ELT(ans, i, mkChar(buf));
+    }
+    UNPROTECT(1);
+    return ans;
+}

--- a/src/main/wideint.c
+++ b/src/main/wideint.c
@@ -4,7 +4,8 @@
  *  wideint.c -- prototype support for wide (64-bit) integer vectors.
  *
  *  A wide integer vector is a standard INTSXP whose payload holds
- *  long long elements, marked with the WIDEINT gp bit.  There is
+ *  R_wideint_t (currently long long) elements, marked with the WIDEINT
+ *  gp bit.  There is
  *  deliberately no 64-bit data-pointer accessor; all access is
  *  element-based (INTEGER64_ELT / SET_INTEGER64_ELT).
  */
@@ -21,14 +22,14 @@
 #include <stdlib.h>
 #include <string.h>
 
-SEXP ScalarWideInt(long long v)
+SEXP ScalarWideInt(R_wideint_t v)
 {
     SEXP ans = allocWideIntVector(1);
     SET_INTEGER64_ELT(ans, 0, v);
     return ans;
 }
 
-static long long wideFromDouble(double v)
+static R_wideint_t wideFromDouble(double v)
 {
     if (ISNAN(v))
 	return NA_INTEGER64;
@@ -38,10 +39,10 @@ static long long wideFromDouble(double v)
 	v <= -9223372036854775808.0)
 	error("value %g is out of range for a wide integer", v);
 
-    return (long long) v;
+    return (R_wideint_t) v;
 }
 
-static long long wideFromString(SEXP ch)
+static R_wideint_t wideFromString(SEXP ch)
 {
     if (ch == NA_STRING)
 	return NA_INTEGER64;
@@ -49,7 +50,7 @@ static long long wideFromString(SEXP ch)
     const char *s = CHAR(ch);
     char *endp;
     errno = 0;
-    long long v = strtoll(s, &endp, 10);
+    R_wideint_t v = strtoll(s, &endp, 10);
     if (errno == ERANGE)
 	error("value '%s' is out of range for a wide integer", s);
     if (endp == s || *endp != '\0')
@@ -75,7 +76,7 @@ attribute_hidden SEXP do_aswideint(SEXP call, SEXP op, SEXP args, SEXP env)
 	for (R_xlen_t i = 0; i < n; i++) {
 	    int v = LOGICAL_ELT(x, i);
 	    SET_INTEGER64_ELT(ans, i,
-			      v == NA_LOGICAL ? NA_INTEGER64 : (long long) v);
+			      v == NA_LOGICAL ? NA_INTEGER64 : (R_wideint_t) v);
 	}
 	break;
     case INTSXP:
@@ -121,7 +122,7 @@ attribute_hidden SEXP R_wideIntCoerce(SEXP v, SEXPTYPE type)
     case LGLSXP:
 	ans = PROTECT(allocVector(LGLSXP, n));
 	for (R_xlen_t i = 0; i < n; i++) {
-	    long long x = INTEGER64_ELT(v, i);
+	    R_wideint_t x = INTEGER64_ELT(v, i);
 	    SET_LOGICAL_ELT(ans, i,
 			    x == NA_INTEGER64 ? NA_LOGICAL : (x != 0));
 	}
@@ -129,7 +130,7 @@ attribute_hidden SEXP R_wideIntCoerce(SEXP v, SEXPTYPE type)
     case REALSXP:
 	ans = PROTECT(allocVector(REALSXP, n));
 	for (R_xlen_t i = 0; i < n; i++) {
-	    long long x = INTEGER64_ELT(v, i);
+	    R_wideint_t x = INTEGER64_ELT(v, i);
 	    if (x == NA_INTEGER64)
 		SET_REAL_ELT(ans, i, NA_REAL);
 	    else {
@@ -142,12 +143,12 @@ attribute_hidden SEXP R_wideIntCoerce(SEXP v, SEXPTYPE type)
     case STRSXP:
 	ans = PROTECT(allocVector(STRSXP, n));
 	for (R_xlen_t i = 0; i < n; i++) {
-	    long long x = INTEGER64_ELT(v, i);
+	    R_wideint_t x = INTEGER64_ELT(v, i);
 	    if (x == NA_INTEGER64)
 		SET_STRING_ELT(ans, i, NA_STRING);
 	    else {
 		char buf[32];
-		snprintf(buf, sizeof(buf), "%lld", x);
+		snprintf(buf, sizeof(buf), "%lld", (long long) x);
 		SET_STRING_ELT(ans, i, mkChar(buf));
 	    }
 	}
@@ -155,7 +156,7 @@ attribute_hidden SEXP R_wideIntCoerce(SEXP v, SEXPTYPE type)
     case CPLXSXP:
 	ans = PROTECT(allocVector(CPLXSXP, n));
 	for (R_xlen_t i = 0; i < n; i++) {
-	    long long x = INTEGER64_ELT(v, i);
+	    R_wideint_t x = INTEGER64_ELT(v, i);
 	    Rcomplex z;
 	    if (x == NA_INTEGER64) {
 		z.r = NA_REAL; z.i = NA_REAL;
@@ -194,25 +195,25 @@ attribute_hidden SEXP R_formatWideInt(SEXP x)
     int w = 0;
 
     for (R_xlen_t i = 0; i < n; i++) {
-	long long v = INTEGER64_ELT(x, i);
+	R_wideint_t v = INTEGER64_ELT(x, i);
 	char buf[32];
 	int len;
 	if (v == NA_INTEGER64)
 	    len = 2; /* NA */
 	else
-	    len = snprintf(buf, sizeof(buf), "%lld", v);
+	    len = snprintf(buf, sizeof(buf), "%lld", (long long) v);
 	if (len > w)
 	    w = len;
     }
 
     SEXP ans = PROTECT(allocVector(STRSXP, n));
     for (R_xlen_t i = 0; i < n; i++) {
-	long long v = INTEGER64_ELT(x, i);
+	R_wideint_t v = INTEGER64_ELT(x, i);
 	char buf[40];
 	if (v == NA_INTEGER64)
 	    snprintf(buf, sizeof(buf), "%*s", w, "NA");
 	else
-	    snprintf(buf, sizeof(buf), "%*lld", w, v);
+	    snprintf(buf, sizeof(buf), "%*lld", w, (long long) v);
 	SET_STRING_ELT(ans, i, mkChar(buf));
     }
     UNPROTECT(1);

--- a/src/main/wideint.c
+++ b/src/main/wideint.c
@@ -24,7 +24,7 @@
 
 SEXP ScalarWideInt(R_wideint_t v)
 {
-    SEXP ans = allocWideIntVector(1);
+    SEXP ans = R_allocWideIntVector(1);
     SET_INTEGER64_ELT(ans, 0, v);
     return ans;
 }
@@ -69,7 +69,7 @@ attribute_hidden SEXP do_aswideint(SEXP call, SEXP op, SEXP args, SEXP env)
 	return x;
 
     R_xlen_t n = XLENGTH(x);
-    SEXP ans = PROTECT(allocWideIntVector(n));
+    SEXP ans = PROTECT(R_allocWideIntVector(n));
 
     switch (TYPEOF(x)) {
     case LGLSXP:
@@ -115,7 +115,7 @@ attribute_hidden SEXP R_widenInteger(SEXP x)
 	return x;
 
     R_xlen_t n = XLENGTH(x);
-    SEXP ans = PROTECT(allocWideIntVector(n));
+    SEXP ans = PROTECT(R_allocWideIntVector(n));
     for (R_xlen_t i = 0; i < n; i++)
 	SET_INTEGER64_ELT(ans, i, INTEGER64_ELT(x, i));
 

--- a/src/main/wideint.c
+++ b/src/main/wideint.c
@@ -108,6 +108,22 @@ attribute_hidden SEXP do_iswideint(SEXP call, SEXP op, SEXP args, SEXP env)
     return ScalarLogical(R_isWideInteger(CAR(args)));
 }
 
+/* Widen a narrow integer vector, preserving attributes. */
+attribute_hidden SEXP R_widenInteger(SEXP x)
+{
+    if (R_isWideInteger(x))
+	return x;
+
+    R_xlen_t n = XLENGTH(x);
+    SEXP ans = PROTECT(allocWideIntVector(n));
+    for (R_xlen_t i = 0; i < n; i++)
+	SET_INTEGER64_ELT(ans, i, INTEGER64_ELT(x, i));
+
+    SHALLOW_DUPLICATE_ATTRIB(ans, x);
+    UNPROTECT(1);
+    return ans;
+}
+
 /* Coercion of a wide integer vector to other atomic types; called
    from coerceVector().  Coercing to INTSXP is the identity there and
    never reaches this function. */

--- a/tests/reg-tests-1c.R
+++ b/tests/reg-tests-1c.R
@@ -381,14 +381,16 @@ stopifnot(is.numeric(rr), identical(rr, r.), all.equal(rr, 1.234567890e18),
 
 
 ## PR#15764: integer overflow could happen without a warning or giving NA
-tools::assertWarning(ii <- 1980000020L + 222000000L)
-stopifnot(is.na(ii))
-tools::assertWarning(ii <- (-1980000020L) + (-222000000L))
-stopifnot(is.na(ii))
-tools::assertWarning(ii <- (-1980000020L) - 222000000L)
-stopifnot(is.na(ii))
-tools::assertWarning(ii <- 1980000020L - (-222000000L))
-stopifnot(is.na(ii))
+## (with wide integers, overflow in + and - promotes to a wide result
+##  instead of warning and returning NA)
+ii <- 1980000020L + 222000000L
+stopifnot(is.integer(ii), .Internal(is.wideint(ii)), ii == 2202000020)
+ii <- (-1980000020L) + (-222000000L)
+stopifnot(is.integer(ii), .Internal(is.wideint(ii)), ii == -2202000020)
+ii <- (-1980000020L) - 222000000L
+stopifnot(is.integer(ii), .Internal(is.wideint(ii)), ii == -2202000020)
+ii <- 1980000020L - (-222000000L)
+stopifnot(is.integer(ii), .Internal(is.wideint(ii)), ii == 2202000020)
 ## first two failed for some version of clang in R < 3.1.1
 
 

--- a/wideint-gauntlet.R
+++ b/wideint-gauntlet.R
@@ -231,4 +231,23 @@ probe("cummax(rev(xs))", quote(cummax(rev(xs))))
 probe("cummin(xs)", quote(cummin(xs)))
 probe("colon big:(big+3)", quote(big:(big + w("3"))))
 
+section("parser literals")
+probe("5000000000L is wide", quote(c(iw(5000000000L), 5000000000L == w("5000000000"))))
+probe("9007199254740993L exact", quote(as.character(9007199254740993L)))
+probe("5L stays narrow", quote(iw(5L)))
+probe("hex 0x1FFFFFFFFL", quote(0x1FFFFFFFFL))
+probe("1e10L widens", quote(iw(1e10L)))
+
+section("subassignment, round 2")
+probe("stretch: xs[5] <- 1L", quote({ y <- xs; y[5] <- 1L; y }))
+probe("narrow[1] <- big literal promotes", quote({ y <- 1:3; y[1] <- 5000000000L; c(iw(y), y[1] == 5000000000L) }))
+probe("logical[1] <- wide promotes", quote({ y <- c(TRUE, FALSE); y[1] <- big; y }))
+probe("wide[2] <- NA", quote({ y <- xs; y[2] <- NA; y }))
+probe("matrix wide subassign", quote({ y <- c(xs, xs); dim(y) <- c(2, 3); y[1, 2] <- 1L; y[1, ] }))
+probe("compiled subassign promotes", quote({
+    f <- compiler::cmpfun(function(v) { v[1] <- 5000000000L; v })
+    r <- f(1:3)
+    c(iw(r), r[1] == 5000000000L)
+}))
+
 cat("\ndone.\n")

--- a/wideint-gauntlet.R
+++ b/wideint-gauntlet.R
@@ -1,0 +1,211 @@
+# Gauntlet for the wide (64-bit) integer vector prototype.
+# Each probe reports: ok / ERR, the expression, and the value or message.
+# The pattern of failures is the point: it catalogs which base operations
+# need wide-awareness and which fail loudly via the guarded accessors.
+
+w  <- function(x) .Internal(as.wideint(x))
+iw <- function(x) .Internal(is.wideint(x))
+
+probe <- function(desc, expr) {
+    wmsg <- NULL
+    out <- tryCatch(
+        withCallingHandlers(
+            eval(expr),
+            warning = function(cnd) {
+                wmsg <<- conditionMessage(cnd)
+                invokeRestart("muffleWarning")
+            }
+        ),
+        error = function(e) structure(conditionMessage(e), class = "probe_error")
+    )
+
+    if (inherits(out, "probe_error")) {
+        status <- "ERR"
+        text <- unclass(out)
+    } else {
+        status <- "ok "
+        text <- tryCatch(
+            paste(utils::capture.output(print(out)), collapse = " / "),
+            error = function(e) paste("<print failed:", conditionMessage(e), ">")
+        )
+    }
+
+    if (!is.null(wmsg))
+        text <- paste0(text, "  [warn: ", wmsg, "]")
+    if (nchar(text) > 110)
+        text <- paste0(substr(text, 1, 110), "...")
+    cat(sprintf("%s | %-42s | %s\n", status, desc, text))
+}
+
+section <- function(name) cat("\n#### ", name, "\n")
+
+big  <- w("5000000000")                       # 5e9 > 2^31
+huge <- w("1152921504606846976")              # 2^60
+xs   <- w(c("5000000000", "6000000000", "7000000000"))
+mix  <- w(c("1", NA, "5000000000"))
+small <- w(c("1", "2", "3"))                  # wide but 32-bit-representable
+
+section("creation and identity")
+probe("iw(big)", quote(iw(big)))
+probe("typeof(big)", quote(typeof(big)))
+probe("class(big)", quote(class(big)))
+probe("is.integer(big)", quote(is.integer(big)))
+probe("is.numeric(big)", quote(is.numeric(big)))
+probe("length(xs)", quote(length(xs)))
+probe("w(1:3) from narrow", quote(w(1:3)))
+probe("w(2^40) from double", quote(w(2^40)))
+probe("w(1.5) fractional errors", quote(w(1.5)))
+probe("is.na(mix)", quote(is.na(mix)))
+probe("storage.mode(big)", quote(storage.mode(big)))
+
+section("printing")
+probe("print(big)", quote(print(big)))
+probe("print(xs)", quote(print(xs)))
+probe("print(mix)", quote(print(mix)))
+probe("print(named wide)", quote(print(setNames(xs, c("a", "b", "c")))))
+probe("str(xs)", quote(str(xs)))
+probe("format(big)", quote(format(big)))
+probe("cat(big)", quote(cat(big, "\n")))
+probe("deparse(big)", quote(deparse(big)))
+probe("paste(big)", quote(paste(big)))
+probe("sprintf %d", quote(sprintf("%d", big)))
+
+section("coercion")
+probe("as.numeric(big)", quote(as.numeric(big)))
+probe("as.numeric(huge) warns >2^53", quote(as.numeric(huge)))
+probe("as.character(big)", quote(as.character(big)))
+probe("as.logical(mix)", quote(as.logical(mix)))
+probe("as.integer(small in range)", quote(as.integer(small)))
+probe("as.integer(big) identity (wide)", quote(iw(as.integer(big))))
+probe("as.vector(xs, 'list')", quote(as.vector(xs, "list")))
+probe("as.double round trip", quote(w(as.numeric(big)) == big))
+
+section("arithmetic: narrow overflow promotion")
+probe(".Machine$integer.max + 1L", quote(2147483647L + 1L))
+probe("iw(.Machine int.max + 1L)", quote(iw(2147483647L + 1L)))
+probe("narrow * narrow overflow", quote(100000L * 100000L))
+probe("narrow - narrow underflow", quote(-2147483647L - 100L))
+probe("no-overflow stays narrow", quote(iw(1L + 1L)))
+
+section("arithmetic: wide operands")
+probe("big + 1L", quote(big + 1L))
+probe("big * 2L", quote(big * 2L))
+probe("-big", quote(-big))
+probe("big - big", quote(big - big))
+probe("big / 2L (double)", quote(big / 2L))
+probe("big %/% 3L", quote(big %/% 3L))
+probe("big %% 3L", quote(big %% 3L))
+probe("big ^ 2L (double)", quote(big ^ 2L))
+probe("big + 0.5 (double)", quote(big + 0.5))
+probe("huge + 0.5 warns precision", quote(huge + 0.5))
+probe("huge * huge overflows to NA", quote(huge * huge))
+probe("xs + xs vectorized", quote(xs + xs))
+probe("xs + 1:3 recycle narrow", quote(xs + 1:3))
+probe("wide + TRUE", quote(big + TRUE))
+probe("sum via + on NA", quote(mix + 1L))
+
+section("comparison")
+probe("big > 1L", quote(big > 1L))
+probe("big == w('5000000000')", quote(big == w("5000000000")))
+probe("big < 6e9", quote(big < 6e9))
+probe("huge == 2^60 exact", quote(huge == 2^60))
+probe("huge+1 == 2^60 not equal", quote((huge + w("1")) == 2^60))
+probe("xs >= 6e9 vectorized", quote(xs >= 6e9))
+probe("mix > 0L propagates NA", quote(mix > 0L))
+probe("if (big > 0L)", quote(if (big > 0L) "yes" else "no"))
+
+section("subsetting")
+probe("xs[2]", quote(xs[2]))
+probe("xs[c(1,3)]", quote(xs[c(1, 3)]))
+probe("xs[-1]", quote(xs[-1]))
+probe("xs[c(TRUE,FALSE,TRUE)]", quote(xs[c(TRUE, FALSE, TRUE)]))
+probe("xs[[2]]", quote(xs[[2]]))
+probe("rev(xs)", quote(rev(xs)))
+probe("head(xs, 2)", quote(head(xs, 2)))
+probe("xs[10] out of bounds -> NA", quote(xs[10]))
+
+section("subassignment")
+probe("xs[1] <- w('9000000000')", quote({ y <- xs; y[1] <- w("9000000000"); y }))
+probe("xs[1] <- 1L", quote({ y <- xs; y[1] <- 1L; y }))
+probe("xs[1] <- 1.0", quote({ y <- xs; y[1] <- 1.0; y }))
+probe("narrow[1] <- wide promotes?", quote({ y <- 1:3; y[1] <- big; y }))
+probe("xs[[2]] <- w('123')", quote({ y <- xs; y[[2]] <- w("123"); y }))
+
+section("combination")
+probe("c(xs, xs)", quote(c(xs, xs)))
+probe("c(big, 1L)", quote(c(big, 1L)))
+probe("c(big, 1.5)", quote(c(big, 1.5)))
+probe("c(big, 'a')", quote(c(big, "a")))
+probe("unlist(list(big, big))", quote(unlist(list(big, big))))
+probe("rep(big, 3)", quote(rep(big, 3)))
+probe("rbind(xs, xs)", quote(rbind(xs, xs)))
+
+section("summaries and sorting")
+probe("sum(xs)", quote(sum(xs)))
+probe("mean(xs)", quote(mean(xs)))
+probe("min(xs) / max(xs)", quote(c(min(xs), max(xs))))
+probe("range(xs)", quote(range(xs)))
+probe("prod(xs)", quote(prod(xs)))
+probe("sort(rev(xs))", quote(sort(rev(xs))))
+probe("order(rev(xs))", quote(order(rev(xs))))
+probe("unique(c(xs, xs))", quote(unique(c(xs, xs))))
+probe("duplicated(c(xs, xs))", quote(duplicated(c(xs, xs))))
+probe("match(big, xs)", quote(match(big, xs)))
+probe("big %in% xs", quote(big %in% xs))
+probe("which.max(xs)", quote(which.max(xs)))
+probe("which(xs > 5e9)", quote(which(xs > 5e9)))
+probe("cumsum(xs)", quote(cumsum(xs)))
+probe("abs(-big)", quote(abs(-big)))
+probe("sqrt(big) (double)", quote(sqrt(big)))
+probe("bitwAnd(big, big)", quote(bitwAnd(big, big)))
+
+section("structures")
+probe("names(xs) <- letters[1:3]", quote({ y <- xs; names(y) <- c("a", "b", "c"); names(y) }))
+probe("matrix(xs, nrow = 1)", quote(matrix(xs, nrow = 1)))
+probe("dim<- on wide", quote({ y <- c(xs, xs); dim(y) <- c(2, 3); y }))
+probe("list(big)", quote(list(big)))
+probe("data.frame(x = xs)", quote(data.frame(x = xs)))
+probe("identical(big, w('5000000000'))", quote(identical(big, w("5000000000"))))
+probe("identical(big, 5e9)", quote(identical(big, 5e9)))
+probe("all.equal(big, w('5000000000'))", quote(all.equal(big, w("5000000000"))))
+
+section("control flow and apply")
+probe("for (v in xs) typeof(v)", quote({ r <- NULL; for (v in xs) r <- c(r, typeof(v)); r }))
+probe("for value survives wide", quote({ r <- NULL; for (v in xs) r <- c(r, v > 4e9); r }))
+probe("sapply(xs, function(x) x + 1L)", quote(sapply(xs, function(x) x + 1L)))
+probe("lapply(xs, identity)", quote(lapply(xs, identity)))
+probe("vapply numeric", quote(vapply(xs, as.numeric, numeric(1))))
+probe("Map(`+`, xs, xs)", quote(Map(`+`, xs, xs)))
+probe("do.call('+', list(big, 1L))", quote(do.call("+", list(big, 1L))))
+
+section("bytecode consistency")
+probe("compiled overflow promotes?", quote({
+    f <- function(x) x + 1L
+    fc <- compiler::cmpfun(f)
+    r <- fc(2147483647L)
+    c(iw(r), r == w("2147483648"))
+}))
+probe("compiled wide arithmetic", quote({
+    g <- function(x) x * 2L
+    gc <- compiler::cmpfun(g)
+    gc(big)
+}))
+probe("compiled loop over wide", quote({
+    h <- function(v) { s <- 0; for (x in v) s <- s + as.numeric(x); s }
+    hc <- compiler::cmpfun(h)
+    hc(xs)
+}))
+
+section("serialization (guarded)")
+probe("serialize(big) errors", quote(serialize(big, NULL)))
+probe("narrow serialize unaffected", quote(length(serialize(1:3, NULL))))
+
+section("seq and misc")
+probe("seq_along(xs)", quote(seq_along(xs)))
+probe("big:(big) colon", quote(big:big))
+probe("xtfrm(xs)", quote(xtfrm(xs)))
+probe("tabulate-ish table(small)", quote(table(small)))
+probe("outer(small, small)", quote(outer(small, small)))
+probe("wide in switch/eval", quote(eval(quote(big + big))))
+
+cat("\ndone.\n")

--- a/wideint-gauntlet.R
+++ b/wideint-gauntlet.R
@@ -255,6 +255,17 @@ probe("sort decreasing", quote(sort(xs, decreasing = TRUE)))
 probe("order with ties", quote(order(c(xs, xs))))
 probe("match narrow in wide table", quote(match(2L, w(c("1", "2", "3")))))
 probe("match wide in narrow table", quote(match(w("2"), 1:3)))
+# negative values are where the 32-bit and width-agnostic hash schemes
+# diverge, so mixed-width match must widen the table's scheme
+probe("match mixed-width negatives", quote({
+    tab <- w(c("-7", "5000000000", "3"))
+    identical(match(c(-1L, -7L, 3L), tab), c(NA, 1L, 3L)) &&
+        identical(match(tab, c(-1L, -7L, 3L)), c(2L, NA, 3L)) &&
+        identical(match(w("5000000000"), 1:3), NA_integer_)
+}))
+probe("in-op mixed-width negatives", quote({
+    identical(c(-7L, -1L) %in% w(c("-7", "5000000000")), c(TRUE, FALSE))
+}))
 probe("factor(xs)", quote(factor(xs)))
 probe("table(xs)", quote(table(xs)))
 probe("rank(rev(xs))", quote(rank(rev(xs))))

--- a/wideint-gauntlet.R
+++ b/wideint-gauntlet.R
@@ -250,4 +250,14 @@ probe("compiled subassign promotes", quote({
     c(iw(r), r[1] == 5000000000L)
 }))
 
+section("sort and hash, round 3")
+probe("sort decreasing", quote(sort(xs, decreasing = TRUE)))
+probe("order with ties", quote(order(c(xs, xs))))
+probe("match narrow in wide table", quote(match(2L, w(c("1", "2", "3")))))
+probe("match wide in narrow table", quote(match(w("2"), 1:3)))
+probe("factor(xs)", quote(factor(xs)))
+probe("table(xs)", quote(table(xs)))
+probe("rank(rev(xs))", quote(rank(rev(xs))))
+probe("rev sorted stays sorted", quote(!is.unsorted(sort(rev(xs)))))
+
 cat("\ndone.\n")

--- a/wideint-gauntlet.R
+++ b/wideint-gauntlet.R
@@ -3,8 +3,8 @@
 # The pattern of failures is the point: it catalogs which base operations
 # need wide-awareness and which fail loudly via the guarded accessors.
 
-w  <- function(x) .Internal(as.wideint(x))
-iw <- function(x) .Internal(is.wideint(x))
+w  <- as.wideint
+iw <- is.wideint
 
 probe <- function(desc, expr) {
     wmsg <- NULL
@@ -207,5 +207,28 @@ probe("xtfrm(xs)", quote(xtfrm(xs)))
 probe("tabulate-ish table(small)", quote(table(small)))
 probe("outer(small, small)", quote(outer(small, small)))
 probe("wide in switch/eval", quote(eval(quote(big + big))))
+
+section("display layer, round 2")
+probe("format(xs)", quote(format(xs)))
+probe("format(big, width = 20)", quote(format(big, width = 20)))
+probe("deparse round-trips exactly", quote({
+    v <- w("9007199254740993")  # odd value above 2^53
+    identical(eval(parse(text = deparse(v))), v)
+}))
+probe("print matrix of wide", quote(print(matrix(c(xs, xs), nrow = 2))))
+probe("print data.frame of wide", quote(print(data.frame(x = xs))))
+probe("toString(xs)", quote(toString(xs)))
+
+section("summaries, round 2")
+probe("min(xs) is wide", quote({ m <- min(xs); c(m == w("5000000000"), iw(m)) }))
+probe("max(xs)", quote(max(xs)))
+probe("range(xs)", quote(range(xs)))
+probe("min(xs, 1L) mixed", quote(min(xs, 1L)))
+probe("min NA propagates", quote(min(mix)))
+probe("min(xs, na.rm-style)", quote(min(mix, na.rm = TRUE)))
+probe("cumsum(xs)", quote(cumsum(xs)))
+probe("cummax(rev(xs))", quote(cummax(rev(xs))))
+probe("cummin(xs)", quote(cummin(xs)))
+probe("colon big:(big+3)", quote(big:(big + w("3"))))
 
 cat("\ndone.\n")

--- a/wideint-gauntlet.R
+++ b/wideint-gauntlet.R
@@ -272,3 +272,37 @@ probe("rank(rev(xs))", quote(rank(rev(xs))))
 probe("rev sorted stays sorted", quote(!is.unsorted(sort(rev(xs)))))
 
 cat("\ndone.\n")
+
+section("review fixes (PR #300 code review)")
+probe("sum(2^53+1) exact wide", quote({
+    h <- w("9007199254740993"); r <- sum(h)
+    iw(r) && format(r) == "9007199254740993"
+}))
+probe("sum int-overflow widens", quote({
+    r <- sum(c(2147483647L, 1L)); iw(r) && format(r) == "2147483648"
+}))
+probe("sum(1:10) stays narrow 55L", quote(identical(sum(1:10), 55L)))
+probe("prod(2^53+1) warns", quote(prod(w("9007199254740993"))))
+probe("colon warns above 2^53", quote(length(w("9007199254740993"):(w("9007199254740993") + 2L))))
+probe("min(wide, NULL) exact", quote({
+    r <- min(w("9007199254740993"), NULL)
+    iw(r) && format(r) == "9007199254740993"
+}))
+probe("max(wide, 1.5) warns", quote(max(w("9007199254740993"), 1.5)))
+probe("wide / 1L warns", quote(w("9007199254740993") / 1L))
+probe("c(wide, 1.5) warns above 2^53", quote(c(w("9007199254740993"), 1.5)))
+probe("formatC(small wide)", quote(formatC(small)))
+probe("c(wide, complex)", quote(c(w("2"), 1i)))
+probe("c(list, wide) keeps value", quote(format(c(list(1), big)[[2]])))
+probe("cbind(wide, raw)", quote(cbind(w(1:2), as.raw(1:2))))
+probe("sort quick downgrades for wide", quote(sort(small, method = "quick")))
+probe("sort partial for wide", quote(sort(small, partial = 2)))
+probe("rowsum with wide group", quote(rowsum(c(1.5, 2.5, 3), w(c("-1", "-1", "2")))))
+probe("sort.list default for wide", quote(sort.list(w(c("3", "1", "2")))))
+probe("wide 3-d array prints", quote({
+    a <- w(as.character(1:8)); dim(a) <- c(2, 2, 2)
+    length(utils::capture.output(print(a))) > 8
+}))
+probe("duplicated wide incomparables", quote(duplicated(w(c("5000000000", "5000000000", NA, NA)),
+                                                        incomparables = 5e9)))
+probe("match wide incomparables", quote(match(xs, xs, incomparables = 5e9)))


### PR DESCRIPTION
> [!NOTE]
> This is a prototype / RFC, not a merge candidate. CI is expected to fail
> (formatting, sorting, and subassignment paths are not yet wide-aware, and
> serialization of wide vectors deliberately errors). It exists to make a
> design discussion concrete.

## What this is

An experiment in giving R 64-bit integers via **dual-representation
INTSXP** rather than a new SEXP type: a standard (non-ALTREP) integer
vector may store `long long` elements, tagged with a spare `gp` bit
(bit 7, unused on vectors). `typeof()` stays `"integer"` and
`is.integer()` is `TRUE` -- wideness is a storage property, not a type.
`NA` is `INT64_MIN`, mirroring `NA_INTEGER == INT32_MIN`. This is the
same shape as Python's int/long unification (PEP 237): one language-level
type, two representations underneath, old C code keeps working on values
that fit and fails loudly on values that don't.

Design rules (details in `WIDEINT-NOTES.md`):

- **No 64-bit data-pointer accessor, by design.** The new C API is
  element-based only: `INTEGER64_ELT()` / `SET_INTEGER64_ELT()`. This
  sidesteps the representation-aliasing / write-back problem that a
  `INTEGER64()` pointer would create.
- The 32-bit pointer accessors (`INTEGER()`, `INTEGER0()`,
  `INTEGER_RO()`) **error** on wide vectors -- including the core macros
  in `Defn.h`, which now route through checked functions. There is no
  silent-misread path.
- `INTEGER_ELT()` narrows per element: it succeeds for representable
  values and errors otherwise, so existing ELT-based code keeps working
  until a big value actually reaches it.
- `INTEGER_OR_NULL()` / `DATAPTR_OR_NULL()` return `NULL` for wide
  vectors, pushing `ITERATE_BY_REGION` users onto the (guarded) region
  path.
- Narrow `+`, `-`, `*` **promote to wide on overflow** instead of
  returning NA with a warning, in both the AST and byte-code engines;
  wide overflow past 64 bits returns NA64 with a warning.
- Mixed wide/double arithmetic coerces to double (precision warning
  above 2^53); wide-vs-double *comparisons* are exact.
- `as.integer()` of a wide vector is the identity -- one type.
- Serialization of wide vectors errors; unserialization defensively
  clears the bit (format work is out of scope here).
- Allocation goes through `allocVector(REALSXP, n)` + relabel, so GC
  node classes and heap accounting see the true 8-byte payload.

Test hooks: `.Internal(as.wideint(x))` (logical/integer/double/character;
strings allow exact values above 2^53) and `.Internal(is.wideint(x))`.

## What works

`wideint-gauntlet.R` (in the repo root) probes ~110 base operations.
Passing today: creation, printing (unnamed), all coercions, full
arithmetic (overflow promotion, vectorized wide ops with recycling,
mixed-type behavior), exact comparisons, subsetting including the
scalar fast paths, `c()`/`unlist`, `for` loops,
`lapply`/`sapply`/`vapply`/`Map`, `sum`, `is.na`, `identical`,
`all.equal`, `rev`, `names<-`/`dim<-`, `data.frame` construction.
Compiled and interpreted arithmetic agree.

Narrow-integer behavior is unchanged (sanity checks incl. compiled
loops pass), with one deliberate exception:
`.Machine$integer.max + 1L` now returns (wide) `2147483648` instead of
NA + warning. The full R build bootstraps with promotion enabled --
nothing in base relied on overflow-to-NA.

## What fails loudly (the point of the exercise)

The remaining failures are the catalog of what a real implementation
would still need to touch: the formatting layer (`format`, `deparse`,
`cat`, `sprintf`, `str`, named/matrix printing), subassignment, `rep`,
`rbind`, the sort/hash family (`sort`, `order`, `unique`, `match`),
most of summary.c (`mean`, `min`/`max`, `range`, `cumsum`), `abs`,
`bitwAnd`, `:`, and byte-code `STEPFOR` over wide vectors. All are the
same mechanical five-line ELT64 pattern; the interesting items are
semantic decisions (64-bit hashing in unique.c, `sum()` result type,
serialization format, `x[1] <- 1.0` currently coercing a wide vector
to double).

## Findings worth recording

1. The only silent-corruption hazard found was `DATAPTR_OR_NULL()`
   handing out wide payloads as `int*` (sum/min/max/prod read garbage
   until it was taught to return NULL). Everything else failed loudly
   by construction. The post-ALTREP accessor perimeter makes this
   design feasible; the audit burden is the raw-pointer escape
   hatches, and they are few.
2. The byte-code engine needed no arithmetic changes:
   `DO_FAST_BINOP_INT` already computes in double and falls through to
   the builtin when the result leaves int range. Only the `do_arith`
   scalar fast path needed its own promotion.
3. Overflow promotion requires the promotable ops to stop reusing an
   input as the result buffer (the wide redo needs pristine inputs) --
   the one structural cost found so far.

Roughly 1050 lines across 19 files.
