### PR TITLE
update bundled TRE to current upstream plus pending PRs

### DIFF
--- a/src/extra/tre/R_changes
+++ b/src/extra/tre/R_changes
@@ -23,12 +23,25 @@ tre-internal.h:
  - includes "tre.h" rather than "tre/tre.h" (flat layout);
  - assert() is remapped to R_assert(), which calls Rf_error(), so that
    a failed invariant raises an R error instead of aborting the R
-   process (all TRE compilation units include <assert.h>, if at all,
-   before tre-internal.h, so the remapping applies everywhere);
- - under USE_RI18N_CASE (Windows, and by default macOS and Solaris),
-   case-insensitive matching uses R's internal Unicode case tables
-   (Ri18n_towlower/Ri18n_towupper from rlocale.h) since the system
-   functions are deficient there.
+   process.  Every compiled TRE unit includes <assert.h> (if at all)
+   before tre-internal.h, so the remapping applies throughout; xmalloc.c
+   is the one file that includes <assert.h> without tre-internal.h, and
+   it is not compiled (see above);
+ - rlocale.h is included under either USE_RI18N_FNS or USE_RI18N_CASE.
+   R selects the two independently: USE_RI18N_FNS (Windows, and by
+   default macOS, AIX and Solaris) makes rlocale.h remap iswalpha() and
+   friends, and the iswctype()/wctype() pair, onto R's internal Unicode
+   tables; USE_RI18N_CASE (Windows, and by default macOS and Solaris)
+   additionally supplies Ri18n_towlower/Ri18n_towupper, which TRE uses
+   for case-insensitive matching because the system versions are
+   deficient there (the UCRT ones fail for e.g. \ue9/\uc9);
+ - HAVE_ISWBLANK is asserted here rather than in tre-config.h.  Upstream's
+   configure tests iswblank(); R's tests isblank() but not iswblank(),
+   which is C99 and required by R.  Defining it in tre-config.h would
+   also make it visible to every R source that includes <tre/tre.h>
+   (grep.c, agrep.c, dcf.c, platform.c).  Without it TRE omits "blank"
+   from tre_ctype_map and [[:blank:]] fails with REG_ECTYPE wherever
+   TRE_USE_SYSTEM_WCTYPE is not defined, i.e. on Windows.
 
 tre-compile.c:
  - tre_version() reports "R_fixes" to mark this as a modified copy.
@@ -37,7 +50,23 @@ tre-config.h:
  - R-maintained (upstream generates it with configure); other HAVE_*
    macros come from R's config.h.  TRE_USE_ALLOCA is deliberately not
    defined: the matchers allocate buffers proportional to the automaton
-   size, which for large patterns can exceed the stack.
+   size, which for large patterns can exceed the stack.  TRE_VERSION
+   carries the upstream commit ("0.9.0-899ad48"), since these sources are
+   post-0.9.0 plus the pull requests above; update it whenever the copy
+   is refreshed.
+
+Behavior changes in bound expressions, from upstream's parser rewrite:
+
+ - {n,} with n > RE_DUP_MAX (255) is now rejected with REG_BADMAX.  The
+   0.8.0 copy checked only the maximum, so grepl("a{300,}", strrep("a",
+   400)) was TRUE and is now an "invalid regular expression" error.
+   {n,m} with m > 255 was already rejected; only the error code changes
+   there (REG_BADBR -> REG_BADMAX).
+ - {,} and {,~n} now mean "zero or more" rather than "exactly one":
+   regexpr("a{,}", "aaa") matches 3 characters rather than 1, and
+   agrep()/aregexec() patterns using {,~n} match a wider language.
+   Relatedly, {,m} now allows m copies rather than m+1, which is a fix:
+   regexpr("a{,3}", "aaaa") matched 4 characters and now matches 3.
 
 Notes carried over from the previous (0.8.0-based) copy:
 

--- a/src/extra/tre/R_changes
+++ b/src/extra/tre/R_changes
@@ -1,56 +1,61 @@
-tre-config.h contains additional defines that their configure puts in
-config.h.
+This directory contains a copy of TRE (https://github.com/laurikari/tre),
+taken from git commit 899ad4894a747fcee66ce3dbf6cad2145ab58e47 of the
+integration branch at https://github.com/kevinushey/tre/tree/r-integration.
+That branch is upstream master (2026-05-23, post-0.9.0) plus the following
+pull requests pending upstream, which restore behaviors R's previous
+bundled copy (based on TRE 0.8.0) had patched in locally:
 
-We have remapped the POSIX entry points with a tre_ suffix: without
-it there was confusion with entry points in OS libraries on some OSes
-(e.g. macOS).
+  #144  Convert tre_ast_to_tnfa() to iteration over a tre_stack
+  #145  Grow the delete-handling deque in tre_tnfa_run_approx() dynamically
+  #146  Make REG_LITERAL match the empty pattern
+  #148  Fix pointer truncation and under-alignment in ALIGN() on LLP64
+  #149  Do not use the system wctype() on Windows
 
-alloca has been disabled: the declarations used do not work on
-Windows, and most likely not on FreeBSD.
+The files in lib/ and include/tre/tre.h were copied verbatim into this
+flat directory, except for the R-specific changes listed below.  Files
+tre-filter.[ch] (referenced by nothing) and include/tre/regex.h (R
+includes tre/tre.h directly) were omitted.  xmalloc.c is retained but,
+as before, only compiled for debugging.
 
-The way we compile it, TRE works internally in one of three modes
+R-specific changes, all confined to three files:
 
-STR_BYTE, using bytes
-STR_MBS , using wchar_t for matching, I/O in MBCS
-STR_WIDE, using wchar_t
+tre-internal.h:
+ - includes "tre.h" rather than "tre/tre.h" (flat layout);
+ - assert() is remapped to R_assert(), which calls Rf_error(), so that
+   a failed invariant raises an R error instead of aborting the R
+   process (all TRE compilation units include <assert.h>, if at all,
+   before tre-internal.h, so the remapping applies everywhere);
+ - under USE_RI18N_CASE (Windows, and by default macOS and Solaris),
+   case-insensitive matching uses R's internal Unicode case tables
+   (Ri18n_towlower/Ri18n_towupper from rlocale.h) since the system
+   functions are deficient there.
 
-We've added interfaces tre_regcompb, tre_regncompb, tre_regexecb,
-tre_regnexecb and regaexecb to force STR_BYTE.  Unless forced, bytes
+tre-compile.c:
+ - tre_version() reports "R_fixes" to mark this as a modified copy.
+
+tre-config.h:
+ - R-maintained (upstream generates it with configure); other HAVE_*
+   macros come from R's config.h.  TRE_USE_ALLOCA is deliberately not
+   defined: the matchers allocate buffers proportional to the automaton
+   size, which for large patterns can exceed the stack.
+
+Notes carried over from the previous (0.8.0-based) copy:
+
+The way we compile it, TRE works internally in one of three modes:
+STR_BYTE (bytes), STR_MBS (wchar_t matching, I/O in MBCS), STR_WIDE
+(wchar_t).  The interfaces tre_regcompb, tre_regncompb, tre_regexecb,
+tre_regnexecb and tre_regaexecb force STR_BYTE; unless forced, bytes
 are used in a single-byte locale and wchar_t in a MBCS.  We need to
-force for useBytes=TRUE, for support for UTF-8 encoded strings
-in a single-byte locale (principally on Windows) and when dealing with
-raw vectors. You do need to ensure that regcomp and regexec use the
-same type.
+force for useBytes=TRUE, for UTF-8 encoded strings in a single-byte
+locale and when dealing with raw vectors.  regcomp and regexec must use
+the same type.  The offsets in the regmatch_t structure are in
+characters for STR_WIDE, bytes for the other two modes.  (These
+interfaces, added for R, are part of upstream TRE since 0.9.0.)
 
-The offsets in the regmatch_t structure are in characters for
-STR_WIDE, bytes for the other two modes.
-
-On Windows (MinGW?), iswctype is missing 'blank'.
-
-REG_LITERAL was not matching "" in some cases, hence a change at
-line 1652 of tre-parse.c.
-
-We fixed stack trampling in tre_tnfa_run_approx() and converted
-tre_ast_to_tnfa() from recursion to iteration over a TRE stack.
-
-We commented out in tre-match-approx.c
-
-/* These seem compiler/OS-specific, but unexplained
-On Linux the first is intended to be used only with GCC.
-#define __USE_STRING_INLINES
-#undef __NO_INLINE__
-*/
-
-since it failed on clang
-https://stat.ethz.ch/pipermail/r-devel/2010-February/056728.html
-
-Nov 2011: incorporated minor fixes from https://github.com/GerHobbelt/libtre
-(see https://laurikari.net/tre/website-issues-and-future-plans/#comments).
-
-Oct 2014: fixed R bug PR#16009 by copying the class member of a LITERAL
-in tre_copy_ast.
-
-Nov 2014: changed tre_version() to report this is a modified version.
-
-Apr 2020: incorporated a patch to tre-parse.c from
-https://github.com/laurikari/tre/issues/55
+Most other historical R patches have been merged upstream or are
+superseded: the byte-mode interfaces and REG_USEBYTES, the 8-bit
+optimizations in 8-bit mode (PR#14408), copying the class member of a
+LITERAL in tre_copy_ast (PR#16009), the tre_parse_int overflow fix,
+the WCHAR_MAX/AIX workaround, and various matcher fixes.  Upstream now
+also caps pattern length at TRE_MAX_RE (65536) characters, so guards
+that were only needed for unbounded patterns have been dropped.

--- a/src/extra/tre/regcomp.c
+++ b/src/extra/tre/regcomp.c
@@ -14,7 +14,6 @@
 #include <errno.h>
 #include <stdlib.h>
 
-#include "tre.h"
 #include "tre-internal.h"
 #include "xmalloc.h"
 
@@ -22,6 +21,8 @@ int
 tre_regncomp(regex_t *preg, const char *regex, size_t n, int cflags)
 {
   int ret;
+  if (n > TRE_MAX_RE)
+    return REG_ESPACE;
 #if TRE_WCHAR
   tre_char_t *wregex;
   size_t wlen;
@@ -71,11 +72,11 @@ tre_regncomp(regex_t *preg, const char *regex, size_t n, int cflags)
 		  return REG_BADPAT;
 		}
 	      break;
-	    case (size_t)-1:
+	    case -1:
 	      DPRINT(("mbrtowc: error %d: %s.\n", errno, strerror(errno)));
 	      xfree(wregex);
 	      return REG_BADPAT;
-	    case (size_t)-2:
+	    case -2:
 	      /* The last character wasn't complete.  Let's not call it a
 		 fatal error. */
 	      consumed = n;
@@ -104,6 +105,8 @@ int
 tre_regncompb(regex_t *preg, const char *regex, size_t n, int cflags)
 {
   int ret;
+  if (n > TRE_MAX_RE)
+    return REG_ESPACE;
 #if TRE_WCHAR /* wide chars = we need to convert it all to the wide format */
   tre_char_t *wregex;
   size_t i;
@@ -127,7 +130,10 @@ tre_regncompb(regex_t *preg, const char *regex, size_t n, int cflags)
 int
 tre_regcomp(regex_t *preg, const char *regex, int cflags)
 {
-  return tre_regncomp(preg, regex, regex ? strlen(regex) : 0, cflags);
+  size_t n = regex ? strlen(regex) : 0;
+  if (n > TRE_MAX_RE)
+    return REG_ESPACE;
+  return tre_regncomp(preg, regex, n, cflags);
 }
 
 int
@@ -135,19 +141,20 @@ tre_regcompb(regex_t *preg, const char *regex, int cflags)
 {
   int ret;
   tre_char_t *wregex;
-  size_t wlen, n = strlen(regex);
-  unsigned int i;
+  size_t i, n = regex ? strlen(regex) : 0;
   const unsigned char *str = (const unsigned char *)regex;
   tre_char_t *wstr;
 
+  if (n > TRE_MAX_RE)
+    return REG_ESPACE;
   wregex = xmalloc(sizeof(tre_char_t) * (n + 1));
   if (wregex == NULL) return REG_ESPACE;
   wstr = wregex;
 
-  for (i = 0; i < n; i++) *(wstr++) = *(str++);
-  wlen = n;
-  wregex[wlen] = L'\0';
-  ret = tre_compile(preg, wregex, wlen, cflags | REG_USEBYTES);
+  for (i = 0; i < n; i++)
+    *(wstr++) = *(str++);
+  wregex[n] = L'\0';
+  ret = tre_compile(preg, wregex, n, cflags | REG_USEBYTES);
   xfree(wregex);
   return ret;
 }
@@ -157,13 +164,18 @@ tre_regcompb(regex_t *preg, const char *regex, int cflags)
 int
 tre_regwncomp(regex_t *preg, const wchar_t *regex, size_t n, int cflags)
 {
+  if (n > TRE_MAX_RE)
+    return REG_ESPACE;
   return tre_compile(preg, regex, n, cflags);
 }
 
 int
 tre_regwcomp(regex_t *preg, const wchar_t *regex, int cflags)
 {
-  return tre_compile(preg, regex, regex ? wcslen(regex) : 0, cflags);
+  size_t n = regex ? wcslen(regex) : 0;
+  if (n > TRE_MAX_RE)
+    return REG_ESPACE;
+  return tre_compile(preg, regex, n, cflags);
 }
 #endif /* TRE_WCHAR */
 

--- a/src/extra/tre/regerror.c
+++ b/src/extra/tre/regerror.c
@@ -19,7 +19,6 @@
 #endif /* HAVE_WCTYPE_H */
 
 #include "tre-internal.h"
-#include "tre.h"
 
 #ifdef HAVE_GETTEXT
 #include <libintl.h>
@@ -31,23 +30,27 @@
 #define _(String) dgettext(PACKAGE, String)
 #define gettext_noop(String) String
 
+#define xstr(s) str(s)
+#define str(s) #s
+
 /* Error message strings for error codes listed in `tre.h'.  This list
    needs to be in sync with the codes listed there, naturally. */
 static const char *tre_error_messages[] =
-  { gettext_noop("No error"),				 /* REG_OK */
-    gettext_noop("No match"),				 /* REG_NOMATCH */
-    gettext_noop("Invalid regexp"),			 /* REG_BADPAT */
-    gettext_noop("Unknown collating element"),		 /* REG_ECOLLATE */
-    gettext_noop("Unknown character class name"),	 /* REG_ECTYPE */
-    gettext_noop("Trailing backslash"),			 /* REG_EESCAPE */
-    gettext_noop("Invalid back reference"),		 /* REG_ESUBREG */
-    gettext_noop("Missing ']'"),			 /* REG_EBRACK */
-    gettext_noop("Missing ')'"),			 /* REG_EPAREN */
-    gettext_noop("Missing '}'"),			 /* REG_EBRACE */
-    gettext_noop("Invalid contents of {}"),		 /* REG_BADBR */
-    gettext_noop("Invalid character range"),		 /* REG_ERANGE */
-    gettext_noop("Out of memory"),			 /* REG_ESPACE */
-    gettext_noop("Invalid use of repetition operators")	 /* REG_BADRPT */
+  { gettext_noop("No error"),							/* REG_OK */
+    gettext_noop("No match"),							/* REG_NOMATCH */
+    gettext_noop("Invalid regexp"),						/* REG_BADPAT */
+    gettext_noop("Unknown collating element"),					/* REG_ECOLLATE */
+    gettext_noop("Unknown character class name"),				/* REG_ECTYPE */
+    gettext_noop("Trailing backslash"),						/* REG_EESCAPE */
+    gettext_noop("Invalid back reference"),					/* REG_ESUBREG */
+    gettext_noop("Missing ']'"),						/* REG_EBRACK */
+    gettext_noop("Missing ')'"),						/* REG_EPAREN */
+    gettext_noop("Missing '}'"),						/* REG_EBRACE */
+    gettext_noop("Invalid contents of {}"),					/* REG_BADBR */
+    gettext_noop("Invalid character range"),					/* REG_ERANGE */
+    gettext_noop("Out of memory"),						/* REG_ESPACE */
+    gettext_noop("Invalid use of repetition operators"),			/* REG_BADRPT */
+    gettext_noop("Maximum repetition in {} larger than " xstr(RE_DUP_MAX)),	/* REG_BADMAX */
   };
 
 size_t

--- a/src/extra/tre/regexec.c
+++ b/src/extra/tre/regexec.c
@@ -10,10 +10,6 @@
 #include <config.h>
 #endif /* HAVE_CONFIG_H */
 
-/* https://github.com/laurikari/tre/issues/37
- * disables TRE_USE_ALLOCA, but R does not use that
- */
-
 #ifdef TRE_USE_ALLOCA
 /* AIX requires this to be the first thing in the file.	 */
 #ifndef __GNUC__
@@ -31,7 +27,7 @@ char *alloca ();
 #endif
 #endif /* TRE_USE_ALLOCA */
 
-// #include <assert.h>
+#include <assert.h>
 #include <stdlib.h>
 #include <string.h>
 #ifdef HAVE_WCHAR_H
@@ -49,10 +45,8 @@ char *alloca ();
 #include <limits.h>
 
 #include "tre-internal.h"
-#include "tre.h"
 #include "xmalloc.h"
 
-#define assert(a) R_assert(a)
 
 /* Fills the POSIX.2 regmatch_t array according to the TNFA tag and match
    endpoint values. */
@@ -142,7 +136,7 @@ tre_have_approx(const regex_t *preg)
 }
 
 static int
-tre_match(const tre_tnfa_t *tnfa, const void *string, size_t len,
+tre_match(const tre_tnfa_t *tnfa, const void *string, ssize_t len,
 	  tre_str_type_t type, size_t nmatch, regmatch_t pmatch[],
 	  int eflags)
 {
@@ -166,17 +160,18 @@ tre_match(const tre_tnfa_t *tnfa, const void *string, size_t len,
       if (type == STR_USER)
 	{
 	  const tre_str_source *source = string;
-	  if (source->rewind == NULL || source->compare == NULL) {
-	    /* The backtracking matcher requires rewind and compare
-	       capabilities from the input stream. */
+	  if (source->rewind == NULL || source->compare == NULL)
+	    {
+	      /* The backtracking matcher requires rewind and compare
+		 capabilities from the input stream. */
 #ifndef TRE_USE_ALLOCA
-	    if (tags)
+	      if (tags)
 		xfree(tags);
 #endif /* !TRE_USE_ALLOCA */
-	    return REG_BADPAT;
-	  }
+	      return REG_BADPAT;
+	    }
 	}
-      status = tre_tnfa_run_backtrack(tnfa, string, (int)len, type,
+      status = tre_tnfa_run_backtrack(tnfa, string, len, type,
 				      tags, eflags, &eo);
     }
 #ifdef TRE_APPROX
@@ -188,14 +183,14 @@ tre_match(const tre_tnfa_t *tnfa, const void *string, size_t len,
       tre_regaparams_default(&params);
       params.max_err = 0;
       params.max_cost = 0;
-      status = tre_tnfa_run_approx(tnfa, string, (int)len, type, tags,
+      status = tre_tnfa_run_approx(tnfa, string, len, type, tags,
 				   &match, params, eflags, &eo);
     }
 #endif /* TRE_APPROX */
   else
     {
       /* Exact matching, no back references, use the parallel matcher. */
-      status = tre_tnfa_run_parallel(tnfa, string, (int)len, type,
+      status = tre_tnfa_run_parallel(tnfa, string, len, type,
 				     tags, eflags, &eo);
     }
 
@@ -211,7 +206,7 @@ tre_match(const tre_tnfa_t *tnfa, const void *string, size_t len,
 
 int
 tre_regnexec(const regex_t *preg, const char *str, size_t len,
-	     size_t nmatch, regmatch_t pmatch[], int eflags)
+	 size_t nmatch, regmatch_t pmatch[], int eflags)
 {
   tre_tnfa_t *tnfa = (void *)preg->TRE_REGEX_T_FIELD;
   tre_str_type_t type = (TRE_MB_CUR_MAX == 1) ? STR_BYTE : STR_MBS;
@@ -219,25 +214,32 @@ tre_regnexec(const regex_t *preg, const char *str, size_t len,
   return tre_match(tnfa, str, len, type, nmatch, pmatch, eflags);
 }
 
+#ifdef TRE_USE_GNUC_REGEXEC_FPL
 int
 tre_regexec(const regex_t *preg, const char *str,
-	    size_t nmatch, regmatch_t pmatch[], int eflags)
+	size_t nmatch, regmatch_t pmatch[_Restrict_arr_ _REGEX_NELTS (nmatch)],
+	int eflags)
+#else
+int
+tre_regexec(const regex_t *preg, const char *str,
+	size_t nmatch, regmatch_t pmatch[], int eflags)
+#endif
 {
-  return tre_regnexec(preg, str, (unsigned)-1, nmatch, pmatch, eflags);
+  return tre_regnexec(preg, str, -1, nmatch, pmatch, eflags);
 }
 
 int
 tre_regexecb(const regex_t *preg, const char *str,
-	     size_t nmatch, regmatch_t pmatch[], int eflags)
+        size_t nmatch, regmatch_t pmatch[], int eflags)
 {
   tre_tnfa_t *tnfa = (void *)preg->TRE_REGEX_T_FIELD;
 
-  return tre_match(tnfa, str, (unsigned)-1, STR_BYTE, nmatch, pmatch, eflags);
+  return tre_match(tnfa, str, -1, STR_BYTE, nmatch, pmatch, eflags);
 }
 
 int
 tre_regnexecb(const regex_t *preg, const char *str, size_t len,
-	      size_t nmatch, regmatch_t pmatch[], int eflags)
+        size_t nmatch, regmatch_t pmatch[], int eflags)
 {
   tre_tnfa_t *tnfa = (void *)preg->TRE_REGEX_T_FIELD;
 
@@ -249,7 +251,7 @@ tre_regnexecb(const regex_t *preg, const char *str, size_t len,
 
 int
 tre_regwnexec(const regex_t *preg, const wchar_t *str, size_t len,
-	      size_t nmatch, regmatch_t pmatch[], int eflags)
+	  size_t nmatch, regmatch_t pmatch[], int eflags)
 {
   tre_tnfa_t *tnfa = (void *)preg->TRE_REGEX_T_FIELD;
   return tre_match(tnfa, str, len, STR_WIDE, nmatch, pmatch, eflags);
@@ -257,19 +259,19 @@ tre_regwnexec(const regex_t *preg, const wchar_t *str, size_t len,
 
 int
 tre_regwexec(const regex_t *preg, const wchar_t *str,
-	     size_t nmatch, regmatch_t pmatch[], int eflags)
+	 size_t nmatch, regmatch_t pmatch[], int eflags)
 {
-  return tre_regwnexec(preg, str, (unsigned)-1, nmatch, pmatch, eflags);
+  return tre_regwnexec(preg, str, -1, nmatch, pmatch, eflags);
 }
 
 #endif /* TRE_WCHAR */
 
 int
 tre_reguexec(const regex_t *preg, const tre_str_source *str,
-	     size_t nmatch, regmatch_t pmatch[], int eflags)
+	 size_t nmatch, regmatch_t pmatch[], int eflags)
 {
   tre_tnfa_t *tnfa = (void *)preg->TRE_REGEX_T_FIELD;
-  return tre_match(tnfa, str, (unsigned)-1, STR_USER, nmatch, pmatch, eflags);
+  return tre_match(tnfa, str, -1, STR_USER, nmatch, pmatch, eflags);
 }
 
 
@@ -280,7 +282,7 @@ tre_reguexec(const regex_t *preg, const tre_str_source *str,
 */
 
 static int
-tre_match_approx(const tre_tnfa_t *tnfa, const void *string, size_t len,
+tre_match_approx(const tre_tnfa_t *tnfa, const void *string, ssize_t len,
 		 tre_str_type_t type, regamatch_t *match, regaparams_t params,
 		 int eflags)
 {
@@ -309,7 +311,7 @@ tre_match_approx(const tre_tnfa_t *tnfa, const void *string, size_t len,
       if (tags == NULL)
 	return REG_ESPACE;
     }
-  status = tre_tnfa_run_approx(tnfa, string, (int)len, type, tags,
+  status = tre_tnfa_run_approx(tnfa, string, len, type, tags,
 			       match, params, eflags, &eo);
   if (status == REG_OK)
     tre_fill_pmatch(match->nmatch, match->pmatch, tnfa->cflags, tnfa, tags, eo);
@@ -322,7 +324,7 @@ tre_match_approx(const tre_tnfa_t *tnfa, const void *string, size_t len,
 
 int
 tre_reganexec(const regex_t *preg, const char *str, size_t len,
-	      regamatch_t *match, regaparams_t params, int eflags)
+	  regamatch_t *match, regaparams_t params, int eflags)
 {
   tre_tnfa_t *tnfa = (void *)preg->TRE_REGEX_T_FIELD;
   tre_str_type_t type = (TRE_MB_CUR_MAX == 1) ? STR_BYTE : STR_MBS;
@@ -332,26 +334,25 @@ tre_reganexec(const regex_t *preg, const char *str, size_t len,
 
 int
 tre_regaexec(const regex_t *preg, const char *str,
-	     regamatch_t *match, regaparams_t params, int eflags)
+	 regamatch_t *match, regaparams_t params, int eflags)
 {
-  return tre_reganexec(preg, str, (unsigned)-1, match, params, eflags);
+  return tre_reganexec(preg, str, -1, match, params, eflags);
 }
 
 int
 tre_regaexecb(const regex_t *preg, const char *str,
-	  regamatch_t *match, regaparams_t params, int eflags)
+          regamatch_t *match, regaparams_t params, int eflags)
 {
   tre_tnfa_t *tnfa = (void *)preg->TRE_REGEX_T_FIELD;
 
-  return tre_match_approx(tnfa, str, (unsigned)-1, STR_BYTE, 
-			  match, params, eflags);
+  return tre_match_approx(tnfa, str, -1, STR_BYTE, match, params, eflags);
 }
 
 #ifdef TRE_WCHAR
 
 int
 tre_regawnexec(const regex_t *preg, const wchar_t *str, size_t len,
-	       regamatch_t *match, regaparams_t params, int eflags)
+	   regamatch_t *match, regaparams_t params, int eflags)
 {
   tre_tnfa_t *tnfa = (void *)preg->TRE_REGEX_T_FIELD;
   return tre_match_approx(tnfa, str, len, STR_WIDE,
@@ -362,7 +363,7 @@ int
 tre_regawexec(const regex_t *preg, const wchar_t *str,
 	  regamatch_t *match, regaparams_t params, int eflags)
 {
-  return tre_regawnexec(preg, str, (unsigned)-1, match, params, eflags);
+  return tre_regawnexec(preg, str, -1, match, params, eflags);
 }
 
 #endif /* TRE_WCHAR */

--- a/src/extra/tre/tre-ast.c
+++ b/src/extra/tre/tre-ast.c
@@ -10,7 +10,6 @@
 #include <config.h>
 #endif /* HAVE_CONFIG_H */
 #include <assert.h>
-#include <limits.h>
 
 #include "tre-ast.h"
 #include "tre-mem.h"
@@ -34,7 +33,7 @@ tre_ast_new_node(tre_mem_t mem, tre_ast_type_t type, size_t size)
 }
 
 tre_ast_node_t *
-tre_ast_new_literal(tre_mem_t mem, int code_min, int code_max, int position)
+tre_ast_new_literal(tre_mem_t mem, int code_min, int code_max)
 {
   tre_ast_node_t *node;
   tre_literal_t *lit;
@@ -45,7 +44,7 @@ tre_ast_new_literal(tre_mem_t mem, int code_min, int code_max, int position)
   lit = node->obj;
   lit->code_min = code_min;
   lit->code_max = code_max;
-  lit->position = position;
+  lit->position = -1;
 
   return node;
 }
@@ -96,11 +95,7 @@ tre_ast_new_catenation(tre_mem_t mem, tre_ast_node_t *left,
     return NULL;
   ((tre_catenation_t *)node->obj)->left = left;
   ((tre_catenation_t *)node->obj)->right = right;
-  // UBSAN warning in clang 10: signed integer overflow
-  double tmp = (double)left->num_submatches + (double)right->num_submatches;
-  if (tmp >= INT_MIN && tmp <= INT_MAX)
-      node->num_submatches = left->num_submatches + right->num_submatches;
-  else node->num_submatches = 0;
+  node->num_submatches = left->num_submatches + right->num_submatches;
 
   return node;
 }

--- a/src/extra/tre/tre-ast.h
+++ b/src/extra/tre/tre-ast.h
@@ -1,14 +1,12 @@
 /*
-  tre-ast.h - Abstract syntax tree (AST) definitions
-
-  This software is released under a BSD-style license.
-  See the file LICENSE for details and copyright.
-
-*/
-
+ * tre-ast.h - Abstract syntax tree (AST) definitions
+ *
+ * This software is released under a BSD-style license.
+ * See the file LICENSE for details and copyright.
+ */
 
 #ifndef TRE_AST_H
-#define TRE_AST_H 1
+#define TRE_AST_H
 
 #include "tre-mem.h"
 #include "tre-internal.h"
@@ -44,8 +42,8 @@ typedef struct {
   void *obj;             /* Pointer to actual node. */
   int nullable;
   int submatch_id;
-  int num_submatches;
-  int num_tags;
+  unsigned int num_submatches;
+  unsigned int num_tags;
   tre_pos_and_tags_t *firstpos;
   tre_pos_and_tags_t *lastpos;
 } tre_ast_node_t;
@@ -101,7 +99,7 @@ tre_ast_node_t *
 tre_ast_new_node(tre_mem_t mem, tre_ast_type_t type, size_t size);
 
 tre_ast_node_t *
-tre_ast_new_literal(tre_mem_t mem, int code_min, int code_max, int position);
+tre_ast_new_literal(tre_mem_t mem, int code_min, int code_max);
 
 tre_ast_node_t *
 tre_ast_new_iter(tre_mem_t mem, tre_ast_node_t *arg, int min, int max,

--- a/src/extra/tre/tre-compile.c
+++ b/src/extra/tre/tre-compile.c
@@ -6,18 +6,11 @@
 
 */
 
-/*
-  TODO:
-   - Fix tre_ast_to_tnfa() to recurse using a stack instead of recursive
-     function calls.
-*/
-
-
 #ifdef HAVE_CONFIG_H
 #include <config.h>
 #endif /* HAVE_CONFIG_H */
 #include <stdio.h>
-//#include <assert.h>
+#include <assert.h>
 #include <string.h>
 
 #include "tre-internal.h"
@@ -26,10 +19,7 @@
 #include "tre-ast.h"
 #include "tre-parse.h"
 #include "tre-compile.h"
-#include "tre.h"
 #include "xmalloc.h"
-
-#define assert(a) R_assert(a)
 
 /*
   Algorithms to setup tags so that submatch addressing can be done.
@@ -49,7 +39,7 @@ tre_add_tag_left(tre_mem_t mem, tre_ast_node_t *node, int tag_id)
   c = tre_mem_alloc(mem, sizeof(*c));
   if (c == NULL)
     return REG_ESPACE;
-  c->left = tre_ast_new_literal(mem, TAG, tag_id, -1);
+  c->left = tre_ast_new_literal(mem, TAG, tag_id);
   if (c->left == NULL)
     return REG_ESPACE;
   c->right = tre_mem_alloc(mem, sizeof(tre_ast_node_t));
@@ -81,7 +71,7 @@ tre_add_tag_right(tre_mem_t mem, tre_ast_node_t *node, int tag_id)
   c = tre_mem_alloc(mem, sizeof(*c));
   if (c == NULL)
     return REG_ESPACE;
-  c->right = tre_ast_new_literal(mem, TAG, tag_id, -1);
+  c->right = tre_ast_new_literal(mem, TAG, tag_id);
   if (c->right == NULL)
     return REG_ESPACE;
   c->left = tre_mem_alloc(mem, sizeof(tre_ast_node_t));
@@ -149,14 +139,14 @@ tre_add_tags(tre_mem_t mem, tre_stack_t *stack, tre_ast_node_t *tree,
   reg_errcode_t status = REG_OK;
   tre_addtags_symbol_t symbol;
   tre_ast_node_t *node = tree; /* Tree node we are currently looking at. */
-  int bottom = tre_stack_num_objects(stack);
+  size_t bottom = tre_stack_num_items(stack);
   /* True for first pass (counting number of needed tags) */
   int first_pass = (mem == NULL || tnfa == NULL);
   int *regset, *orig_regset;
-  int num_tags = 0; /* Total number of tags. */
-  int num_minimals = 0;	 /* Number of special minimal tags. */
-  int tag = 0;	    /* The tag that is to be added next. */
-  int next_tag = 1; /* Next tag to use after this one. */
+  unsigned int num_tags = 0; /* Total number of tags. */
+  unsigned int num_minimals = 0;	 /* Number of special minimal tags. */
+  unsigned int tag = 0;	    /* The tag that is to be added next. */
+  unsigned int next_tag = 1; /* Next tag to use after this one. */
   int *parents;	    /* Stack of submatches the current submatch is
 		       contained in. */
   int minimal_tag = -1; /* Tag that marks the beginning of a minimal match. */
@@ -200,11 +190,8 @@ tre_add_tags(tre_mem_t mem, tre_stack_t *stack, tre_ast_node_t *tree,
   STACK_PUSH(stack, voidptr, node);
   STACK_PUSH(stack, int, ADDTAGS_RECURSE);
 
-  while (tre_stack_num_objects(stack) > bottom)
+  while (status == REG_OK && tre_stack_num_items(stack) > bottom)
     {
-      if (status != REG_OK)
-	break;
-
       symbol = (tre_addtags_symbol_t)tre_stack_pop_int(stack);
       switch (symbol)
 	{
@@ -611,7 +598,7 @@ tre_add_tags(tre_mem_t mem, tre_stack_t *stack, tre_ast_node_t *tree,
 	  break;
 
 	} /* end switch(symbol) */
-    } /* end while(tre_stack_num_objects(stack) > bottom) */
+    } /* end while(tre_stack_num_items(stack) > bottom) */
 
   if (!first_pass)
     tre_purge_regset(regset, tnfa, tag);
@@ -662,7 +649,7 @@ tre_copy_ast(tre_mem_t mem, tre_stack_t *stack, tre_ast_node_t *ast,
 	     tre_ast_node_t **copy, int *max_pos)
 {
   reg_errcode_t status = REG_OK;
-  int bottom = tre_stack_num_objects(stack);
+  size_t bottom = tre_stack_num_items(stack);
   int num_copied = 0;
   int first_tag = 1;
   tre_ast_node_t **result = copy;
@@ -671,7 +658,7 @@ tre_copy_ast(tre_mem_t mem, tre_stack_t *stack, tre_ast_node_t *ast,
   STACK_PUSH(stack, voidptr, ast);
   STACK_PUSH(stack, int, COPY_RECURSE);
 
-  while (status == REG_OK && tre_stack_num_objects(stack) > bottom)
+  while (status == REG_OK && tre_stack_num_items(stack) > bottom)
     {
       tre_ast_node_t *node;
       if (status != REG_OK)
@@ -691,8 +678,8 @@ tre_copy_ast(tre_mem_t mem, tre_stack_t *stack, tre_ast_node_t *ast,
 	      {
 		tre_literal_t *lit = node->obj;
 		int pos = lit->position;
-		int min = (int)lit->code_min;
-		int max = (int)lit->code_max;
+		long min = lit->code_min;
+		long max = lit->code_max;
 		if (!IS_SPECIAL(lit) || IS_BACKREF(lit))
 		  {
 		    /* XXX - e.g. [ab] has only one position but two
@@ -714,11 +701,18 @@ tre_copy_ast(tre_mem_t mem, tre_stack_t *stack, tre_ast_node_t *ast,
 		    tag_directions[max] = TRE_TAG_MAXIMIZE;
 		    first_tag = 0;
 		  }
-		*result = tre_ast_new_literal(mem, min, max, pos);
-		if (*result == NULL)
+		*result = tre_ast_new_literal(mem, min, max);
+		if (*result == NULL) {
 		  status = REG_ESPACE;
+		  break;
+		}
+		if (!IS_SPECIAL(lit)) {
+		  ((tre_literal_t *)(*result)->obj)->u.class = lit->u.class;
+		  ((tre_literal_t *)(*result)->obj)->neg_classes = lit->neg_classes;
+		} else if (IS_PARAMETER(lit)) {
+		  ((tre_literal_t *)(*result)->obj)->u.params = lit->u.params;
+		}
 
-                ((tre_literal_t*)(*result)->obj)->u.class = lit->u.class;  
 		if (pos > *max_pos)
 		  *max_pos = pos;
 		break;
@@ -802,11 +796,10 @@ typedef enum {
    iteration count to a catenated sequence of copies of the node. */
 static reg_errcode_t
 tre_expand_ast(tre_mem_t mem, tre_stack_t *stack, tre_ast_node_t *ast,
-	       int *position, tre_tag_direction_t *tag_directions,
-	       int *max_depth)
+	       tre_tag_direction_t *tag_directions, int *max_depth)
 {
   reg_errcode_t status = REG_OK;
-  int bottom = tre_stack_num_objects(stack);
+  size_t bottom = tre_stack_num_items(stack);
   int pos_add = 0;
   int pos_add_total = 0;
   int max_pos = 0;
@@ -822,7 +815,7 @@ tre_expand_ast(tre_mem_t mem, tre_stack_t *stack, tre_ast_node_t *ast,
 
   STACK_PUSHR(stack, voidptr, ast);
   STACK_PUSHR(stack, int, EXPAND_RECURSE);
-  while (status == REG_OK && tre_stack_num_objects(stack) > bottom)
+  while (status == REG_OK && tre_stack_num_items(stack) > bottom)
     {
       tre_ast_node_t *node;
       tre_expand_ast_symbol_t symbol;
@@ -941,7 +934,7 @@ tre_expand_ast(tre_mem_t mem, tre_stack_t *stack, tre_ast_node_t *ast,
 		  {
 		    for (j = iter->min; j < iter->max; j++)
 		      {
-			tre_ast_node_t *tmp, *copy;
+			tre_ast_node_t *copy;
 			pos_add_save = pos_add;
 			status = tre_copy_ast(mem, stack, iter->arg, 0,
 					      &pos_add, NULL, &copy, &max_pos);
@@ -953,10 +946,7 @@ tre_expand_ast(tre_mem_t mem, tre_stack_t *stack, tre_ast_node_t *ast,
 			  seq2 = copy;
 			if (seq2 == NULL)
 			  return REG_ESPACE;
-			tmp = tre_ast_new_literal(mem, EMPTY, -1, -1);
-			if (tmp == NULL)
-			  return REG_ESPACE;
-			seq2 = tre_ast_new_union(mem, tmp, seq2);
+			seq2 = tre_ast_new_iter(mem, seq2, 0, 1, 0);
 			if (seq2 == NULL)
 			  return REG_ESPACE;
 		      }
@@ -987,12 +977,12 @@ tre_expand_ast(tre_mem_t mem, tre_stack_t *stack, tre_ast_node_t *ast,
 		tre_ast_node_t *tmp_l, *tmp_r, *tmp_node, *node_copy;
 		int *old_params;
 
-		tmp_l = tre_ast_new_literal(mem, PARAMETER, 0, -1);
+		tmp_l = tre_ast_new_literal(mem, PARAMETER, 0);
 		if (!tmp_l)
 		  return REG_ESPACE;
 		((tre_literal_t *)tmp_l->obj)->u.params = iter->params;
 		iter->params[TRE_PARAM_DEPTH] = params_depth + 1;
-		tmp_r = tre_ast_new_literal(mem, PARAMETER, 0, -1);
+		tmp_r = tre_ast_new_literal(mem, PARAMETER, 0);
 		if (!tmp_r)
 		  return REG_ESPACE;
 		old_params = tre_mem_alloc(mem, sizeof(*old_params)
@@ -1032,19 +1022,9 @@ tre_expand_ast(tre_mem_t mem, tre_stack_t *stack, tre_ast_node_t *ast,
 	}
     }
 
-  *position += pos_add_total;
-
-  /* `max_pos' should never be larger than `*position' if the above
-     code works, but just an extra safeguard let's make sure
-     `*position' is set large enough so enough memory will be
-     allocated for the transition table. */
-  if (max_pos > *position)
-    *position = max_pos;
-
 #ifdef TRE_DEBUG
   DPRINT(("Expanded AST:\n"));
   tre_ast_print(ast);
-  DPRINT(("*position %d, max_pos %d\n", *position, max_pos));
 #endif
 
   return status;
@@ -1067,7 +1047,7 @@ tre_set_empty(tre_mem_t mem)
 }
 
 static tre_pos_and_tags_t *
-tre_set_one(tre_mem_t mem, int position, int code_min, int code_max,
+tre_set_one(tre_mem_t mem, int position, long code_min, long code_max,
 	    tre_ctype_t class, tre_ctype_t *neg_classes, int backref)
 {
   tre_pos_and_tags_t *new_set;
@@ -1208,7 +1188,7 @@ tre_match_empty(tre_stack_t *stack, tre_ast_node_t *node, int *tags,
   tre_catenation_t *cat;
   tre_iteration_t *iter;
   int i;
-  int bottom = tre_stack_num_objects(stack);
+  size_t bottom = tre_stack_num_items(stack);
   reg_errcode_t status = REG_OK;
   if (num_tags_seen)
     *num_tags_seen = 0;
@@ -1218,7 +1198,7 @@ tre_match_empty(tre_stack_t *stack, tre_ast_node_t *node, int *tags,
   status = tre_stack_push_voidptr(stack, node);
 
   /* Walk through the tree recursively. */
-  while (status == REG_OK && tre_stack_num_objects(stack) > bottom)
+  while (status == REG_OK && tre_stack_num_items(stack) > bottom)
     {
       node = tre_stack_pop_voidptr(stack);
 
@@ -1239,7 +1219,7 @@ tre_match_empty(tre_stack_t *stack, tre_ast_node_t *node, int *tags,
 			  break;
 		      if (tags[i] < 0)
 			{
-			  tags[i] = (int)lit->code_max;
+			  tags[i] = lit->code_max;
 			  tags[i + 1] = -1;
 			}
 		    }
@@ -1248,8 +1228,7 @@ tre_match_empty(tre_stack_t *stack, tre_ast_node_t *node, int *tags,
 		}
 	      break;
 	    case ASSERTION:
-	      assert(lit->code_max >= 1
-		     || lit->code_max <= ASSERT_LAST);
+	      assert(lit->code_max >= 1 && lit->code_max <= ASSERT_LAST);
 	      if (assertions != NULL)
 		*assertions |= lit->code_max;
 	      break;
@@ -1309,33 +1288,36 @@ tre_match_empty(tre_stack_t *stack, tre_ast_node_t *node, int *tags,
 
 
 typedef enum {
-  NFL_RECURSE,
-  NFL_POST_UNION,
-  NFL_POST_CATENATION,
-  NFL_POST_ITERATION
-} tre_nfl_stack_symbol_t;
+  NPFL_RECURSE,
+  NPFL_POST_UNION,
+  NPFL_POST_CATENATION,
+  NPFL_POST_ITERATION
+} tre_npfl_stack_symbol_t;
 
 
-/* Computes and fills in the fields `nullable', `firstpos', and `lastpos' for
-   the nodes of the AST `tree'. */
+/* Computes and fills in the fields `nullable', `position`, `firstpos',
+   and `lastpos' for the nodes of the AST `tree'; `nextpos' points to an
+   integer indicating the next available position, and will be updated on
+   return to reflect the number of additional positions assigned. */
 static reg_errcode_t
-tre_compute_nfl(tre_mem_t mem, tre_stack_t *stack, tre_ast_node_t *tree)
+tre_compute_npfl(tre_mem_t mem, tre_stack_t *stack, tre_ast_node_t *tree,
+		 int *nextpos)
 {
-  int bottom = tre_stack_num_objects(stack);
+  size_t bottom = tre_stack_num_items(stack);
 
   STACK_PUSHR(stack, voidptr, tree);
-  STACK_PUSHR(stack, int, NFL_RECURSE);
+  STACK_PUSHR(stack, int, NPFL_RECURSE);
 
-  while (tre_stack_num_objects(stack) > bottom)
+  while (tre_stack_num_items(stack) > bottom)
     {
-      tre_nfl_stack_symbol_t symbol;
+      tre_npfl_stack_symbol_t symbol;
       tre_ast_node_t *node;
 
-      symbol = (tre_nfl_stack_symbol_t)tre_stack_pop_int(stack);
+      symbol = (tre_npfl_stack_symbol_t)tre_stack_pop_int(stack);
       node = tre_stack_pop_voidptr(stack);
       switch (symbol)
 	{
-	case NFL_RECURSE:
+	case NPFL_RECURSE:
 	  switch (node->type)
 	    {
 	    case LITERAL:
@@ -1346,13 +1328,14 @@ tre_compute_nfl(tre_mem_t mem, tre_stack_t *stack, tre_ast_node_t *tree)
 		    /* Back references: nullable = false, firstpos = {i},
 		       lastpos = {i}. */
 		    node->nullable = 0;
+		    lit->position = (*nextpos)++;
 		    node->firstpos = tre_set_one(mem, lit->position, 0,
 					     TRE_CHAR_MAX, 0, NULL, -1);
 		    if (!node->firstpos)
 		      return REG_ESPACE;
 		    node->lastpos = tre_set_one(mem, lit->position, 0,
 						TRE_CHAR_MAX, 0, NULL,
-						(int)lit->code_max);
+						lit->code_max);
 		    if (!node->lastpos)
 		      return REG_ESPACE;
 		  }
@@ -1373,14 +1356,15 @@ tre_compute_nfl(tre_mem_t mem, tre_stack_t *stack, tre_ast_node_t *tree)
 		    /* Literal at position i: nullable = false, firstpos = {i},
 		       lastpos = {i}. */
 		    node->nullable = 0;
+		    lit->position = (*nextpos)++;
 		    node->firstpos =
-		      tre_set_one(mem, lit->position, (int)lit->code_min,
-				  (int)lit->code_max, 0, NULL, -1);
+		      tre_set_one(mem, lit->position, lit->code_min,
+				  lit->code_max, 0, NULL, -1);
 		    if (!node->firstpos)
 		      return REG_ESPACE;
 		    node->lastpos = tre_set_one(mem, lit->position,
-						(int)lit->code_min,
-						(int)lit->code_max,
+						lit->code_min,
+						lit->code_max,
 						lit->u.class, lit->neg_classes,
 						-1);
 		    if (!node->lastpos)
@@ -1393,36 +1377,36 @@ tre_compute_nfl(tre_mem_t mem, tre_stack_t *stack, tre_ast_node_t *tree)
 	      /* Compute the attributes for the two subtrees, and after that
 		 for this node. */
 	      STACK_PUSHR(stack, voidptr, node);
-	      STACK_PUSHR(stack, int, NFL_POST_UNION);
+	      STACK_PUSHR(stack, int, NPFL_POST_UNION);
 	      STACK_PUSHR(stack, voidptr, ((tre_union_t *)node->obj)->right);
-	      STACK_PUSHR(stack, int, NFL_RECURSE);
+	      STACK_PUSHR(stack, int, NPFL_RECURSE);
 	      STACK_PUSHR(stack, voidptr, ((tre_union_t *)node->obj)->left);
-	      STACK_PUSHR(stack, int, NFL_RECURSE);
+	      STACK_PUSHR(stack, int, NPFL_RECURSE);
 	      break;
 
 	    case CATENATION:
 	      /* Compute the attributes for the two subtrees, and after that
 		 for this node. */
 	      STACK_PUSHR(stack, voidptr, node);
-	      STACK_PUSHR(stack, int, NFL_POST_CATENATION);
+	      STACK_PUSHR(stack, int, NPFL_POST_CATENATION);
 	      STACK_PUSHR(stack, voidptr, ((tre_catenation_t *)node->obj)->right);
-	      STACK_PUSHR(stack, int, NFL_RECURSE);
+	      STACK_PUSHR(stack, int, NPFL_RECURSE);
 	      STACK_PUSHR(stack, voidptr, ((tre_catenation_t *)node->obj)->left);
-	      STACK_PUSHR(stack, int, NFL_RECURSE);
+	      STACK_PUSHR(stack, int, NPFL_RECURSE);
 	      break;
 
 	    case ITERATION:
 	      /* Compute the attributes for the subtree, and after that for
 		 this node. */
 	      STACK_PUSHR(stack, voidptr, node);
-	      STACK_PUSHR(stack, int, NFL_POST_ITERATION);
+	      STACK_PUSHR(stack, int, NPFL_POST_ITERATION);
 	      STACK_PUSHR(stack, voidptr, ((tre_iteration_t *)node->obj)->arg);
-	      STACK_PUSHR(stack, int, NFL_RECURSE);
+	      STACK_PUSHR(stack, int, NPFL_RECURSE);
 	      break;
 	    }
-	  break; /* end case: NFL_RECURSE */
+	  break; /* end case: NPFL_RECURSE */
 
-	case NFL_POST_UNION:
+	case NPFL_POST_UNION:
 	  {
 	    tre_union_t *uni = (tre_union_t *)node->obj;
 	    node->nullable = uni->left->nullable || uni->right->nullable;
@@ -1437,7 +1421,7 @@ tre_compute_nfl(tre_mem_t mem, tre_stack_t *stack, tre_ast_node_t *tree)
 	    break;
 	  }
 
-	case NFL_POST_ITERATION:
+	case NPFL_POST_ITERATION:
 	  {
 	    tre_iteration_t *iter = (tre_iteration_t *)node->obj;
 
@@ -1450,7 +1434,7 @@ tre_compute_nfl(tre_mem_t mem, tre_stack_t *stack, tre_ast_node_t *tree)
 	    break;
 	  }
 
-	case NFL_POST_CATENATION:
+	case NPFL_POST_CATENATION:
 	  {
 	    int num_tags, *tags, assertions, params_seen;
 	    int *params;
@@ -1519,7 +1503,7 @@ tre_compute_nfl(tre_mem_t mem, tre_stack_t *stack, tre_ast_node_t *tree)
 		if (status != REG_OK)
 		  return status;
 		/* Allocate arrays for the tags and parameters. */
-		tags = xmalloc(sizeof(int) * (num_tags + 1));
+		tags = xmalloc(sizeof(*tags) * (num_tags + 1));
 		if (!tags)
 		  return REG_ESPACE;
 		tags[0] = -1;
@@ -1787,12 +1771,13 @@ tre_make_trans(tre_pos_and_tags_t *p1, tre_pos_and_tags_t *p2,
    labelled with one character range (there are no transitions on empty
    strings).  The TNFA takes O(n^2) space in the worst case, `n' is size of
    the regexp.
-   This is the iterative version using a stack (previously used recursion
-   which will fail for large patterns)
- */
+
+   This is the iterative version using an explicit stack; the previous
+   recursive implementation could overflow the C stack for large patterns. */
 static reg_errcode_t
-tre_ast_to_tnfa_iter(tre_stack_t *stack, tre_ast_node_t *node, tre_tnfa_transition_t *transitions,
-		     int *counts, int *offs)
+tre_ast_to_tnfa(tre_stack_t *stack, tre_ast_node_t *node,
+		tre_tnfa_transition_t *transitions,
+		int *counts, int *offs)
 {
   tre_union_t *uni;
   tre_catenation_t *cat;
@@ -1801,69 +1786,55 @@ tre_ast_to_tnfa_iter(tre_stack_t *stack, tre_ast_node_t *node, tre_tnfa_transiti
 
   STACK_PUSHR(stack, voidptr, node);
 
-  while (tre_stack_num_objects(stack)) {
-    node = (tre_ast_node_t*) tre_stack_pop_voidptr(stack);
+  while (tre_stack_num_items(stack))
+    {
+      node = tre_stack_pop_voidptr(stack);
 
-    switch (node->type)
-      {
-      case LITERAL:
-	break;
+      switch (node->type)
+	{
+	case LITERAL:
+	  break;
 
-      case UNION:
-	uni = (tre_union_t *)node->obj;
-	STACK_PUSHR(stack, voidptr, uni->right);
-	STACK_PUSHR(stack, voidptr, uni->left);
-	break;
+	case UNION:
+	  uni = (tre_union_t *)node->obj;
+	  /* Push right before left so that left is processed first,
+	     preserving the traversal order of the recursive version. */
+	  STACK_PUSHR(stack, voidptr, uni->right);
+	  STACK_PUSHR(stack, voidptr, uni->left);
+	  break;
 
-      case CATENATION:
-	cat = (tre_catenation_t *)node->obj;
-	/* Add a transition from each position in cat->left->lastpos
-	   to each position in cat->right->firstpos. */
-	errcode = tre_make_trans(cat->left->lastpos, cat->right->firstpos,
-				 transitions, counts, offs);
-	if (errcode != REG_OK)
-	  return errcode;
-	
-	STACK_PUSHR(stack, voidptr, cat->right);
-	STACK_PUSHR(stack, voidptr, cat->left);
-	break;
+	case CATENATION:
+	  cat = (tre_catenation_t *)node->obj;
+	  /* Add a transition from each position in cat->left->lastpos
+	     to each position in cat->right->firstpos. */
+	  errcode = tre_make_trans(cat->left->lastpos, cat->right->firstpos,
+				   transitions, counts, offs);
+	  if (errcode != REG_OK)
+	    return errcode;
+	  STACK_PUSHR(stack, voidptr, cat->right);
+	  STACK_PUSHR(stack, voidptr, cat->left);
+	  break;
 
-      case ITERATION:
-	iter = (tre_iteration_t *)node->obj;
-	// assert(iter->max == -1 || iter->max == 1);
-	if(!(iter->max == -1 || iter->max == 1)) return REG_BADBR;
+	case ITERATION:
+	  iter = (tre_iteration_t *)node->obj;
+	  assert(iter->max == -1 || iter->max == 1);
 
-	if (iter->max == -1)
-	  {
-	    // assert(iter->min == 0 || iter->min == 1);
-	    if(!(iter->min == 0 || iter->min == 1)) return REG_BADBR;
-	    /* Add a transition from each last position in the iterated
-	       expression to each first position. */
-	    errcode = tre_make_trans(iter->arg->lastpos, iter->arg->firstpos,
-				     transitions, counts, offs);
-	    if (errcode != REG_OK)
-	      return errcode;	  
-	  }
-	STACK_PUSHR(stack, voidptr, iter->arg);
-	break;
-      }
-  }
+	  if (iter->max == -1)
+	    {
+	      assert(iter->min == 0 || iter->min == 1);
+	      /* Add a transition from each last position in the iterated
+		 expression to each first position. */
+	      errcode = tre_make_trans(iter->arg->lastpos, iter->arg->firstpos,
+				       transitions, counts, offs);
+	      if (errcode != REG_OK)
+		return errcode;
+	    }
+	  STACK_PUSHR(stack, voidptr, iter->arg);
+	  break;
+	}
+    }
   return REG_OK;
 }
-
-static reg_errcode_t
-tre_ast_to_tnfa(tre_ast_node_t *node, tre_tnfa_transition_t *transitions,
-		int *counts, int *offs)
-{
-  reg_errcode_t errcode;
-  tre_stack_t *stack;
-  /* I made up max_size, there is no reason for that particular value */
-  stack = tre_stack_new(1024, 256*1024, 4096);
-  errcode = tre_ast_to_tnfa_iter(stack, node, transitions, counts, offs);
-  tre_stack_destroy(stack);
-  return errcode;
-}
-
 
 #define ERROR_EXIT(err)		  \
   do				  \
@@ -1889,13 +1860,14 @@ tre_compile(regex_t *preg, const tre_char_t *regex, size_t n, int cflags)
   tre_tag_direction_t *tag_directions = NULL;
   reg_errcode_t errcode;
   tre_mem_t mem;
+  int numpos = 0;
 
   /* Parse context. */
   tre_parse_ctx_t parse_ctx;
 
   /* Allocate a stack used throughout the compilation process for various
      purposes. */
-  stack = tre_stack_new(512, 10240, 128);
+  stack = tre_stack_new(512, TRE_MAX_STACK);
   if (!stack)
     return REG_ESPACE;
   /* Allocate a fast memory allocator. */
@@ -1914,8 +1886,8 @@ tre_compile(regex_t *preg, const tre_char_t *regex, size_t n, int cflags)
   parse_ctx.len = n;
   parse_ctx.cflags = cflags;
   parse_ctx.max_backref = -1;
-  /* workaround for PR#14408: use 8-bit optimizations in 8-bit mode */
-  parse_ctx.cur_max = (cflags & REG_USEBYTES) ? 1 : TRE_MB_CUR_MAX;
+  /* Use 8-bit optimizations in 8-bit mode */
+  parse_ctx.mb_cur_max = (cflags & REG_USEBYTES) ? 1 : TRE_MB_CUR_MAX;
   DPRINT(("tre_compile: parsing '%.*" STRF "'\n", (int)n, regex));
   errcode = tre_parse(&parse_ctx);
   if (errcode != REG_OK)
@@ -1968,8 +1940,8 @@ tre_compile(regex_t *preg, const tre_char_t *regex, size_t n, int cflags)
 	  memset(tag_directions, -1,
 		 sizeof(*tag_directions) * (tnfa->num_tags + 1));
 	}
-      tnfa->minimal_tags = xcalloc((unsigned)tnfa->num_tags * 2 + 1,
-				   sizeof(tnfa->minimal_tags));
+      tnfa->minimal_tags = xcalloc(tnfa->num_tags * 2 + 1,
+				   sizeof(*tnfa->minimal_tags));
       if (tnfa->minimal_tags == NULL)
 	ERROR_EXIT(REG_ESPACE);
 
@@ -1995,8 +1967,8 @@ tre_compile(regex_t *preg, const tre_char_t *regex, size_t n, int cflags)
     }
 
   /* Expand iteration nodes. */
-  errcode = tre_expand_ast(mem, stack, tree, &parse_ctx.position,
-			   tag_directions, &tnfa->params_depth);
+  errcode = tre_expand_ast(mem, stack, tree, tag_directions,
+			   &tnfa->params_depth);
   if (errcode != REG_OK)
     ERROR_EXIT(errcode);
 
@@ -2005,7 +1977,7 @@ tre_compile(regex_t *preg, const tre_char_t *regex, size_t n, int cflags)
 	   for example "a*" or "ab*".	Figure out a simple way to detect
 	   this possibility. */
   tmp_ast_l = tree;
-  tmp_ast_r = tre_ast_new_literal(mem, 0, 0, parse_ctx.position++);
+  tmp_ast_r = tre_ast_new_literal(mem, 0, 0);
   if (tmp_ast_r == NULL)
     ERROR_EXIT(REG_ESPACE);
 
@@ -2013,29 +1985,31 @@ tre_compile(regex_t *preg, const tre_char_t *regex, size_t n, int cflags)
   if (tree == NULL)
     ERROR_EXIT(REG_ESPACE);
 
-#ifdef TRE_DEBUG
-  tre_ast_print(tree);
-  DPRINT(("Number of states: %d\n", parse_ctx.position));
-#endif /* TRE_DEBUG */
-
-  errcode = tre_compute_nfl(mem, stack, tree);
+  errcode = tre_compute_npfl(mem, stack, tree, &numpos);
   if (errcode != REG_OK)
     ERROR_EXIT(errcode);
 
-  counts = xmalloc(sizeof(int) * parse_ctx.position);
+#ifdef TRE_DEBUG
+  tre_ast_print(tree);
+  DPRINT(("Number of states: %d\n", numpos));
+#endif /* TRE_DEBUG */
+
+  counts = xmalloc(sizeof(int) * numpos);
   if (counts == NULL)
     ERROR_EXIT(REG_ESPACE);
 
-  offs = xmalloc(sizeof(int) * parse_ctx.position);
+  offs = xmalloc(sizeof(int) * numpos);
   if (offs == NULL)
     ERROR_EXIT(REG_ESPACE);
 
-  for (i = 0; i < parse_ctx.position; i++)
+  for (i = 0; i < numpos; i++)
     counts[i] = 0;
-  tre_ast_to_tnfa(tree, NULL, counts, NULL);
+  errcode = tre_ast_to_tnfa(stack, tree, NULL, counts, NULL);
+  if (errcode != REG_OK)
+    ERROR_EXIT(errcode);
 
   add = 0;
-  for (i = 0; i < parse_ctx.position; i++)
+  for (i = 0; i < numpos; i++)
     {
       offs[i] = add;
       add += counts[i] + 1;
@@ -2048,14 +2022,14 @@ tre_compile(regex_t *preg, const tre_char_t *regex, size_t n, int cflags)
   tnfa->num_transitions = add;
 
   DPRINT(("Converting to TNFA:\n"));
-  errcode = tre_ast_to_tnfa(tree, transitions, counts, offs);
+  errcode = tre_ast_to_tnfa(stack, tree, transitions, counts, offs);
   if (errcode != REG_OK)
     ERROR_EXIT(errcode);
 
   /* If in eight bit mode, compute a table of characters that can be the
      first character of a match. */
   tnfa->first_char = -1;
-  if (TRE_MB_CUR_MAX == 1 && !tmp_ast_l->nullable)
+  if (parse_ctx.mb_cur_max == 1 && !tmp_ast_l->nullable)
     {
       int count = 0;
       tre_cint_t k;
@@ -2173,7 +2147,7 @@ tre_compile(regex_t *preg, const tre_char_t *regex, size_t n, int cflags)
 
   tnfa->num_transitions = add;
   tnfa->final = transitions + offs[tree->lastpos[0].position];
-  tnfa->num_states = parse_ctx.position;
+  tnfa->num_states = numpos;
   tnfa->cflags = cflags;
 
   DPRINT(("final state %p\n", (void *)tnfa->final));
@@ -2265,12 +2239,8 @@ tre_version(void)
   if (str[0] == 0)
     {
       (void) tre_config(TRE_CONFIG_VERSION, &version);
-	  assert(strlen(version) < 200);
-#if defined(_MSC_VER)
-	  (void) _snprintf(str, sizeof(str), "TRE %s R_fixes (BSD)", version);
-#else
-	  (void) snprintf(str, sizeof(str), "TRE %s R_fixes (BSD)", version);
-#endif
+      /* R change: mark this as R's modified copy of TRE. */
+      (void) snprintf(str, sizeof(str), "TRE %s R_fixes (BSD)", version);
     }
   return str;
 }

--- a/src/extra/tre/tre-config.h
+++ b/src/extra/tre/tre-config.h
@@ -1,7 +1,9 @@
-/* lib/tre-config.h.  Generated from tre-config.h.in by configure.  */
-/* tre-config.h.in.  This file has all definitions that are needed in
-   `tre.h'.  Note that this file must contain only the bare minimum
-   of definitions without the TRE_ prefix to avoid conflicts between
+/* tre-config.h -- R-maintained configuration for the bundled TRE.
+
+   Upstream generates this file (and config.h) with its own configure;
+   in R it is static, with HAVE_* macros otherwise supplied by R's
+   config.h.  Note that this file must contain only the bare minimum of
+   definitions without the TRE_ prefix to avoid conflicts between
    definitions here and definitions included from somewhere else. */
 
 /* Define if you want to enable approximate matching functionality. */
@@ -15,11 +17,18 @@
 #define TRE_REGEX_T_FIELD value
 
 /* Define if you want TRE to use alloca() instead of malloc() when allocating
-   memory needed for regexec operations. */
+   memory needed for regexec operations.  Deliberately not defined for R:
+   the matchers allocate buffers proportional to the automaton size, which
+   for large patterns can exceed the stack. */
 /* #define TRE_USE_ALLOCA 1 */
 
 /* Define to enable wide character (wchar_t) support. */
 #define TRE_WCHAR 1
 
 /* TRE version string. */
-#define TRE_VERSION "0.8.0"
+#define TRE_VERSION "0.9.0"
+
+/* R addition: not tested for by R's configure; iswblank() is C99 and
+   required by R.  Only consulted by TRE on Windows, where the system
+   wctype() path is not used. */
+#define HAVE_ISWBLANK 1

--- a/src/extra/tre/tre-config.h
+++ b/src/extra/tre/tre-config.h
@@ -25,10 +25,7 @@
 /* Define to enable wide character (wchar_t) support. */
 #define TRE_WCHAR 1
 
-/* TRE version string. */
-#define TRE_VERSION "0.9.0"
-
-/* R addition: not tested for by R's configure; iswblank() is C99 and
-   required by R.  Only consulted by TRE on Windows, where the system
-   wctype() path is not used. */
-#define HAVE_ISWBLANK 1
+/* TRE version string.  The sources are post-0.9.0 upstream plus the pull
+   requests listed in R_changes, so the commit they were taken from is
+   included to keep extSoftVersion() unambiguous; update both together. */
+#define TRE_VERSION "0.9.0-899ad48"

--- a/src/extra/tre/tre-internal.h
+++ b/src/extra/tre/tre-internal.h
@@ -1,13 +1,16 @@
 /*
-  tre-internal.h - TRE internal definitions
-
-  This software is released under a BSD-style license.
-  See the file LICENSE for details and copyright.
-
-*/
+ * tre-internal.h - TRE internal definitions
+ *
+ * This software is released under a BSD-style license.
+ * See the file LICENSE for details and copyright.
+ */
 
 #ifndef TRE_INTERNAL_H
-#define TRE_INTERNAL_H 1
+#define TRE_INTERNAL_H
+
+#ifdef HAVE_SYS_TYPES_H
+#include <sys/types.h>
+#endif /* HAVE_SYS_TYPES_H */
 
 #ifdef HAVE_WCHAR_H
 #include <wchar.h>
@@ -15,10 +18,34 @@
 
 #ifdef HAVE_WCTYPE_H
 #include <wctype.h>
-#endif /* !HAVE_WCTYPE_H */
+#endif /* HAVE_WCTYPE_H */
 
+#include <limits.h>
 #include <ctype.h>
+#include <stddef.h>
+
+/* R change: the R copy uses a flat directory layout, so "tre.h" rather
+   than "tre/tre.h". */
 #include "tre.h"
+
+/* R change: remap assert() onto the R error handler, so that a failed
+   invariant raises an R error instead of aborting the R process.  All
+   TRE compilation units include <assert.h> (if at all) before this
+   header, so the remapping below takes effect everywhere. */
+extern void Rf_error(const char *str, ...);
+
+#ifdef NDEBUG
+#define R_assert(e) ((void) 0)
+#else
+#define R_assert(e) ((e) ? (void) 0 : Rf_error("assertion '%s' failed in executing regexp: file '%s', line %d\n", #e, __FILE__, __LINE__))
+#endif /* NDEBUG */
+
+#undef assert
+#define assert(e) R_assert(e)
+
+#define TRE_MAX_RE	65536
+#define TRE_MAX_STRING	INT_MAX
+#define TRE_MAX_STACK	1048576
 
 #ifdef TRE_DEBUG
 #include <stdio.h>
@@ -48,20 +75,10 @@
 
 /* Wide characters. */
 typedef wint_t tre_cint_t;
-/* Workaround problem seen on AIX, (2010 & 2015), e.g.,
-    https://stat.ethz.ch/pipermail/r-devel/2015-October/071902.html
-  WCHAR_MAX = UINT32_MAX on AIX and that is "not possible to work"
-  Solaris-sparcv9   WCHAR_MAX = INT32_MAX
-  Linux amd64       WCHAR_MAX = INT32_MAX
-*/
-/*
-   [U]INT32_MAX need to be declared: this is a C99 header which we assume
- */
-#include <stdint.h>
-#if WCHAR_MAX == UINT32_MAX
-# define TRE_CHAR_MAX INT32_MAX
-#else
-# define TRE_CHAR_MAX WCHAR_MAX
+#if WCHAR_MAX <= INT_MAX
+#define TRE_CHAR_MAX WCHAR_MAX
+#else /* WCHAR_MAX > INT_MAX */
+#define TRE_CHAR_MAX INT_MAX
 #endif
 
 #ifdef TRE_MULTIBYTE
@@ -70,11 +87,11 @@ typedef wint_t tre_cint_t;
 #define TRE_MB_CUR_MAX 1
 #endif /* !TRE_MULTIBYTE */
 
-#include "rlocale.h"
-
 #define tre_isalnum iswalnum
 #define tre_isalpha iswalpha
+#ifdef HAVE_ISWBLANK
 #define tre_isblank iswblank
+#endif /* HAVE_ISWBLANK */
 #define tre_iscntrl iswcntrl
 #define tre_isdigit iswdigit
 #define tre_isgraph iswgraph
@@ -85,9 +102,12 @@ typedef wint_t tre_cint_t;
 #define tre_isupper iswupper
 #define tre_isxdigit iswxdigit
 
+/* R change: on platforms whose system towlower/towupper are deficient
+   (Windows UCRT, and by default macOS and Solaris: see R's configure),
+   use R's internal Unicode case tables for case-insensitive matching.
+   The UCRT versions do not work for some characters, e.g. \ue9/\uc9. */
 #ifdef USE_RI18N_CASE
-/* use Ri18n_towlower and Ri18n_towupper, because the UCRT versions do not seem
-   do be working with some characters, such as \ue9 / \uc9 */
+#include "rlocale.h"
 #define tre_tolower Ri18n_towlower
 #define tre_toupper Ri18n_towupper
 #else
@@ -127,17 +147,20 @@ typedef short tre_cint_t;
 
 #endif /* !TRE_WCHAR */
 
-/* _WIN32 opt-out is R addition - iswctype was missing "blank"
-   R requires iswctype and wctype */
-#if !defined(_WIN32) && defined(TRE_WCHAR) && defined(HAVE_ISWCTYPE) && defined(HAVE_WCTYPE)
+/* Do not use the system iswctype()/wctype() on Windows: the CRT has no
+   "blank" character class (wctype("blank") returns 0, so [[:blank:]]
+   fails with REG_ECTYPE), and iswprint(L'\t') incorrectly returns true.
+   TRE's own implementations in tre-parse.c handle both. */
+#if !defined(_WIN32) && \
+  defined(TRE_WCHAR) && defined(HAVE_ISWCTYPE) && defined(HAVE_WCTYPE)
 #define TRE_USE_SYSTEM_WCTYPE 1
 #endif
 
 #ifdef TRE_USE_SYSTEM_WCTYPE
 /* Use system provided iswctype() and wctype(). */
 typedef wctype_t tre_ctype_t;
-#define tre_isctype(c, type) iswctype(c, type)
-#define tre_ctype(s)   wctype(s)
+#define tre_isctype iswctype
+#define tre_ctype   wctype
 #else /* !TRE_USE_SYSTEM_WCTYPE */
 /* Define our own versions of iswctype() and wctype(). */
 typedef int (*tre_ctype_t)(tre_cint_t);
@@ -147,22 +170,24 @@ tre_ctype_t tre_ctype(const char *name);
 
 typedef enum { STR_WIDE, STR_BYTE, STR_MBS, STR_USER } tre_str_type_t;
 
+/* A union with the strictest alignment of the objects TRE places in
+   its memory blocks.  Aligning to `long' is not enough on LLP64
+   platforms such as 64-bit Windows, where `long' is narrower than
+   pointers and doubles. */
+typedef union {
+  void *ptr;
+  void (*fn)(void);
+  long long ll;
+  double d;
+} tre_aligned_t;
+
 /* Returns number of bytes to add to (char *)ptr to make it
-   properly aligned for the type. */
-/* R change:  was (long) but that is shorter than pointer on Win64 */
+   properly aligned for the type.  The cast must be to `size_t', not
+   `long', which would truncate the pointer on LLP64 platforms. */
 #define ALIGN(ptr, type) \
   ((((size_t)ptr) % sizeof(type)) \
    ? (sizeof(type) - (((size_t)ptr) % sizeof(type))) \
    : 0)
-
-/* R addition, only "long" has been used before for alignment of allocated
-   data. With C11, one could use max_align_t. */
-typedef union {
-    void *ptr;
-    void (*funptr)(void);
-    long long ll;
-    double dbl;
-} anytype;
 
 #undef MAX
 #undef MIN
@@ -217,18 +242,6 @@ struct tnfa_transition {
 #define ASSERT_AT_WB_NEG	128   /* Not a word boundary. */
 #define ASSERT_BACKREF		256   /* A back reference in `backref'. */
 #define ASSERT_LAST		256
-
-/* define R_assert() which can replace assert() */
-
-/* fake definition (important: jsut const char* str is not enough!) */
-extern void Rf_error(const char *str, ...);
-
-#ifdef NDEBUG
-#define R_assert(e) ((void) 0)
-#else
-/* The line below requires an ANSI C preprocessor (stringify operator) */
-#define R_assert(e) ((e) ? (void) 0 : Rf_error("assertion '%s' failed in executing regexp: file '%s', line %d\n", #e, __FILE__, __LINE__))
-#endif /* NDEBUG */
 
 /* Tag directions. */
 typedef enum {
@@ -305,26 +318,20 @@ tre_fill_pmatch(size_t nmatch, regmatch_t pmatch[], int cflags,
 		const tre_tnfa_t *tnfa, int *tags, int match_eo);
 
 reg_errcode_t
-tre_tnfa_run_parallel(const tre_tnfa_t *tnfa, const void *string, int len,
+tre_tnfa_run_parallel(const tre_tnfa_t *tnfa, const void *string, ssize_t len,
 		      tre_str_type_t type, int *match_tags, int eflags,
 		      int *match_end_ofs);
 
 reg_errcode_t
-tre_tnfa_run_parallel(const tre_tnfa_t *tnfa, const void *string, int len,
-		      tre_str_type_t type, int *match_tags, int eflags,
-		      int *match_end_ofs);
-
-reg_errcode_t
-tre_tnfa_run_backtrack(const tre_tnfa_t *tnfa, const void *string,
-		       int len, tre_str_type_t type, int *match_tags,
-		       int eflags, int *match_end_ofs);
+tre_tnfa_run_backtrack(const tre_tnfa_t *tnfa, const void *string, ssize_t len,
+		       tre_str_type_t type, int *match_tags, int eflags,
+		       int *match_end_ofs);
 
 #ifdef TRE_APPROX
 reg_errcode_t
-tre_tnfa_run_approx(const tre_tnfa_t *tnfa, const void *string, int len,
-		    tre_str_type_t type, int *match_tags,
-		    regamatch_t *match, regaparams_t params,
-		    int eflags, int *match_end_ofs);
+tre_tnfa_run_approx(const tre_tnfa_t *tnfa, const void *string, ssize_t len,
+		    tre_str_type_t type, int *match_tags, regamatch_t *match,
+		    regaparams_t params, int eflags, int *match_end_ofs);
 #endif /* TRE_APPROX */
 
 #endif /* TRE_INTERNAL_H */

--- a/src/extra/tre/tre-internal.h
+++ b/src/extra/tre/tre-internal.h
@@ -87,6 +87,32 @@ typedef wint_t tre_cint_t;
 #define TRE_MB_CUR_MAX 1
 #endif /* !TRE_MULTIBYTE */
 
+/* R change: R replaces parts of the wide character API on platforms where
+   the system versions are deficient, and the two replacements are selected
+   independently by R's configure.  Under USE_RI18N_FNS (Windows, and by
+   default macOS, AIX and Solaris) rlocale.h remaps iswalpha() and friends,
+   and the iswctype()/wctype() pair used further down, onto R's internal
+   Unicode tables.  Under USE_RI18N_CASE (Windows, and by default macOS and
+   Solaris) it also supplies Ri18n_towlower/Ri18n_towupper.  The header is
+   therefore needed whenever either macro is defined; gating it on
+   USE_RI18N_CASE alone would silently leave AIX using the system
+   iswalpha()/iswctype(). */
+#if defined(USE_RI18N_FNS) || defined(USE_RI18N_CASE)
+#include "rlocale.h"
+#endif
+
+/* R change: upstream's configure tests for iswblank(); R's tests isblank()
+   but not iswblank().  It is C99, and R requires C99, so assert it here
+   rather than in tre-config.h -- that file is included by tre.h, so a
+   HAVE_* macro defined there also becomes visible to every R source using
+   the TRE API (grep.c, agrep.c, dcf.c, platform.c).  Without it TRE omits
+   "blank" from tre_ctype_map, and [[:blank:]] fails with REG_ECTYPE
+   wherever TRE_USE_SYSTEM_WCTYPE is not defined (i.e. on Windows).  The
+   alternative would be an AC_CHECK_FUNCS(iswblank) in R's configure. */
+#ifndef HAVE_ISWBLANK
+#define HAVE_ISWBLANK 1
+#endif
+
 #define tre_isalnum iswalnum
 #define tre_isalpha iswalpha
 #ifdef HAVE_ISWBLANK
@@ -105,9 +131,9 @@ typedef wint_t tre_cint_t;
 /* R change: on platforms whose system towlower/towupper are deficient
    (Windows UCRT, and by default macOS and Solaris: see R's configure),
    use R's internal Unicode case tables for case-insensitive matching.
-   The UCRT versions do not work for some characters, e.g. \ue9/\uc9. */
+   The UCRT versions do not work for some characters, e.g. \ue9/\uc9.
+   rlocale.h is included above. */
 #ifdef USE_RI18N_CASE
-#include "rlocale.h"
 #define tre_tolower Ri18n_towlower
 #define tre_toupper Ri18n_towupper
 #else

--- a/src/extra/tre/tre-match-approx.c
+++ b/src/extra/tre/tre-match-approx.c
@@ -27,13 +27,7 @@ char *alloca ();
 #endif
 #endif /* TRE_USE_ALLOCA */
 
-/* These seem compiler/OS-specific, but unexplained
-On Linux the first is intended to be used only with GCC.
-#define __USE_STRING_INLINES
-#undef __NO_INLINE__
-*/
-
-// #include <assert.h>
+#include <assert.h>
 #include <stdlib.h>
 #include <string.h>
 #include <limits.h>
@@ -52,10 +46,7 @@ On Linux the first is intended to be used only with GCC.
 
 #include "tre-internal.h"
 #include "tre-match-utils.h"
-#include "tre.h"
 #include "xmalloc.h"
-
-#define assert(a) R_assert(a) 
 
 #define TRE_M_COST	0
 #define TRE_M_NUM_INS	1
@@ -206,7 +197,7 @@ tre_set_params(tre_tnfa_approx_reach_t *reach,
 }
 
 reg_errcode_t
-tre_tnfa_run_approx(const tre_tnfa_t *tnfa, const void *string, int len,
+tre_tnfa_run_approx(const tre_tnfa_t *tnfa, const void *string, ssize_t len,
 		    tre_str_type_t type, int *match_tags,
 		    regamatch_t *match, regaparams_t default_params,
 		    int eflags, int *match_end_ofs)
@@ -214,7 +205,7 @@ tre_tnfa_run_approx(const tre_tnfa_t *tnfa, const void *string, int len,
   /* State variables required by GET_NEXT_WCHAR. */
   tre_char_t prev_c = 0, next_c = 0;
   const char *str_byte = string;
-  int pos = -1;
+  ssize_t pos = -1;
   unsigned int pos_add_next = 1;
 #ifdef TRE_WCHAR
   const wchar_t *str_wide = string;
@@ -222,6 +213,7 @@ tre_tnfa_run_approx(const tre_tnfa_t *tnfa, const void *string, int len,
   mbstate_t mbstate;
 #endif /* !TRE_WCHAR */
 #endif /* TRE_WCHAR */
+  reg_errcode_t ret;
   int reg_notbol = eflags & REG_NOTBOL;
   int reg_noteol = eflags & REG_NOTEOL;
   int reg_newline = tnfa->cflags & REG_NEWLINE;
@@ -246,16 +238,20 @@ tre_tnfa_run_approx(const tre_tnfa_t *tnfa, const void *string, int len,
 
   int i, id;
 
-  if (!match_tags)
-    num_tags = 0;
-  else
-    num_tags = tnfa->num_tags;
+  /*
+   * TRE internals tend to use int instead of size_t for positions or
+   * lengths and don't check for overflow.  This will take time to fix
+   * properly.  In the meantime, simply limit the input to what we can
+   * handle.
+   */
+  if (len > TRE_MAX_STRING)
+    len = TRE_MAX_STRING;
 
 #ifdef TRE_MBSTATE
   memset(&mbstate, '\0', sizeof(mbstate));
 #endif /* TRE_MBSTATE */
 
-  DPRINT(("tre_tnfa_run_approx, input type %d, len %d, eflags %d, "
+  DPRINT(("tre_tnfa_run_approx, input type %d, len %zd, eflags %d, "
 	  "match_tags %p\n",
 	  type, len, eflags,
 	  match_tags));
@@ -264,6 +260,11 @@ tre_tnfa_run_approx(const tre_tnfa_t *tnfa, const void *string, int len,
 	  default_params.cost_ins,
 	  default_params.cost_del,
 	  default_params.cost_subst));
+
+  if (!match_tags)
+    num_tags = 0;
+  else
+    num_tags = tnfa->num_tags;
 
   /* Allocate memory for temporary data required for matching.	This needs to
      be done for every matching operation to be thread safe.  This allocates
@@ -294,17 +295,17 @@ tre_tnfa_run_approx(const tre_tnfa_t *tnfa, const void *string, int len,
     /* Allocate `tmp_tags' from `buf'. */
     tmp_tags = (void *)buf;
     buf_cursor = buf + tag_bytes;
-    buf_cursor += ALIGN(buf_cursor, anytype);
+    buf_cursor += ALIGN(buf_cursor, tre_aligned_t);
 
     /* Allocate `reach' from `buf'. */
     reach = (void *)buf_cursor;
     buf_cursor += reach_bytes;
-    buf_cursor += ALIGN(buf_cursor, anytype);
+    buf_cursor += ALIGN(buf_cursor, tre_aligned_t);
 
     /* Allocate `reach_next' from `buf'. */
     reach_next = (void *)buf_cursor;
     buf_cursor += reach_bytes;
-    buf_cursor += ALIGN(buf_cursor, anytype);
+    buf_cursor += ALIGN(buf_cursor, tre_aligned_t);
 
     /* Allocate tag arrays for `reach' and `reach_next' from `buf'. */
     for (i = 0; i < tnfa->num_states; i++)
@@ -330,7 +331,7 @@ tre_tnfa_run_approx(const tre_tnfa_t *tnfa, const void *string, int len,
 
   while (/*CONSTCOND*/(void)1,1)
     {
-      DPRINT(("%03d:%2lc/%05d\n", pos, (tre_cint_t)next_c, (int)next_c));
+      DPRINT(("%03zd:%2lc/%05d\n", pos, (tre_cint_t)next_c, (int)next_c));
 
       /* Add initial states to `reach_next' if an exact match has not yet
 	 been found. */
@@ -487,34 +488,34 @@ tre_tnfa_run_approx(const tre_tnfa_t *tnfa, const void *string, int len,
 	      continue;
 	    *deque_end = &reach_next[id];
 	    deque_end++;
-	    /* check if we need to resize the buffer */
-	    if (deque_end >= (ringbuffer + rb_size)) {
-	      tre_tnfa_approx_reach_t **larger_buf;
-	      rb_size += 512;
-	      size_t os = deque_start - ringbuffer,
-		  oe = deque_end - ringbuffer;
-	      // GCC complained here that ringbuffer is still used.
-	      // Although realloc could free it, it does not change the pointer.
-	      larger_buf = (tre_tnfa_approx_reach_t **)
-		((ringbuffer == static_ringbuffer) ?
-		 xmalloc(sizeof(tre_tnfa_approx_reach_t *) * rb_size) :
-		 xrealloc(ringbuffer, sizeof(tre_tnfa_approx_reach_t *) * rb_size));
-	      if (!larger_buf) {
-		DPRINT(("tre_tnfa_run_approx: cannot resize ring buffer\n"));
-		if (ringbuffer != static_ringbuffer)
-		  xfree(ringbuffer);
+	    /* Grow the buffer (moving to the heap) if full. */
+	    if (deque_end >= (ringbuffer + rb_size))
+	      {
+		tre_tnfa_approx_reach_t **larger_buf;
+		size_t os = deque_start - ringbuffer;
+		size_t oe = deque_end - ringbuffer;
+		rb_size += 512;
+		if (ringbuffer == static_ringbuffer)
+		  larger_buf = xmalloc(sizeof(*ringbuffer) * rb_size);
+		else
+		  larger_buf = xrealloc(ringbuffer, sizeof(*ringbuffer) * rb_size);
+		if (larger_buf == NULL)
+		  {
+		    if (ringbuffer != static_ringbuffer)
+		      xfree(ringbuffer);
 #ifndef TRE_USE_ALLOCA
-		if (buf)
-		  xfree(buf);
+		    if (buf)
+		      xfree(buf);
 #endif /* !TRE_USE_ALLOCA */
-		return REG_ESPACE;
+		    return REG_ESPACE;
+		  }
+		if (ringbuffer == static_ringbuffer)
+		  /* Moving from stack to heap: copy existing contents. */
+		  memcpy(larger_buf, ringbuffer, sizeof(static_ringbuffer));
+		ringbuffer = larger_buf;
+		deque_start = ringbuffer + os;
+		deque_end = ringbuffer + oe;
 	      }
-	      deque_start = larger_buf + os;
-	      deque_end = larger_buf + oe;
-	      if (ringbuffer == static_ringbuffer) /* when switching from stack to heap we need to copy */
-		memcpy(larger_buf, ringbuffer, sizeof(static_ringbuffer));
-	      ringbuffer = larger_buf;
-	    }
 	  }
 
 	/* Repeat until the deque is empty. */
@@ -527,7 +528,7 @@ tre_tnfa_run_approx(const tre_tnfa_t *tnfa, const void *string, int len,
 
 	    /* Pop the first item off the deque. */
 	    reach_p = *deque_start;
-	    id = (int)(reach_p - reach_next);
+	    id = reach_p - reach_next;
 	    depth = reach_p->depth;
 
 	    /* Compute cost at current depth. */
@@ -632,7 +633,7 @@ tre_tnfa_run_approx(const tre_tnfa_t *tnfa, const void *string, int len,
 			    && (num_tags > 0
 				&& tmp_tags[0] <= match_tags[0]))))
 		  {
-		    DPRINT(("	 setting new match at %d, cost %d\n",
+		    DPRINT(("	 setting new match at %zd, cost %d\n",
 			    pos, cost0));
 		    match_eo = pos;
 		    memcpy(match_costs, reach_next[dest_id].costs[0],
@@ -669,7 +670,7 @@ tre_tnfa_run_approx(const tre_tnfa_t *tnfa, const void *string, int len,
 	      if (str_user_end)
 		break;
 	    }
-	  else if (next_c == L'\0')
+	  else if (next_c == L'\0' || pos >= TRE_MAX_STRING)
 	    break;
 	}
       else
@@ -817,7 +818,7 @@ tre_tnfa_run_approx(const tre_tnfa_t *tnfa, const void *string, int len,
 		      || (cost0 == match_costs[TRE_M_COST]
 			  && num_tags > 0 && tmp_tags[0] <= match_tags[0])))
 		{
-		  DPRINT(("    setting new match at %d, cost %d\n",
+		  DPRINT(("    setting new match at %zd, cost %d\n",
 			  pos, cost0));
 		  match_eo = pos;
 		  for (i = 0; i < TRE_M_LAST; i++)
@@ -832,16 +833,17 @@ tre_tnfa_run_approx(const tre_tnfa_t *tnfa, const void *string, int len,
   DPRINT(("match end offset = %d, match cost = %d\n", match_eo,
 	  match_costs[TRE_M_COST]));
 
-#ifndef TRE_USE_ALLOCA
-  if (buf)
-    xfree(buf);
-#endif /* !TRE_USE_ALLOCA */
-
   match->cost = match_costs[TRE_M_COST];
   match->num_ins = match_costs[TRE_M_NUM_INS];
   match->num_del = match_costs[TRE_M_NUM_DEL];
   match->num_subst = match_costs[TRE_M_NUM_SUBST];
   *match_end_ofs = match_eo;
 
-  return match_eo >= 0 ? REG_OK : REG_NOMATCH;
+  ret = match_eo >= 0 ? REG_OK : REG_NOMATCH;
+
+#ifndef TRE_USE_ALLOCA
+  if (buf)
+    xfree(buf);
+#endif /* !TRE_USE_ALLOCA */
+  return ret;
 }

--- a/src/extra/tre/tre-match-backtrack.c
+++ b/src/extra/tre/tre-match-backtrack.c
@@ -51,7 +51,7 @@ char *alloca ();
 #endif
 #endif /* TRE_USE_ALLOCA */
 
-//#include <assert.h>
+#include <assert.h>
 #include <stdlib.h>
 #include <string.h>
 #ifdef HAVE_WCHAR_H
@@ -70,10 +70,7 @@ char *alloca ();
 #include "tre-internal.h"
 #include "tre-mem.h"
 #include "tre-match-utils.h"
-#include "tre.h"
 #include "xmalloc.h"
-
-#define assert(a) R_assert(a)
 
 typedef struct {
   int pos;
@@ -116,11 +113,13 @@ typedef struct tre_backtrack_struct {
 #ifdef TRE_USE_ALLOCA
 #define tre_bt_mem_new		  tre_mem_newa
 #define tre_bt_mem_alloc	  tre_mem_alloca
-#define tre_bt_mem_destroy(obj)	  do { } while (0,0)
+#define tre_bt_mem_destroy(obj)	  do { } while (0)
+#define xafree(obj)		  do { } while (0) /* do nothing, obj was obtained with alloca() */
 #else /* !TRE_USE_ALLOCA */
 #define tre_bt_mem_new		  tre_mem_new
 #define tre_bt_mem_alloc	  tre_mem_alloc
 #define tre_bt_mem_destroy	  tre_mem_destroy
+#define xafree(obj)		  xfree(obj)
 #endif /* !TRE_USE_ALLOCA */
 
 
@@ -136,11 +135,11 @@ typedef struct tre_backtrack_struct {
 	    {								      \
 	      tre_bt_mem_destroy(mem);					      \
 	      if (tags)							      \
-		xfree(tags);						      \
+		xafree(tags);						      \
 	      if (pmatch)						      \
-		xfree(pmatch);						      \
+		xafree(pmatch);						      \
 	      if (states_seen)						      \
-		xfree(states_seen);					      \
+		xafree(states_seen);					      \
 	      return REG_ESPACE;					      \
 	    }								      \
 	  s->prev = stack;						      \
@@ -151,11 +150,11 @@ typedef struct tre_backtrack_struct {
 	    {								      \
 	      tre_bt_mem_destroy(mem);					      \
 	      if (tags)							      \
-		xfree(tags);						      \
+		xafree(tags);						      \
 	      if (pmatch)						      \
-		xfree(pmatch);						      \
+		xafree(pmatch);						      \
 	      if (states_seen)						      \
-		xfree(states_seen);					      \
+		xafree(states_seen);					      \
 	      return REG_ESPACE;					      \
 	    }								      \
 	  stack->next = s;						      \
@@ -199,13 +198,13 @@ typedef struct tre_backtrack_struct {
 
 reg_errcode_t
 tre_tnfa_run_backtrack(const tre_tnfa_t *tnfa, const void *string,
-		       int len, tre_str_type_t type, int *match_tags,
+		       ssize_t len, tre_str_type_t type, int *match_tags,
 		       int eflags, int *match_end_ofs)
 {
   /* State variables required by GET_NEXT_WCHAR. */
   tre_char_t prev_c = 0, next_c = 0;
   const char *str_byte = string;
-  int pos = 0;
+  ssize_t pos = 0;
   unsigned int pos_add_next = 1;
 #ifdef TRE_WCHAR
   const wchar_t *str_wide = string;
@@ -230,6 +229,7 @@ tre_tnfa_run_backtrack(const tre_tnfa_t *tnfa, const void *string,
 #ifdef TRE_MBSTATE
   mbstate_t mbstate_start;
 #endif /* TRE_MBSTATE */
+  reg_errcode_t ret;
 
   /* End offset of best match so far, or -1 if no match found yet. */
   int match_eo = -1;
@@ -247,7 +247,15 @@ tre_tnfa_run_backtrack(const tre_tnfa_t *tnfa, const void *string,
 
   tre_tnfa_transition_t *trans_i;
   regmatch_t *pmatch = NULL;
-  int ret;
+
+  /*
+   * TRE internals tend to use int instead of size_t for positions or
+   * lengths and don't check for overflow.  This will take time to fix
+   * properly.  In the meantime, simply limit the input to what we can
+   * handle.
+   */
+  if (len > TRE_MAX_STRING)
+    len = TRE_MAX_STRING;
 
 #ifdef TRE_MBSTATE
   memset(&mbstate, '\0', sizeof(mbstate));
@@ -265,7 +273,7 @@ tre_tnfa_run_backtrack(const tre_tnfa_t *tnfa, const void *string,
   stack->next = NULL;
 
   DPRINT(("tnfa_execute_backtrack, input type %d\n", type));
-  DPRINT(("len = %d\n", len));
+  DPRINT(("len = %zd\n", len));
 
 #ifdef TRE_USE_ALLOCA
   tags = alloca(sizeof(*tags) * tnfa->num_tags);
@@ -365,7 +373,7 @@ tre_tnfa_run_backtrack(const tre_tnfa_t *tnfa, const void *string,
       tags[*next_tags] = pos;
 
 
-  DPRINT(("entering match loop, pos %d, str_byte %p\n", pos, str_byte));
+  DPRINT(("entering match loop, pos %zd, str_byte %p\n", pos, str_byte));
   DPRINT(("pos:chr/code | state and tags\n"));
   DPRINT(("-------------+------------------------------------------------\n"));
 
@@ -380,7 +388,7 @@ tre_tnfa_run_backtrack(const tre_tnfa_t *tnfa, const void *string,
       DPRINT(("start loop\n"));
       if (state == tnfa->final)
 	{
-	  DPRINT(("  match found, %d %d\n", match_eo, pos));
+	  DPRINT(("  match found, %d %zd\n", match_eo, pos));
 	  if (match_eo < pos
 	      || (match_eo == pos
 		  && match_tags
@@ -401,7 +409,7 @@ tre_tnfa_run_backtrack(const tre_tnfa_t *tnfa, const void *string,
 	}
 
 #ifdef TRE_DEBUG
-      DPRINT(("%3d:%2lc/%05d | %p ", pos, (tre_cint_t)next_c, (int)next_c,
+      DPRINT(("%3zd:%2lc/%05d | %p ", pos, (tre_cint_t)next_c, (int)next_c,
 	      state));
       {
 	int i;
@@ -506,7 +514,7 @@ tre_tnfa_run_backtrack(const tre_tnfa_t *tnfa, const void *string,
 #endif /* TRE_WCHAR */
 	      pos += bt_len - 1;
 	      GET_NEXT_WCHAR();
-	      DPRINT(("	 pos now %d\n", pos));
+	      DPRINT(("	 pos now %zd\n", pos));
 	    }
 	  else
 	    {
@@ -524,7 +532,7 @@ tre_tnfa_run_backtrack(const tre_tnfa_t *tnfa, const void *string,
 		  if (str_user_end)
 		    goto backtrack;
 		}
-	      else if (next_c == L'\0')
+	      else if (next_c == L'\0' || pos >= TRE_MAX_STRING)
 		goto backtrack;
 	    }
 	  else
@@ -617,7 +625,7 @@ tre_tnfa_run_backtrack(const tre_tnfa_t *tnfa, const void *string,
 	      /* Check for end of string. */
 	      if (len < 0)
 		{
-		  if (next_c == L'\0')
+		  if (next_c_start == L'\0' || pos_start >= TRE_MAX_STRING)
 		    {
 		      DPRINT(("end of string.\n"));
 		      break;
@@ -625,7 +633,7 @@ tre_tnfa_run_backtrack(const tre_tnfa_t *tnfa, const void *string,
 		}
 	      else
 		{
-		  if (pos >= len)
+		  if (pos_start >= len)
 		    {
 		      DPRINT(("end of string.\n"));
 		      break;
@@ -657,11 +665,11 @@ tre_tnfa_run_backtrack(const tre_tnfa_t *tnfa, const void *string,
   tre_bt_mem_destroy(mem);
 #ifndef TRE_USE_ALLOCA
   if (tags)
-    xfree(tags);
+    xafree(tags);
   if (pmatch)
-    xfree(pmatch);
+    xafree(pmatch);
   if (states_seen)
-    xfree(states_seen);
+    xafree(states_seen);
 #endif /* !TRE_USE_ALLOCA */
 
   return ret;

--- a/src/extra/tre/tre-match-parallel.c
+++ b/src/extra/tre/tre-match-parallel.c
@@ -44,7 +44,7 @@ char *alloca ();
 #endif
 #endif /* TRE_USE_ALLOCA */
 
-// #include <assert.h>
+#include <assert.h>
 #include <stdlib.h>
 #include <string.h>
 #ifdef HAVE_WCHAR_H
@@ -62,10 +62,9 @@ char *alloca ();
 
 #include "tre-internal.h"
 #include "tre-match-utils.h"
-#include "tre.h"
 #include "xmalloc.h"
 
-#define assert(a) R_assert(a)
+
 
 typedef struct {
   tre_tnfa_transition_t *state;
@@ -80,7 +79,7 @@ typedef struct {
 
 #ifdef TRE_DEBUG
 static void
-tre_print_reach(const tre_tnfa_t *tnfa, tre_tnfa_reach_t *reach, int num_tags)
+tre_print_reach(const tre_tnfa_reach_t *reach, int num_tags)
 {
   int i;
 
@@ -105,14 +104,14 @@ tre_print_reach(const tre_tnfa_t *tnfa, tre_tnfa_reach_t *reach, int num_tags)
 #endif /* TRE_DEBUG */
 
 reg_errcode_t
-tre_tnfa_run_parallel(const tre_tnfa_t *tnfa, const void *string, int len,
+tre_tnfa_run_parallel(const tre_tnfa_t *tnfa, const void *string, ssize_t len,
 		      tre_str_type_t type, int *match_tags, int eflags,
 		      int *match_end_ofs)
 {
   /* State variables required by GET_NEXT_WCHAR. */
   tre_char_t prev_c = 0, next_c = 0;
   const char *str_byte = string;
-  int pos = -1;
+  ssize_t pos = -1;
   unsigned int pos_add_next = 1;
 #ifdef TRE_WCHAR
   const wchar_t *str_wide = string;
@@ -120,6 +119,7 @@ tre_tnfa_run_parallel(const tre_tnfa_t *tnfa, const void *string, int len,
   mbstate_t mbstate;
 #endif /* TRE_MBSTATE */
 #endif /* TRE_WCHAR */
+  reg_errcode_t ret;
   int reg_notbol = eflags & REG_NOTBOL;
   int reg_noteol = eflags & REG_NOTEOL;
   int reg_newline = tnfa->cflags & REG_NEWLINE;
@@ -137,6 +137,15 @@ tre_tnfa_run_parallel(const tre_tnfa_t *tnfa, const void *string, int len,
   int *tmp_tags = NULL;
   int *tmp_iptr;
 
+  /*
+   * TRE internals tend to use int instead of size_t for positions or
+   * lengths and don't check for overflow.  This will take time to fix
+   * properly.  In the meantime, simply limit the input to what we can
+   * handle.
+   */
+  if (len > TRE_MAX_STRING)
+    len = TRE_MAX_STRING;
+
 #ifdef TRE_MBSTATE
   memset(&mbstate, '\0', sizeof(mbstate));
 #endif /* TRE_MBSTATE */
@@ -153,7 +162,7 @@ tre_tnfa_run_parallel(const tre_tnfa_t *tnfa, const void *string, int len,
      everything in a single large block from the stack frame using alloca()
      or with malloc() if alloca is unavailable. */
   {
-    int tbytes, rbytes, pbytes, xbytes, total_bytes;
+    size_t tbytes, rbytes, pbytes, xbytes, total_bytes;
     char *tmp_buf;
     /* Compute the length of the block we need. */
     tbytes = sizeof(*tmp_tags) * num_tags;
@@ -168,25 +177,25 @@ tre_tnfa_run_parallel(const tre_tnfa_t *tnfa, const void *string, int len,
 #ifdef TRE_USE_ALLOCA
     buf = alloca(total_bytes);
 #else /* !TRE_USE_ALLOCA */
-    buf = xmalloc((unsigned)total_bytes);
+    buf = xmalloc(total_bytes);
 #endif /* !TRE_USE_ALLOCA */
     if (buf == NULL)
       return REG_ESPACE;
-    memset(buf, 0, (size_t)total_bytes);
+    memset(buf, 0, total_bytes);
 
     /* Get the various pointers within tmp_buf (properly aligned). */
     tmp_tags = (void *)buf;
     tmp_buf = buf + tbytes;
-    tmp_buf += ALIGN(tmp_buf, anytype);
+    tmp_buf += ALIGN(tmp_buf, tre_aligned_t);
     reach_next = (void *)tmp_buf;
     tmp_buf += rbytes;
-    tmp_buf += ALIGN(tmp_buf, anytype);
+    tmp_buf += ALIGN(tmp_buf, tre_aligned_t);
     reach = (void *)tmp_buf;
     tmp_buf += rbytes;
-    tmp_buf += ALIGN(tmp_buf, anytype);
+    tmp_buf += ALIGN(tmp_buf, tre_aligned_t);
     reach_pos = (void *)tmp_buf;
     tmp_buf += pbytes;
-    tmp_buf += ALIGN(tmp_buf, anytype);
+    tmp_buf += ALIGN(tmp_buf, tre_aligned_t);
     for (i = 0; i < tnfa->num_states; i++)
       {
 	reach[i].tags = (void *)tmp_buf;
@@ -221,7 +230,7 @@ tre_tnfa_run_parallel(const tre_tnfa_t *tnfa, const void *string, int len,
       if (str_byte >= orig_str + 1)
 	prev_c = (unsigned char)*(str_byte - 1);
       next_c = (unsigned char)*str_byte;
-      pos = (int)(str_byte - orig_str);
+      pos = str_byte - orig_str;
       if (len < 0 || pos < len)
 	str_byte++;
     }
@@ -264,7 +273,7 @@ tre_tnfa_run_parallel(const tre_tnfa_t *tnfa, const void *string, int len,
     }
 #endif
 
-  DPRINT(("length: %d\n", len));
+  DPRINT(("length: %zd\n", len));
   DPRINT(("pos:chr/code | states and tags\n"));
   DPRINT(("-------------+------------------------------------------------\n"));
 
@@ -332,7 +341,7 @@ tre_tnfa_run_parallel(const tre_tnfa_t *tnfa, const void *string, int len,
 	      if (str_user_end)
 		break;
 	    }
-	  else if (next_c == L'\0')
+	  else if (next_c == L'\0' || pos >= TRE_MAX_STRING)
 	    break;
 	}
       else
@@ -344,10 +353,10 @@ tre_tnfa_run_parallel(const tre_tnfa_t *tnfa, const void *string, int len,
       GET_NEXT_WCHAR();
 
 #ifdef TRE_DEBUG
-      DPRINT(("%3d:%2lc/%05d |", pos - 1, (tre_cint_t)prev_c, (int)prev_c));
-      tre_print_reach(tnfa, reach_next, num_tags);
-      DPRINT(("%3d:%2lc/%05d |", pos, (tre_cint_t)next_c, (int)next_c));
-      tre_print_reach(tnfa, reach_next, num_tags);
+      DPRINT(("%3zd:%2lc/%05d |", pos - 1, (tre_cint_t)prev_c, (int)prev_c));
+      tre_print_reach(reach_next, num_tags);
+      DPRINT(("%3zd:%2lc/%05d |", pos, (tre_cint_t)next_c, (int)next_c));
+      tre_print_reach(reach_next, num_tags);
 #endif /* TRE_DEBUG */
 
       /* Swap `reach' and `reach_next'. */
@@ -489,13 +498,14 @@ tre_tnfa_run_parallel(const tre_tnfa_t *tnfa, const void *string, int len,
 
   DPRINT(("match end offset = %d\n", match_eo));
 
+  *match_end_ofs = match_eo;
+  ret = match_eo >= 0 ? REG_OK : REG_NOMATCH;
+
 #ifndef TRE_USE_ALLOCA
   if (buf)
     xfree(buf);
 #endif /* !TRE_USE_ALLOCA */
-
-  *match_end_ofs = match_eo;
-  return match_eo >= 0 ? REG_OK : REG_NOMATCH;
+  return ret;
 }
 
 /* EOF */

--- a/src/extra/tre/tre-match-utils.h
+++ b/src/extra/tre/tre-match-utils.h
@@ -1,10 +1,12 @@
 /*
-  tre-match-utils.h - TRE matcher helper definitions
+ * tre-match-utils.h - TRE matcher helper definitions
+ *
+ * This software is released under a BSD-style license.
+ * See the file LICENSE for details and copyright.
+ */
 
-  This software is released under a BSD-style license.
-  See the file LICENSE for details and copyright.
-
-*/
+#ifndef TRE_MATCH_UTILS_H
+#define TRE_MATCH_UTILS_H
 
 #define str_source ((const tre_str_source*)string)
 
@@ -41,7 +43,7 @@
 	else								      \
 	  {								      \
 	    size_t w;							      \
-	    int max;							      \
+	    size_t max;							      \
 	    if (len >= 0)						      \
 	      max = len - pos;						      \
 	    else							      \
@@ -64,7 +66,7 @@
 		  }							      \
 		else							      \
 		  {							      \
-		    pos_add_next = (unsigned int)w;					      \
+		    pos_add_next = w;					      \
 		    str_byte += w;					      \
 		  }							      \
 	      }								      \
@@ -213,3 +215,7 @@ tre_neg_char_classes_match(tre_ctype_t *classes, tre_cint_t wc, int icase)
       classes++;
   return 0; /* No match. */
 }
+
+#endif /* TRE_MATCH_UTILS_H */
+
+/* EOF */

--- a/src/extra/tre/tre-mem.c
+++ b/src/extra/tre/tre-mem.c
@@ -111,8 +111,8 @@ tre_mem_alloc_impl(tre_mem_t mem, int provided, void *provided_block,
 	    block_size = size * 8;
 	  else
 	    block_size = TRE_MEM_BLOCK_SIZE;
-	  DPRINT(("tre_mem_alloc: allocating new %lu byte block\n",
-		  (unsigned long)block_size));
+	  DPRINT(("tre_mem_alloc: allocating new %zu byte block\n",
+		  block_size));
 	  l = xmalloc(sizeof(*l));
 	  if (l == NULL)
 	    {
@@ -138,7 +138,7 @@ tre_mem_alloc_impl(tre_mem_t mem, int provided, void *provided_block,
     }
 
   /* Make sure the next pointer will be aligned. */
-  size += ALIGN(mem->ptr + size, anytype);
+  size += ALIGN(mem->ptr + size, tre_aligned_t);
 
   /* Allocate from current block. */
   ptr = mem->ptr;

--- a/src/extra/tre/tre-mem.h
+++ b/src/extra/tre/tre-mem.h
@@ -1,13 +1,12 @@
 /*
-  tre-mem.h - TRE memory allocator interface
-
-  This software is released under a BSD-style license.
-  See the file LICENSE for details and copyright.
-
-*/
+ * tre-mem.h - TRE memory allocator interface
+ *
+ * This software is released under a BSD-style license.
+ * See the file LICENSE for details and copyright.
+ */
 
 #ifndef TRE_MEM_H
-#define TRE_MEM_H 1
+#define TRE_MEM_H
 
 #include <stdlib.h>
 
@@ -26,7 +25,6 @@ typedef struct tre_mem_struct {
   int failed;
   void **provided;
 } *tre_mem_t;
-
 
 tre_mem_t tre_mem_new_impl(int provided, void *provided_block);
 void *tre_mem_alloc_impl(tre_mem_t mem, int provided, void *provided_block,
@@ -56,7 +54,6 @@ void *tre_mem_alloc_impl(tre_mem_t mem, int provided, void *provided_block,
    ? tre_mem_alloc_impl((mem), 1, NULL, 0, (size))			      \
    : tre_mem_alloc_impl((mem), 1, alloca(TRE_MEM_BLOCK_SIZE), 0, (size)))
 #endif /* TRE_USE_ALLOCA */
-
 
 /* Frees the memory allocator and all memory allocated with it. */
 void tre_mem_destroy(tre_mem_t mem);

--- a/src/extra/tre/tre-parse.c
+++ b/src/extra/tre/tre-parse.c
@@ -17,7 +17,7 @@
 #include <config.h>
 #endif /* HAVE_CONFIG_H */
 #include <string.h>
-// #include <assert.h>
+#include <assert.h>
 #include <limits.h>
 
 #include "xmalloc.h"
@@ -26,7 +26,6 @@
 #include "tre-stack.h"
 #include "tre-parse.h"
 
-#define assert(a) R_assert(a)
 
 /* Characters with special meanings in regexp syntax. */
 #define CHAR_PIPE	   L'|'
@@ -84,7 +83,6 @@ tre_expand_macro(const tre_char_t *regex, const tre_char_t *regex_end,
 	  unsigned int j;
 	  DPRINT(("Expanding macro '%c' => '%s'\n",
 		  tre_macros[i].c, tre_macros[i].expansion));
-	  // R_change:  - 1 is r62537
 	  for (j = 0; tre_macros[i].expansion[j] && j < buf_len - 1; j++)
 	    buf[j] = tre_macros[i].expansion[j];
 	  buf[j] = 0;
@@ -115,7 +113,7 @@ tre_new_item(tre_mem_t mem, int min, int max, int *i, int *max_i,
 	return REG_ESPACE;
       *items = array = new_items;
     }
-  array[*i] = tre_ast_new_literal(mem, min, max, -1);
+  array[*i] = tre_ast_new_literal(mem, min, max);
   status = array[*i] == NULL ? REG_ESPACE : REG_OK;
   (*i)++;
   return status;
@@ -130,7 +128,6 @@ tre_expand_ctype(tre_mem_t mem, tre_ctype_t class, tre_ast_node_t ***items,
   reg_errcode_t status = REG_OK;
   tre_cint_t c;
   int j, min = -1, max = 0;
-  //assert(TRE_MB_CUR_MAX == 1); It is the ctx->cur_max that matters
 
   DPRINT(("  expanding class to character ranges\n"));
   for (j = 0; (j < 256) && (status == REG_OK); j++)
@@ -198,15 +195,12 @@ int tre_isgraph_func(tre_cint_t c) { return tre_isgraph(c); }
 int tre_islower_func(tre_cint_t c) { return tre_islower(c); }
 int tre_isprint_func(tre_cint_t c)
 {
-#ifdef TRE_WCHAR
-  /* Windows has \t as printable via iswprint in all locales. By POSIX
-     and ?regex, we need \t to be non-printable in the C locale, so we
-     cannot use iswprint. By C99, iswprint(L'\t') should be the same as
-     isprint('\t'). In Windows, in C locale, isprint('\t') is false, 
-     hence this workaround. */
-    if (c == L'\t') return isprint('\t');
+  return
+#if defined(WIN32) && TRE_WCHAR
+    /* On Windows, iswprint(L'\t') incorrectly returns true. */
+    c != L'\t' &&
 #endif
-  return tre_isprint(c); /* Windows has \t as printable */
+    tre_isprint(c);
 }
 int tre_ispunct_func(tre_cint_t c) { return tre_ispunct(c); }
 int tre_isspace_func(tre_cint_t c) { return tre_isspace(c); }
@@ -265,166 +259,164 @@ tre_parse_bracket_items(tre_parse_ctx_t *ctx, int negate,
 			int *items_size)
 {
   const tre_char_t *re = ctx->re;
-  reg_errcode_t status = REG_OK;
+  reg_errcode_t status;
   tre_ctype_t class = (tre_ctype_t)0;
+  tre_cint_t min = 0, max = 0;
   int i = *num_items;
   int max_i = *items_size;
   int skip;
 
   /* Build an array of the items in the bracket expression. */
-  while (status == REG_OK)
+  for (;;)
     {
       skip = 0;
       if (re == ctx->re_end)
 	{
-	  status = REG_EBRACK;
+	  return REG_EBRACK;
 	}
-      else if (*re == CHAR_RBRACKET && re > ctx->re)
+      if (*re == CHAR_RBRACKET && re > ctx->re)
 	{
 	  DPRINT(("tre_parse_bracket:	done: '%.*" STRF "'\n", REST(re)));
 	  re++;
 	  break;
 	}
-      else
+      class = (tre_ctype_t)0;
+      if (re + 2 < ctx->re_end
+	  && *(re + 1) == CHAR_MINUS && *(re + 2) != CHAR_RBRACKET)
 	{
-	  tre_cint_t min = 0, max = 0;
-
-	  class = (tre_ctype_t)0;
-	  if (re + 2 < ctx->re_end
-	      && *(re + 1) == CHAR_MINUS && *(re + 2) != CHAR_RBRACKET)
+	  DPRINT(("tre_parse_bracket:  range: '%.*" STRF "'\n", REST(re)));
+	  min = *re;
+	  max = *(re + 2);
+	  re += 3;
+	  /* XXX - Should use collation order instead of encoding values
+	     in character ranges. */
+	  if (min > max)
+	    return REG_ERANGE;
+	}
+      else if (re + 1 < ctx->re_end
+	       && *re == CHAR_LBRACKET && *(re + 1) == CHAR_PERIOD)
+	return REG_ECOLLATE;
+      else if (re + 1 < ctx->re_end
+	       && *re == CHAR_LBRACKET && *(re + 1) == CHAR_EQUAL)
+	return REG_ECOLLATE;
+      else if (re + 1 < ctx->re_end
+	       && *re == CHAR_LBRACKET && *(re + 1) == CHAR_COLON)
+	{
+	  char tmp_str[64];
+	  const tre_char_t *endptr = re + 2;
+	  size_t len;
+	  DPRINT(("tre_parse_bracket:  class: '%.*" STRF "'\n", REST(re)));
+	  while (endptr < ctx->re_end && *endptr != CHAR_COLON)
+	    endptr++;
+	  if (endptr != ctx->re_end)
 	    {
-	      DPRINT(("tre_parse_bracket:  range: '%.*" STRF "'\n", REST(re)));
-	      min = *re;
-	      max = *(re + 2);
-	      re += 3;
-	      /* XXX - Should use collation order instead of encoding values
-		 in character ranges. */
-	      if (min > max)
-		status = REG_ERANGE;
-	    }
-	  else if (re + 1 < ctx->re_end
-		   && *re == CHAR_LBRACKET && *(re + 1) == CHAR_PERIOD)
-	    status = REG_ECOLLATE;
-	  else if (re + 1 < ctx->re_end
-		   && *re == CHAR_LBRACKET && *(re + 1) == CHAR_EQUAL)
-	    status = REG_ECOLLATE;
-	  else if (re + 1 < ctx->re_end
-		   && *re == CHAR_LBRACKET && *(re + 1) == CHAR_COLON)
-	    {
-	      char tmp_str[64];
-	      const tre_char_t *endptr = re + 2;
-	      size_t len;
-	      DPRINT(("tre_parse_bracket:  class: '%.*" STRF "'\n", REST(re)));
-	      while (endptr < ctx->re_end && *endptr != CHAR_COLON)
-		endptr++;
-	      if (endptr != ctx->re_end)
-		{
-		  len = MIN(endptr - re - 2, 63);
+	      len = MIN(endptr - re - 2, 63);
 #ifdef TRE_WCHAR
-		  {
-		    tre_char_t tmp_wcs[64];
-		    wcsncpy(tmp_wcs, re + 2, len);
-		    tmp_wcs[len] = L'\0';
+	      {
+		tre_char_t tmp_wcs[64];
+		wcsncpy(tmp_wcs, re + 2, len);
+		tmp_wcs[len] = L'\0';
 #if defined HAVE_WCSRTOMBS
-		    {
-		      mbstate_t state;
-		      const tre_char_t *src = tmp_wcs;
-		      memset(&state, '\0', sizeof(state));
-		      len = wcsrtombs(tmp_str, &src, sizeof(tmp_str), &state);
-		    }
-#elif defined HAVE_WCSTOMBS
-		    len = wcstombs(tmp_str, tmp_wcs, 63);
-#endif /* defined HAVE_WCSTOMBS */
-		  }
-#else /* !TRE_WCHAR */
-		  strncpy(tmp_str, (const char*)re + 2, len);
-#endif /* !TRE_WCHAR */
-		  tmp_str[len] = '\0';
-		  DPRINT(("  class name: %s\n", tmp_str));
-		  class = tre_ctype(tmp_str);
-		  if (!class)
-		    status = REG_ECTYPE;
-		  /* Optimize character classes for 8 bit character sets. */
-		  if (status == REG_OK && ctx->cur_max == 1)
-		    {
-		      status = tre_expand_ctype(ctx->mem, class, items,
-						&i, &max_i, ctx->cflags);
-		      class = (tre_ctype_t)0;
-		      skip = 1;
-		    }
-		  re = endptr + 2;
+		{
+		  mbstate_t state;
+		  const tre_char_t *src = tmp_wcs;
+		  memset(&state, '\0', sizeof(state));
+		  len = wcsrtombs(tmp_str, &src, sizeof(tmp_str), &state);
 		}
-	      else
-		status = REG_ECTYPE;
-	      min = 0;
-	      max = TRE_CHAR_MAX;
+#elif defined HAVE_WCSTOMBS
+		len = wcstombs(tmp_str, tmp_wcs, 63);
+#endif /* defined HAVE_WCSTOMBS */
+		if (len == (size_t)-1)
+		  return REG_ECTYPE;
+	      }
+#else /* !TRE_WCHAR */
+	      strncpy(tmp_str, (const char*)re + 2, len);
+#endif /* !TRE_WCHAR */
+	      tmp_str[len] = '\0';
+	      DPRINT(("  class name: %s\n", tmp_str));
+	      class = tre_ctype(tmp_str);
+	      if (!class)
+		return REG_ECTYPE;
+	      /* Optimize character classes for 8 bit character sets. */
+	      if (ctx->mb_cur_max == 1)
+		{
+		  status = tre_expand_ctype(ctx->mem, class, items,
+					    &i, &max_i, ctx->cflags);
+		  if (status != REG_OK)
+		    return status;
+		  class = (tre_ctype_t)0;
+		  skip = 1;
+		}
+	      re = endptr + 2;
 	    }
 	  else
-	    {
-	      DPRINT(("tre_parse_bracket:   char: '%.*" STRF "'\n", REST(re)));
-	      if (*re == CHAR_MINUS && *(re + 1) != CHAR_RBRACKET
-		  && ctx->re != re)
-		/* Two ranges are not allowed to share and endpoint. */
-		status = REG_ERANGE;
-	      min = max = *re++;
-	    }
+	    return REG_ECTYPE;
+	  min = 0;
+	  max = TRE_CHAR_MAX;
+	}
+      else
+	{
+	  DPRINT(("tre_parse_bracket:   char: '%.*" STRF "'\n", REST(re)));
+	  if (*re == CHAR_MINUS && *(re + 1) != CHAR_RBRACKET
+	      && ctx->re != re)
+	    /* Two ranges are not allowed to share and endpoint. */
+	    return REG_ERANGE;
+	  min = max = *re++;
+	}
 
+      if (class && negate)
+	if (*num_neg_classes >= MAX_NEG_CLASSES)
+	  return REG_ESPACE;
+	else
+	  neg_classes[(*num_neg_classes)++] = class;
+      else if (!skip)
+	{
+	  status = tre_new_item(ctx->mem, min, max, &i, &max_i, items);
 	  if (status != REG_OK)
-	    break;
+	    return status;
+	  ((tre_literal_t*)((*items)[i-1])->obj)->u.class = class;
+	}
 
-	  if (class && negate)
-	    if (*num_neg_classes >= MAX_NEG_CLASSES)
-	      status = REG_ESPACE;
-	    else
-	      neg_classes[(*num_neg_classes)++] = class;
-	  else if (!skip)
+      /* Add opposite-case counterpoints if REG_ICASE is present.
+	 This is broken if there are more than two "same" characters. */
+      if (ctx->cflags & REG_ICASE && !class && !skip)
+	{
+	  tre_cint_t cmin, ccurr;
+
+	  DPRINT(("adding opposite-case counterpoints\n"));
+	  while (min <= max)
 	    {
-	      status = tre_new_item(ctx->mem, min, max, &i, &max_i, items);
-	      if (status != REG_OK)
-		break;
-	      ((tre_literal_t*)((*items)[i-1])->obj)->u.class = class;
-	    }
-
-	  /* Add opposite-case counterpoints if REG_ICASE is present.
-	     This is broken if there are more than two "same" characters. */
-	  if (ctx->cflags & REG_ICASE && !class && status == REG_OK && !skip)
-	    {
-	      tre_cint_t cmin, ccurr;
-
-	      DPRINT(("adding opposite-case counterpoints\n"));
-	      while (min <= max)
+	      if (tre_islower(min))
 		{
-		  if (tre_islower(min))
-		    {
-		      cmin = ccurr = tre_toupper(min++);
-		      while (tre_islower(min) && tre_toupper(min) == ccurr + 1
-			     && min <= max)
-			ccurr = tre_toupper(min++);
-		      status = tre_new_item(ctx->mem, cmin, ccurr,
-					    &i, &max_i, items);
-		    }
-		  else if (tre_isupper(min))
-		    {
-		      cmin = ccurr = tre_tolower(min++);
-		      while (tre_isupper(min) && tre_tolower(min) == ccurr + 1
-			     && min <= max)
-			ccurr = tre_tolower(min++);
-		      status = tre_new_item(ctx->mem, cmin, ccurr,
-					    &i, &max_i, items);
-		    }
-		  else min++;
+		  cmin = ccurr = tre_toupper(min++);
+		  while (tre_islower(min) && tre_toupper(min) == ccurr + 1
+			 && min <= max)
+		    ccurr = tre_toupper(min++);
+		  status = tre_new_item(ctx->mem, cmin, ccurr,
+					&i, &max_i, items);
 		  if (status != REG_OK)
-		    break;
+		    return status;
 		}
-	      if (status != REG_OK)
-		break;
+	      else if (tre_isupper(min))
+		{
+		  cmin = ccurr = tre_tolower(min++);
+		  while (tre_isupper(min) && tre_tolower(min) == ccurr + 1
+			 && min <= max)
+		    ccurr = tre_tolower(min++);
+		  status = tre_new_item(ctx->mem, cmin, ccurr,
+					&i, &max_i, items);
+		  if (status != REG_OK)
+		    return status;
+		}
+	      else
+		min++;
 	    }
 	}
     }
   *num_items = i;
   *items_size = max_i;
   ctx->re = re;
-  return status;
+  return REG_OK;
 }
 
 static reg_errcode_t
@@ -434,7 +426,8 @@ tre_parse_bracket(tre_parse_ctx_t *ctx, tre_ast_node_t **result)
   int negate = 0;
   reg_errcode_t status = REG_OK;
   tre_ast_node_t **items, *u, *n;
-  int i = 0, j, max_i = 32, curr_max, curr_min;
+  int i = 0, j, max_i = 32;
+  long curr_max, curr_min;
   tre_ctype_t neg_classes[MAX_NEG_CLASSES];
   int num_neg_classes = 0;
 
@@ -464,13 +457,13 @@ tre_parse_bracket(tre_parse_ctx_t *ctx, tre_ast_node_t **result)
   /* Build a union of the items in the array, negated if necessary. */
   for (j = 0; j < i && status == REG_OK; j++)
     {
-      int min, max;
+      long min, max;
       tre_literal_t *l = items[j]->obj;
-      min = (int) l->code_min;
-      max = (int) l->code_max;
+      min = l->code_min;
+      max = l->code_max;
 
-      DPRINT(("item: %d - %d, class %p, curr_max = %d\n",
-	      (int)l->code_min, (int)l->code_max, (void *)l->u.class, curr_max));
+      DPRINT(("item: %ld - %ld, class %ld, curr_max = %ld\n",
+	      l->code_min, l->code_max, (long)l->u.class, curr_max));
 
       if (negate)
 	{
@@ -478,7 +471,7 @@ tre_parse_bracket(tre_parse_ctx_t *ctx, tre_ast_node_t **result)
 	    {
 	      /* Overlap. */
 	      curr_max = MAX(max + 1, curr_max);
-	      DPRINT(("overlap, curr_max = %d\n", curr_max));
+	      DPRINT(("overlap, curr_max = %ld\n", curr_max));
 	      l = NULL;
 	    }
 	  else
@@ -503,8 +496,7 @@ tre_parse_bracket(tre_parse_ctx_t *ctx, tre_ast_node_t **result)
       if (l != NULL)
 	{
 	  int k;
-	  DPRINT(("creating %d - %d\n", (int)l->code_min, (int)l->code_max));
-	  l->position = ctx->position;
+	  DPRINT(("creating %ld - %ld\n", l->code_min, l->code_max));
 	  if (num_neg_classes > 0)
 	    {
 	      l->neg_classes = tre_mem_alloc(ctx->mem,
@@ -539,8 +531,8 @@ tre_parse_bracket(tre_parse_ctx_t *ctx, tre_ast_node_t **result)
   if (negate)
     {
       int k;
-      DPRINT(("final: creating %d - %d\n", curr_min, (int)TRE_CHAR_MAX));
-      n = tre_ast_new_literal(ctx->mem, curr_min, TRE_CHAR_MAX, ctx->position);
+      DPRINT(("final: creating %ld - %ld\n", curr_min, (long)TRE_CHAR_MAX));
+      n = tre_ast_new_literal(ctx->mem, curr_min, TRE_CHAR_MAX);
       if (n == NULL)
 	status = REG_ESPACE;
       else
@@ -583,36 +575,40 @@ tre_parse_bracket(tre_parse_ctx_t *ctx, tre_ast_node_t **result)
 
  parse_bracket_done:
   xfree(items);
-  ctx->position++;
   *result = node;
   return status;
 }
 
 
-// patch from https://github.com/laurikari/tre/issues/55
-/* Parses a positive decimal integer.  Returns -1 if the string does not
-   contain a valid number. */
+/* Parses a positive decimal integer capped at INT_MAX.  Returns -1 if the
+   string does not contain a valid number. */
 static int
 tre_parse_int(const tre_char_t **regex, const tre_char_t *regex_end)
 {
-  int num = -1;
+  unsigned long num = 0;
   int overflow = 0;
   const tre_char_t *r = *regex;
   while (r < regex_end && *r >= L'0' && *r <= L'9')
     {
-      if (num < 0)
-	num = 0;
-      if (num <= (INT_MAX - 9) / 10) {
-         num = num * 10 + *r - L'0';
-      } else {
-          /* This digit could cause an integer overflow. We do not return
-           * directly; instead, consume all remaining digits. */
-          overflow = 1;
-      }
+      if (!overflow)
+	{
+	  if (num * 10 + *r - L'0' < num)
+	    {
+	      overflow = 1;
+	    }
+	  else
+	    {
+	      num = num * 10 + *r - L'0';
+	      if (num > INT_MAX)
+		overflow = 1;
+	    }
+	}
       r++;
     }
+  if (r == *regex)
+    return -1;
   *regex = r;
-  return overflow ? -1 : num;
+  return overflow ? INT_MAX : (int)num;
 }
 
 
@@ -643,14 +639,18 @@ tre_parse_bound(tre_parse_ctx_t *ctx, tre_ast_node_t **result)
   max = min;
   if (r < ctx->re_end && *r == CHAR_COMMA)
     {
+      if (min < 0)
+	min = 0;
       r++;
       DPRINT(("tre_parse:   max count: '%.*" STRF "'\n", REST(r)));
       max = tre_parse_int(&r, ctx->re_end);
     }
 
   /* Check that the repeat counts are sane. */
-  if ((max >= 0 && min > max) || max > RE_DUP_MAX)
+  if (max >= 0 && min > max)
     return REG_BADBR;
+  if (min > RE_DUP_MAX || max > RE_DUP_MAX)
+    return REG_BADMAX;
 
 
   /*
@@ -850,7 +850,7 @@ tre_parse_bound(tre_parse_ctx_t *ctx, tre_ast_node_t **result)
   /* Create the AST node(s). */
   if (min == 0 && max == 0)
     {
-      *result = tre_ast_new_literal(ctx->mem, EMPTY, -1, -1);
+      *result = tre_ast_new_literal(ctx->mem, EMPTY, -1);
       if (*result == NULL)
 	return REG_ESPACE;
     }
@@ -953,12 +953,12 @@ tre_parse(tre_parse_ctx_t *ctx)
   tre_parse_re_stack_symbol_t symbol;
   reg_errcode_t status = REG_OK;
   tre_stack_t *stack = ctx->stack;
-  int bottom = tre_stack_num_objects(stack);
+  size_t bottom = tre_stack_num_items(stack);
   int depth = 0;
   int temporary_cflags = 0;
 
-  DPRINT(("tre_parse: parsing '%.*" STRF "', len = %d\n",
-	  ctx->len, ctx->re, ctx->len));
+  DPRINT(("tre_parse: parsing '%.*" STRF "', len = %zu\n",
+	  (int)ctx->len, ctx->re, ctx->len));
 
   if (!ctx->nofirstsub)
     {
@@ -975,10 +975,8 @@ tre_parse(tre_parse_ctx_t *ctx)
      an explicit stack instead of recursive functions mostly because of
      two reasons: compatibility with systems which have an overflowable
      call stack, and efficiency (both in lines of code and speed).  */
-  while (tre_stack_num_objects(stack) > bottom && status == REG_OK)
+  while (status == REG_OK && tre_stack_num_items(stack) > bottom)
     {
-      if (status != REG_OK)
-	break;
       symbol = tre_stack_pop_int(stack);
       switch (symbol)
 	{
@@ -1220,7 +1218,6 @@ tre_parse(tre_parse_ctx_t *ctx)
 	  switch (*ctx->re)
 	    {
 	    case CHAR_LPAREN:  /* parenthesized subexpression */
-
 	      /* Handle "(?...)" extensions.  They work in a way similar
 		 to Perls corresponding extensions. */
 	      if (ctx->cflags & REG_EXTENDED
@@ -1327,58 +1324,51 @@ tre_parse(tre_parse_ctx_t *ctx)
 		  break;
 		}
 
-	      if (ctx->cflags & REG_EXTENDED
-		  || (ctx->re > ctx->re_start
-		      && *(ctx->re - 1) == CHAR_BACKSLASH))
+	      if (!(ctx->cflags & REG_EXTENDED))
+		goto parse_literal;
+
+	    atom_lparen:
+	      depth++;
+	      if (ctx->re + 2 < ctx->re_end
+		  && *(ctx->re + 1) == CHAR_QUESTIONMARK
+		  && *(ctx->re + 2) == CHAR_COLON)
 		{
-		  depth++;
-		  if (ctx->re + 2 < ctx->re_end
-		      && *(ctx->re + 1) == CHAR_QUESTIONMARK
-		      && *(ctx->re + 2) == CHAR_COLON)
-		    {
-		      DPRINT(("tre_parse: group begin: '%.*" STRF
-			      "', no submatch\n", REST(ctx->re)));
-		      /* Don't mark for submatching. */
-		      ctx->re += 3;
-		      STACK_PUSHX(stack, int, PARSE_RE);
-		    }
-		  else
-		    {
-		      DPRINT(("tre_parse: group begin: '%.*" STRF
-			      "', submatch %d\n", REST(ctx->re),
-			      ctx->submatch_id));
-		      ctx->re++;
-		      /* First parse a whole RE, then mark the resulting tree
-			 for submatching. */
-		      STACK_PUSHX(stack, int, ctx->submatch_id);
-		      STACK_PUSHX(stack, int, PARSE_MARK_FOR_SUBMATCH);
-		      STACK_PUSHX(stack, int, PARSE_RE);
-		      ctx->submatch_id++;
-		    }
+		  DPRINT(("tre_parse: group begin: '%.*" STRF
+			  "', no submatch\n", REST(ctx->re)));
+		  /* Don't mark for submatching. */
+		  ctx->re += 3;
+		  STACK_PUSHX(stack, int, PARSE_RE);
 		}
 	      else
-		goto parse_literal;
+		{
+		  DPRINT(("tre_parse: group begin: '%.*" STRF
+			  "', submatch %d\n", REST(ctx->re),
+			  ctx->submatch_id));
+		  ctx->re++;
+		  /* First parse a whole RE, then mark the resulting tree
+		     for submatching. */
+		  STACK_PUSHX(stack, int, ctx->submatch_id);
+		  STACK_PUSHX(stack, int, PARSE_MARK_FOR_SUBMATCH);
+		  STACK_PUSHX(stack, int, PARSE_RE);
+		  ctx->submatch_id++;
+		}
 	      break;
 
 	    case CHAR_RPAREN:  /* end of current subexpression */
-	      if ((ctx->cflags & REG_EXTENDED && depth > 0)
-		  || (!(ctx->cflags & REG_EXTENDED) && ctx->re > ctx->re_start
-		      && *(ctx->re - 1) == CHAR_BACKSLASH))
-		{
-		  DPRINT(("tre_parse:	    empty: '%.*" STRF "'\n",
-			  REST(ctx->re)));
-		  /* We were expecting an atom, but instead the current
-		     subexpression was closed.	POSIX leaves the meaning of
-		     this to be implementation-defined.	 We interpret this as
-		     an empty expression (which matches an empty string).  */
-		  result = tre_ast_new_literal(ctx->mem, EMPTY, -1, -1);
-		  if (result == NULL)
-		    return REG_ESPACE;
-		  if (!(ctx->cflags & REG_EXTENDED))
-		    ctx->re--;
-		}
-	      else
+	      if (!(ctx->cflags & REG_EXTENDED) || depth == 0)
 		goto parse_literal;
+	    atom_rparen:
+	      DPRINT(("tre_parse:	    empty: '%.*" STRF "'\n",
+		      REST(ctx->re)));
+	      /* We were expecting an atom, but instead the current
+		 subexpression was closed.  POSIX leaves the meaning of
+		 this to be implementation-defined.  We interpret this as
+		 an empty expression (which matches an empty string).  */
+	      result = tre_ast_new_literal(ctx->mem, EMPTY, -1);
+	      if (result == NULL)
+		return REG_ESPACE;
+	      if (!(ctx->cflags & REG_EXTENDED))
+		ctx->re--;
 	      break;
 
 	    case CHAR_LBRACKET: /* bracket expression */
@@ -1391,16 +1381,15 @@ tre_parse(tre_parse_ctx_t *ctx)
 	      break;
 
 	    case CHAR_BACKSLASH:
-	      /* If this is "\(" or "\)" chew off the backslash and
-		 try again. */
-	      if (!(ctx->cflags & REG_EXTENDED)
-		  && ctx->re + 1 < ctx->re_end
-		  && (*(ctx->re + 1) == CHAR_LPAREN
-		      || *(ctx->re + 1) == CHAR_RPAREN))
+	      /* If this is "\(" or "\)" skip straight there. */
+	      if (!(ctx->cflags & REG_EXTENDED) && ctx->re + 1 < ctx->re_end)
 		{
 		  ctx->re++;
-		  STACK_PUSHX(stack, int, PARSE_ATOM);
-		  break;
+		  if (*ctx->re == CHAR_LPAREN)
+		      goto atom_lparen;
+		  if (*ctx->re == CHAR_RPAREN)
+		      goto atom_rparen;
+		  ctx->re--;
 		}
 
 	      /* If a macro is used, parse the expanded macro recursively. */
@@ -1419,7 +1408,6 @@ tre_parse(tre_parse_ctx_t *ctx)
 		    if (status != REG_OK)
 		      return status;
 		    ctx->re += 2;
-		    ctx->position = subctx.position;
 		    result = subctx.result;
 		    break;
 		  }
@@ -1448,22 +1436,22 @@ tre_parse(tre_parse_ctx_t *ctx)
 		{
 		case L'b':
 		  result = tre_ast_new_literal(ctx->mem, ASSERTION,
-					       ASSERT_AT_WB, -1);
+					       ASSERT_AT_WB);
 		  ctx->re++;
 		  break;
 		case L'B':
 		  result = tre_ast_new_literal(ctx->mem, ASSERTION,
-					       ASSERT_AT_WB_NEG, -1);
+					       ASSERT_AT_WB_NEG);
 		  ctx->re++;
 		  break;
 		case L'<':
 		  result = tre_ast_new_literal(ctx->mem, ASSERTION,
-					       ASSERT_AT_BOW, -1);
+					       ASSERT_AT_BOW);
 		  ctx->re++;
 		  break;
 		case L'>':
 		  result = tre_ast_new_literal(ctx->mem, ASSERTION,
-					       ASSERT_AT_EOW, -1);
+					       ASSERT_AT_EOW);
 		  ctx->re++;
 		  break;
 		case L'x':
@@ -1487,23 +1475,21 @@ tre_parse(tre_parse_ctx_t *ctx)
 			  ctx->re++;
 			}
 		      val = strtol(tmp, NULL, 16);
-		      result = tre_ast_new_literal(ctx->mem, (int)val,
-						   (int)val, ctx->position);
-		      ctx->position++;
+		      result = tre_ast_new_literal(ctx->mem, (int)val, (int)val);
 		      break;
 		    }
 		  else if (ctx->re < ctx->re_end)
 		    {
 		      /* Wide char. */
-		      char tmp[32];
+		      char tmp[9]; /* max 8 hex digits + terminator */
 		      long val;
-		      int i = 0;
+		      size_t i = 0;
 		      ctx->re++;
 		      while (ctx->re_end - ctx->re >= 0)
 			{
 			  if (ctx->re[0] == CHAR_RBRACE)
 			    break;
-			  if (tre_isxdigit(ctx->re[0]))
+			  if (tre_isxdigit(ctx->re[0]) && i < sizeof(tmp) - 1)
 			    {
 			      tmp[i] = (char)ctx->re[0];
 			      i++;
@@ -1515,9 +1501,7 @@ tre_parse(tre_parse_ctx_t *ctx)
 		      ctx->re++;
 		      tmp[i] = 0;
 		      val = strtol(tmp, NULL, 16);
-		      result = tre_ast_new_literal(ctx->mem, (int)val, (int)val,
-						   ctx->position);
-		      ctx->position++;
+		      result = tre_ast_new_literal(ctx->mem, (int)val, (int)val);
 		      break;
 		    }
 		  /*FALLTHROUGH*/
@@ -1529,11 +1513,9 @@ tre_parse(tre_parse_ctx_t *ctx)
 		      int val = *ctx->re - L'0';
 		      DPRINT(("tre_parse:     backref: '%.*" STRF "'\n",
 			      REST(ctx->re - 1)));
-		      result = tre_ast_new_literal(ctx->mem, BACKREF, val,
-						   ctx->position);
+		      result = tre_ast_new_literal(ctx->mem, BACKREF, val);
 		      if (result == NULL)
 			return REG_ESPACE;
-		      ctx->position++;
 		      ctx->max_backref = MAX(val, ctx->max_backref);
 		      ctx->re++;
 		    }
@@ -1542,9 +1524,7 @@ tre_parse(tre_parse_ctx_t *ctx)
 		      /* Escaped character. */
 		      DPRINT(("tre_parse:     escaped: '%.*" STRF "'\n",
 			      REST(ctx->re - 1)));
-		      result = tre_ast_new_literal(ctx->mem, *ctx->re, *ctx->re,
-						   ctx->position);
-		      ctx->position++;
+		      result = tre_ast_new_literal(ctx->mem, *ctx->re, *ctx->re);
 		      ctx->re++;
 		    }
 		  break;
@@ -1560,26 +1540,21 @@ tre_parse(tre_parse_ctx_t *ctx)
 		{
 		  tre_ast_node_t *tmp1;
 		  tre_ast_node_t *tmp2;
-		  tmp1 = tre_ast_new_literal(ctx->mem, 0, L'\n' - 1,
-					     ctx->position);
+		  tmp1 = tre_ast_new_literal(ctx->mem, 0, L'\n' - 1);
 		  if (!tmp1)
 		    return REG_ESPACE;
-		  tmp2 = tre_ast_new_literal(ctx->mem, L'\n' + 1, TRE_CHAR_MAX,
-					     ctx->position + 1);
+		  tmp2 = tre_ast_new_literal(ctx->mem, L'\n' + 1, TRE_CHAR_MAX);
 		  if (!tmp2)
 		    return REG_ESPACE;
 		  result = tre_ast_new_union(ctx->mem, tmp1, tmp2);
 		  if (!result)
 		    return REG_ESPACE;
-		  ctx->position += 2;
 		}
 	      else
 		{
-		  result = tre_ast_new_literal(ctx->mem, 0, TRE_CHAR_MAX,
-					       ctx->position);
+		  result = tre_ast_new_literal(ctx->mem, 0, TRE_CHAR_MAX);
 		  if (!result)
 		    return REG_ESPACE;
-		  ctx->position++;
 		}
 	      ctx->re++;
 	      break;
@@ -1596,7 +1571,7 @@ tre_parse(tre_parse_ctx_t *ctx)
 		  DPRINT(("tre_parse:	      BOL: '%.*" STRF "'\n",
 			  REST(ctx->re)));
 		  result = tre_ast_new_literal(ctx->mem, ASSERTION,
-					       ASSERT_AT_BOL, -1);
+					       ASSERT_AT_BOL);
 		  if (result == NULL)
 		    return REG_ESPACE;
 		  ctx->re++;
@@ -1617,7 +1592,7 @@ tre_parse(tre_parse_ctx_t *ctx)
 		  DPRINT(("tre_parse:	      EOL: '%.*" STRF "'\n",
 			  REST(ctx->re)));
 		  result = tre_ast_new_literal(ctx->mem, ASSERTION,
-					       ASSERT_AT_EOL, -1);
+					       ASSERT_AT_EOL);
 		  if (result == NULL)
 		    return REG_ESPACE;
 		  ctx->re++;
@@ -1664,22 +1639,27 @@ tre_parse(tre_parse_ctx_t *ctx)
 		{
 		  DPRINT(("tre_parse:	    empty: '%.*" STRF "'\n",
 			  REST(ctx->re)));
-		  result = tre_ast_new_literal(ctx->mem, EMPTY, -1, -1);
+		  result = tre_ast_new_literal(ctx->mem, EMPTY, -1);
 		  if (!result)
 		    return REG_ESPACE;
 		  break;
 		}
 
-/* R change */
-	      if ((ctx->cflags & REG_LITERAL) && !ctx->re[0]) {
+#ifdef REG_LITERAL
+	      /* In literal mode the branch above is skipped, so an empty
+		 pattern would otherwise fall through without producing an
+		 atom.  Emit an empty expression, which matches the empty
+		 string. */
+	      if ((ctx->cflags & REG_LITERAL) && ctx->re >= ctx->re_end)
+		{
 		  DPRINT(("tre_parse:	    literal empty: '%.*" STRF "'\n",
 			  REST(ctx->re)));
-		  result = tre_ast_new_literal(ctx->mem, EMPTY, -1, -1);
+		  result = tre_ast_new_literal(ctx->mem, EMPTY, -1);
 		  if (!result)
 		    return REG_ESPACE;
 		  break;
-	      }
-/* end R change */
+		}
+#endif /* REG_LITERAL */
 
 	      DPRINT(("tre_parse:     literal: '%.*" STRF "'\n",
 		      REST(ctx->re)));
@@ -1701,13 +1681,11 @@ tre_parse(tre_parse_ctx_t *ctx)
 		     could be several opposite-case counterpoints, but they
 		     cannot be supported portably anyway. */
 		  tmp1 = tre_ast_new_literal(ctx->mem, tre_toupper(*ctx->re),
-					     tre_toupper(*ctx->re),
-					     ctx->position);
+					     tre_toupper(*ctx->re));
 		  if (!tmp1)
 		    return REG_ESPACE;
 		  tmp2 = tre_ast_new_literal(ctx->mem, tre_tolower(*ctx->re),
-					     tre_tolower(*ctx->re),
-					     ctx->position);
+					     tre_tolower(*ctx->re));
 		  if (!tmp2)
 		    return REG_ESPACE;
 		  result = tre_ast_new_union(ctx->mem, tmp1, tmp2);
@@ -1716,12 +1694,10 @@ tre_parse(tre_parse_ctx_t *ctx)
 		}
 	      else
 		{
-		  result = tre_ast_new_literal(ctx->mem, *ctx->re, *ctx->re,
-					       ctx->position);
+		  result = tre_ast_new_literal(ctx->mem, *ctx->re, *ctx->re);
 		  if (!result)
 		    return REG_ESPACE;
 		}
-	      ctx->position++;
 	      ctx->re++;
 	      break;
 	    }
@@ -1731,22 +1707,21 @@ tre_parse(tre_parse_ctx_t *ctx)
 	  {
 	    int submatch_id = tre_stack_pop_int(stack);
 
-            if(result) {
-	      if (result->submatch_id >= 0)
-	        {
-		  tre_ast_node_t *n, *tmp_node;
-		  n = tre_ast_new_literal(ctx->mem, EMPTY, -1, -1);
-		  if (n == NULL)
-		    return REG_ESPACE;
-		  tmp_node = tre_ast_new_catenation(ctx->mem, n, result);
-		  if (tmp_node == NULL)
-		    return REG_ESPACE;
-		  tmp_node->num_submatches = result->num_submatches;
-		  result = tmp_node;
-	        }
-	      result->submatch_id = submatch_id;
-	      result->num_submatches++;
-	    }
+	    assert(result);
+	    if (result->submatch_id >= 0)
+	      {
+		tre_ast_node_t *n, *tmp_node;
+		n = tre_ast_new_literal(ctx->mem, EMPTY, -1);
+		if (n == NULL)
+		  return REG_ESPACE;
+		tmp_node = tre_ast_new_catenation(ctx->mem, n, result);
+		if (tmp_node == NULL)
+		  return REG_ESPACE;
+		tmp_node->num_submatches = result->num_submatches;
+		result = tmp_node;
+	      }
+	    result->submatch_id = submatch_id;
+	    result->num_submatches++;
 	    break;
 	  }
 
@@ -1760,14 +1735,15 @@ tre_parse(tre_parse_ctx_t *ctx)
 	}
     }
 
+  if (status != REG_OK)
+    return status;
+
   /* Check for missing closing parentheses. */
   if (depth > 0)
     return REG_EPAREN;
 
-  if (status == REG_OK)
-    ctx->result = result;
-
-  return status;
+  ctx->result = result;
+  return REG_OK;
 }
 
 /* EOF */

--- a/src/extra/tre/tre-parse.h
+++ b/src/extra/tre/tre-parse.h
@@ -1,13 +1,12 @@
 /*
-  tre-parse.c - Regexp parser definitions
-
-  This software is released under a BSD-style license.
-  See the file LICENSE for details and copyright.
-
-*/
+ * tre-parse.c - Regexp parser definitions
+ *
+ * This software is released under a BSD-style license.
+ * See the file LICENSE for details and copyright.
+ */
 
 #ifndef TRE_PARSE_H
-#define TRE_PARSE_H 1
+#define TRE_PARSE_H
 
 /* Parse context. */
 typedef struct {
@@ -26,8 +25,6 @@ typedef struct {
   size_t len;
   /* Current submatch ID. */
   int submatch_id;
-  /* Current position (number of literal). */
-  int position;
   /* The highest back reference or -1 if none seen so far. */
   int max_backref;
   /* This flag is set if the regexp uses approximate matching. */
@@ -38,8 +35,8 @@ typedef struct {
   int nofirstsub;
   /* The currently set approximate matching parameters. */
   int params[TRE_PARAM_LAST];
-  /* the CUR_MAX in use */
-  int cur_max;
+  /* the MB_CUR_MAX in use */
+  int mb_cur_max;
 } tre_parse_ctx_t;
 
 /* Parses a wide character regexp pattern into a syntax tree.  This parser

--- a/src/extra/tre/tre-stack.c
+++ b/src/extra/tre/tre-stack.c
@@ -10,13 +10,11 @@
 #include <config.h>
 #endif /* HAVE_CONFIG_H */
 #include <stdlib.h>
-//#include <assert.h>
+#include <assert.h>
 
 #include "tre-internal.h"
 #include "tre-stack.h"
 #include "xmalloc.h"
-
-#define assert(a) R_assert(a)
 
 union tre_stack_item {
   void *voidptr_value;
@@ -24,16 +22,15 @@ union tre_stack_item {
 };
 
 struct tre_stack_rec {
-  int size;
-  int max_size;
-  int increment;
-  int ptr;
+  size_t size;
+  size_t max_size;
+  size_t ptr;
   union tre_stack_item *stack;
 };
 
 
 tre_stack_t *
-tre_stack_new(int size, int max_size, int increment)
+tre_stack_new(size_t size, size_t max_size)
 {
   tre_stack_t *s;
 
@@ -48,7 +45,6 @@ tre_stack_new(int size, int max_size, int increment)
 	}
       s->size = size;
       s->max_size = max_size;
-      s->increment = increment;
       s->ptr = 0;
     }
   return s;
@@ -61,8 +57,8 @@ tre_stack_destroy(tre_stack_t *s)
   xfree(s);
 }
 
-int
-tre_stack_num_objects(tre_stack_t *s)
+size_t
+tre_stack_num_items(tre_stack_t *s)
 {
   return s->ptr;
 }
@@ -85,9 +81,9 @@ tre_stack_push(tre_stack_t *s, union tre_stack_item value)
       else
 	{
 	  union tre_stack_item *new_buffer;
-	  int new_size;
+	  size_t new_size;
 	  DPRINT(("tre_stack_push: trying to realloc more space\n"));
-	  new_size = s->size + s->increment;
+	  new_size = s->size + s->size;
 	  if (new_size > s->max_size)
 	    new_size = s->max_size;
 	  new_buffer = xrealloc(s->stack, sizeof(*new_buffer) * new_size);

--- a/src/extra/tre/tre-stack.h
+++ b/src/extra/tre/tre-stack.h
@@ -1,33 +1,30 @@
 /*
-  tre-stack.h: Stack definitions
-
-  This software is released under a BSD-style license.
-  See the file LICENSE for details and copyright.
-
-*/
-
+ * tre-stack.h: Stack definitions
+ *
+ * This software is released under a BSD-style license.
+ * See the file LICENSE for details and copyright.
+ *
+ */
 
 #ifndef TRE_STACK_H
-#define TRE_STACK_H 1
-
-#include "tre.h"
+#define TRE_STACK_H
 
 typedef struct tre_stack_rec tre_stack_t;
 
-/* Creates a new stack object.	`size' is initial size in bytes, `max_size'
-   is maximum size, and `increment' specifies how much more space will be
-   allocated with realloc() if all space gets used up.	Returns the stack
-   object or NULL if out of memory. */
+/* Creates a new stack object with initial size `size' and maximum size
+   `max_size'. Pushing an additional item onto a full stack will resize
+   the stack to double its capacity until the maximum is reached. Returns
+   the stack object or NULL if out of memory. */
 tre_stack_t *
-tre_stack_new(int size, int max_size, int increment);
+tre_stack_new(size_t size, size_t max_size);
 
 /* Frees the stack object. */
 void
 tre_stack_destroy(tre_stack_t *s);
 
-/* Returns the current number of objects in the stack. */
-int
-tre_stack_num_objects(tre_stack_t *s);
+/* Returns the current number of items on the stack. */
+size_t
+tre_stack_num_items(tre_stack_t *s);
 
 /* Each tre_stack_push_*(tre_stack_t *s, <type> value) function pushes
    `value' on top of stack `s'.  Returns REG_ESPACE if out of memory.

--- a/src/extra/tre/tre.h
+++ b/src/extra/tre/tre.h
@@ -1,13 +1,12 @@
 /*
-  tre.h - TRE public API definitions
-
-  This software is released under a BSD-style license.
-  See the file LICENSE for details and copyright.
-
-*/
+ * tre.h - TRE public API definitions
+ *
+ * This software is released under a BSD-style license.
+ * See the file LICENSE for details and copyright.
+ */
 
 #ifndef TRE_H
-#define TRE_H 1
+#define TRE_H
 
 #include "tre-config.h"
 
@@ -27,6 +26,25 @@
 #define tre_regexec  regexec
 #define tre_regerror regerror
 #define tre_regfree  regfree
+/* The GNU C regex has a number of refinements to the POSIX standard for the
+   formal parameter list of the regexec() function, and some of those fail to
+   compile when using LLVM.  The refinements seem to be opt-out rather than
+   opt-in when using a recent gcc, and they produce a warning when TRE tries
+   to mimic the API without the refinements.  The TRE code still works but
+   the warnings are distracting, so try to #define a flag to indicate when to 
+   add the refinements to TRE's parameter list too. */
+#ifdef __GNUC__
+/* Try to test something that looks pretty REGEX specific and hope we don't
+   need a zillion different platform+compiler specific tests to deal with this. */
+#ifdef _REGEX_NELTS
+/* Define a TRE specific flag here so that:
+   1) there is only one place where code has to be changed if the test above is not adequate, and
+   2) the flag can be used in any other parts of the TRE source that might be affected by the
+      GNUC refinements.
+   Note that this flag is only defined when all of TRE_USE_SYSTEM_REGEX_H, __GNUC__, and _REGEX_NELTS are defined. */
+#define TRE_USE_GNUC_REGEXEC_FPL 1
+#endif
+#endif
 #endif /* TRE_USE_SYSTEM_REGEX_H */
 
 #ifdef __cplusplus
@@ -47,15 +65,28 @@ typedef int reg_errcode_t;
 #define REG_LITERAL 0x1000
 #endif
 
+/* Extra tre_regcomp() return error codes. */
+#define REG_BADMAX REG_BADBR
+
 /* Extra tre_regcomp() flags. */
 #ifndef REG_BASIC
 #define REG_BASIC	0
 #endif /* !REG_BASIC */
 #define REG_RIGHT_ASSOC (REG_LITERAL << 1)
+#ifdef REG_UNGREEDY
+/* We're going to use TRE code, so we need the TRE define (dodge problem in MacOS). */
+#undef REG_UNGREEDY
+#endif
 #define REG_UNGREEDY    (REG_RIGHT_ASSOC << 1)
+
+#define REG_USEBYTES    (REG_UNGREEDY << 1)
 
 /* Extra tre_regexec() flags. */
 #define REG_APPROX_MATCHER	 0x1000
+#ifdef REG_BACKTRACKING_MATCHER
+/* We're going to use TRE code, so we need the TRE define (dodge problem in MacOS). */
+#undef REG_BACKTRACKING_MATCHER
+#endif
 #define REG_BACKTRACKING_MATCHER (REG_APPROX_MATCHER << 1)
 
 #else /* !TRE_USE_SYSTEM_REGEX_H */
@@ -91,7 +122,8 @@ typedef enum {
   REG_BADBR,		/* Invalid content of {} */
   REG_ERANGE,		/* Invalid use of range operator */
   REG_ESPACE,		/* Out of memory.  */
-  REG_BADRPT            /* Invalid use of repetition operators. */
+  REG_BADRPT,		/* Invalid use of repetition operators. */
+  REG_BADMAX,		/* Maximum repetition in {} too large */
 } reg_errcode_t;
 
 /* POSIX tre_regcomp() flags. */
@@ -105,7 +137,6 @@ typedef enum {
 #define REG_LITERAL	(REG_NOSUB << 1)
 #define REG_RIGHT_ASSOC (REG_LITERAL << 1)
 #define REG_UNGREEDY    (REG_RIGHT_ASSOC << 1)
-
 #define REG_USEBYTES    (REG_UNGREEDY << 1)
 
 /* POSIX tre_regexec() flags. */
@@ -133,20 +164,27 @@ typedef enum {
 extern int
 tre_regcomp(regex_t *preg, const char *regex, int cflags);
 
+#ifdef TRE_USE_GNUC_REGEXEC_FPL
+extern int
+tre_regexec(const regex_t *preg, const char *string,
+	size_t nmatch, regmatch_t pmatch[_Restrict_arr_ _REGEX_NELTS (nmatch)],
+	int eflags);
+#else
 extern int
 tre_regexec(const regex_t *preg, const char *string, size_t nmatch,
-	    regmatch_t pmatch[], int eflags);
+	regmatch_t pmatch[], int eflags);
+#endif
 
 extern int
 tre_regcompb(regex_t *preg, const char *regex, int cflags);
 
 extern int
 tre_regexecb(const regex_t *preg, const char *string, size_t nmatch,
-	     regmatch_t pmatch[], int eflags);
+	regmatch_t pmatch[], int eflags);
 
 extern size_t
 tre_regerror(int errcode, const regex_t *preg, char *errbuf,
-	     size_t errbuf_size);
+	 size_t errbuf_size);
 
 extern void
 tre_regfree(regex_t *preg);
@@ -172,7 +210,7 @@ tre_regncomp(regex_t *preg, const char *regex, size_t len, int cflags);
 
 extern int
 tre_regnexec(const regex_t *preg, const char *string, size_t len,
-	     size_t nmatch, regmatch_t pmatch[], int eflags);
+	 size_t nmatch, regmatch_t pmatch[], int eflags);
 
 /* regn*b versions take byte literally as 8-bit values */
 extern int
@@ -180,7 +218,7 @@ tre_regncompb(regex_t *preg, const char *regex, size_t n, int cflags);
 
 extern int
 tre_regnexecb(const regex_t *preg, const char *str, size_t len,
-	      size_t nmatch, regmatch_t pmatch[], int eflags);
+	  size_t nmatch, regmatch_t pmatch[], int eflags);
 
 #ifdef TRE_WCHAR
 extern int
@@ -188,7 +226,7 @@ tre_regwncomp(regex_t *preg, const wchar_t *regex, size_t len, int cflags);
 
 extern int
 tre_regwnexec(const regex_t *preg, const wchar_t *string, size_t len,
-	      size_t nmatch, regmatch_t pmatch[], int eflags);
+	  size_t nmatch, regmatch_t pmatch[], int eflags);
 #endif /* TRE_WCHAR */
 
 #ifdef TRE_APPROX
@@ -220,28 +258,25 @@ typedef struct {
 /* Approximate matching functions. */
 extern int
 tre_regaexec(const regex_t *preg, const char *string,
-	     regamatch_t *match, regaparams_t params, int eflags);
+	 regamatch_t *match, regaparams_t params, int eflags);
 
 extern int
 tre_reganexec(const regex_t *preg, const char *string, size_t len,
-	      regamatch_t *match, regaparams_t params, int eflags);
+	  regamatch_t *match, regaparams_t params, int eflags);
 
 extern int
 tre_regaexecb(const regex_t *preg, const char *string,
-	      regamatch_t *match, regaparams_t params, int eflags);
+	  regamatch_t *match, regaparams_t params, int eflags);
 
-extern int
-tre_reganexec(const regex_t *preg, const char *string, size_t len,
-	      regamatch_t *match, regaparams_t params, int eflags);
 #ifdef TRE_WCHAR
 /* Wide character approximate matching. */
 extern int
 tre_regawexec(const regex_t *preg, const wchar_t *string,
-	      regamatch_t *match, regaparams_t params, int eflags);
+	  regamatch_t *match, regaparams_t params, int eflags);
 
 extern int
 tre_regawnexec(const regex_t *preg, const wchar_t *string, size_t len,
-	       regamatch_t *match, regaparams_t params, int eflags);
+	   regamatch_t *match, regaparams_t params, int eflags);
 #endif /* TRE_WCHAR */
 
 /* Sets the parameters to default values. */
@@ -264,7 +299,7 @@ typedef struct {
 
 extern int
 tre_reguexec(const regex_t *preg, const tre_str_source *string,
-	     size_t nmatch, regmatch_t pmatch[], int eflags);
+	 size_t nmatch, regmatch_t pmatch[], int eflags);
 
 /* Returns the version string.	The returned string is static. */
 extern char *
@@ -296,6 +331,7 @@ tre_have_approx(const regex_t *preg);
 #ifdef __cplusplus
 }
 #endif
-#endif				/* TRE_H */
+
+#endif /* TRE_H */
 
 /* EOF */

--- a/src/extra/tre/xmalloc.c
+++ b/src/extra/tre/xmalloc.c
@@ -16,21 +16,12 @@
 #include <config.h>
 #endif /* HAVE_CONFIG_H */
 
+#include <stdint.h>
 #include <stdlib.h>
-//#include <assert.h>
+#include <assert.h>
 #include <stdio.h>
 #define XMALLOC_INTERNAL 1
 #include "xmalloc.h"
-
-/* fake definition */
-extern void Rf_error(const char *str, ...);
-#define assert(a) R_assert(a)
-
-static void assert(int expr)
-{
-    if(expr == 0)
-	Rf_error("internal allocation error in TRE");
-}
 
 
 /*
@@ -38,8 +29,8 @@ static void assert(int expr)
 */
 
 typedef struct hashTableItemRec {
-  void *ptr;
-  int bytes;
+  uintptr_t addr;
+  size_t size;
   const char *file;
   int line;
   const char *func;
@@ -50,15 +41,16 @@ typedef struct {
   hashTableItem **table;
 } hashTable;
 
-static int xmalloc_peak;
-int xmalloc_current;
-static int xmalloc_peak_blocks;
-int xmalloc_current_blocks;
+static unsigned int xmalloc_peak;
+static unsigned int xmalloc_current;
+static unsigned int xmalloc_peak_blocks;
+static unsigned int xmalloc_current_blocks;
+static unsigned int xmalloc_nins;
+static unsigned int xmalloc_ndel;
+static unsigned int xmalloc_ncoll;
 static int xmalloc_fail_after;
 
-#define TABLE_BITS 8
-#define TABLE_MASK ((1 << TABLE_BITS) - 1)
-#define TABLE_SIZE (1 << TABLE_BITS)
+#define TABLE_SIZE 8191
 
 static hashTable *
 hash_table_new(void)
@@ -81,37 +73,34 @@ hash_table_new(void)
   return tbl;
 }
 
-static int
-hash_void_ptr(void *ptr)
+static uint32_t
+adler32(const void *data, size_t len)
 {
-  int hash;
-  int i;
+  const uint8_t *bytes;
+  uint32_t c0, c1;
 
-  /* I took this hash function just off the top of my head, I have
-     no idea whether it is bad or very bad. */
-  hash = 0;
-  for (i = 0; i < (int)sizeof(ptr)*8 / TABLE_BITS; i++)
+  for (bytes = data, c0 = 1, c1 = 0; len > 0; len--, bytes++)
     {
-/* R change: unsigned long may be shorter than ptr */
-#ifdef _WIN64
-      hash ^= (size_t)ptr >> i*8;
-#else
-      hash ^= (unsigned long)ptr >> i*8;
-#endif
-      hash += i * 17;
-      hash &= TABLE_MASK;
+      c0 = (c0 + *bytes) % 65521;
+      c1 = (c1 + c0) % 65521;
     }
-  return hash;
+  return c1 << 16 | c0;
+}
+
+static unsigned int
+hash_addr(uintptr_t addr)
+{
+  return adler32(&addr, sizeof(addr)) % TABLE_SIZE;
 }
 
 static void
-hash_table_add(hashTable *tbl, void *ptr, int bytes,
+hash_table_add(hashTable *tbl, uintptr_t addr, size_t size,
 	       const char *file, int line, const char *func)
 {
-  int i;
+  unsigned int i;
   hashTableItem *item, *new;
 
-  i = hash_void_ptr(ptr);
+  i = hash_addr(addr);
 
   item = tbl->table[i];
   if (item != NULL)
@@ -120,18 +109,25 @@ hash_table_add(hashTable *tbl, void *ptr, int bytes,
 
   new = malloc(sizeof(*new));
   assert(new != NULL);
-  new->ptr = ptr;
-  new->bytes = bytes;
+  new->addr = addr;
+  new->size = size;
   new->file = file;
   new->line = line;
   new->func = func;
   new->next = NULL;
   if (item != NULL)
-    item->next = new;
+    {
+      item->next = new;
+      xmalloc_nins++;
+      xmalloc_ncoll++;
+    }
   else
-    tbl->table[i] = new;
+    {
+      tbl->table[i] = new;
+      xmalloc_nins++;
+    }
 
-  xmalloc_current += bytes;
+  xmalloc_current += size;
   if (xmalloc_current > xmalloc_peak)
     xmalloc_peak = xmalloc_current;
   xmalloc_current_blocks++;
@@ -140,32 +136,24 @@ hash_table_add(hashTable *tbl, void *ptr, int bytes,
 }
 
 static void
-hash_table_del(hashTable *tbl, void *ptr)
+hash_table_del(hashTable *tbl, uintptr_t addr)
 {
-  int i;
   hashTableItem *item, *prev;
+  int i;
 
-  i = hash_void_ptr(ptr);
+  i = hash_addr(addr);
 
-  item = tbl->table[i];
+  for (prev = NULL, item = tbl->table[i];
+       item != NULL && item->addr != addr;
+       prev = item, item = item->next)
+    /* nothing */ ;
   if (item == NULL)
     {
-      printf("xfree: invalid ptr %p\n", ptr);
-      abort();
-    }
-  prev = NULL;
-  while (item->ptr != ptr)
-    {
-      prev = item;
-      item = item->next;
-    }
-  if (item->ptr != ptr)
-    {
-      printf("xfree: invalid ptr %p\n", ptr);
+      printf("xfree: invalid address %#lx\n", addr);
       abort();
     }
 
-  xmalloc_current -= item->bytes;
+  xmalloc_current -= item->size;
   xmalloc_current_blocks--;
 
   if (prev != NULL)
@@ -178,6 +166,7 @@ hash_table_del(hashTable *tbl, void *ptr)
       tbl->table[i] = item->next;
       free(item);
     }
+  xmalloc_ndel++;
 }
 
 static hashTable *xmalloc_table = NULL;
@@ -192,6 +181,9 @@ xmalloc_init(void)
       xmalloc_peak_blocks = 0;
       xmalloc_current = 0;
       xmalloc_current_blocks = 0;
+      xmalloc_nins = 0;
+      xmalloc_ndel = 0;
+      xmalloc_ncoll = 0;
       xmalloc_fail_after = -1;
     }
   assert(xmalloc_table != NULL);
@@ -214,9 +206,9 @@ xmalloc_configure(int fail_after)
 int
 xmalloc_dump_leaks(void)
 {
-  int i;
-  int num_leaks = 0;
-  int leaked_bytes = 0;
+  unsigned int i;
+  unsigned int num_leaks = 0;
+  size_t leaked_bytes = 0;
   hashTableItem *item;
 
   xmalloc_init();
@@ -226,28 +218,34 @@ xmalloc_dump_leaks(void)
       item = xmalloc_table->table[i];
       while (item != NULL)
 	{
-	  printf("%s:%d: %s: %d bytes at %p not freed\n",
-		 item->file, item->line, item->func, item->bytes, item->ptr);
+	  printf("%s:%d: %s: %zu bytes at %#lx not freed\n",
+		 item->file, item->line, item->func, item->size, item->addr);
 	  num_leaks++;
-	  leaked_bytes += item->bytes;
+	  leaked_bytes += item->size;
 	  item = item->next;
 	}
     }
   if (num_leaks == 0)
     printf("No memory leaks.\n");
   else
-    printf("%d unfreed memory chuncks, total %d unfreed bytes.\n",
+    printf("%u unfreed memory chuncks, total %zu unfreed bytes.\n",
 	   num_leaks, leaked_bytes);
-  printf("Peak memory consumption %d bytes (%.1f kB, %.1f MB) in %d blocks ",
+  printf("Peak memory consumption %u bytes (%.1f kB, %.1f MB) in %u blocks ",
 	 xmalloc_peak, (double)xmalloc_peak / 1024,
 	 (double)xmalloc_peak / (1024*1024), xmalloc_peak_blocks);
   printf("(average ");
   if (xmalloc_peak_blocks)
-    printf("%d", ((xmalloc_peak + xmalloc_peak_blocks / 2)
+    printf("%u", ((xmalloc_peak + xmalloc_peak_blocks / 2)
 		  / xmalloc_peak_blocks));
   else
     printf("N/A");
   printf(" bytes per block).\n");
+
+  printf("Hash table: %u inserts %u deletes %u collisions",
+	 xmalloc_nins, xmalloc_ndel, xmalloc_ncoll);
+  if (xmalloc_ncoll > 0)
+    printf(" (%.2f%%)", 100.0 * xmalloc_ncoll / xmalloc_nins);
+  printf("\n");
 
   return num_leaks;
 }
@@ -279,7 +277,7 @@ xmalloc_impl(size_t size, const char *file, int line, const char *func)
 
   ptr = malloc(size);
   if (ptr != NULL)
-    hash_table_add(xmalloc_table, ptr, (int)size, file, line, func);
+    hash_table_add(xmalloc_table, (uintptr_t)ptr, size, file, line, func);
   return ptr;
 }
 
@@ -311,20 +309,21 @@ xcalloc_impl(size_t nmemb, size_t size, const char *file, int line,
 
   ptr = calloc(nmemb, size);
   if (ptr != NULL)
-    hash_table_add(xmalloc_table, ptr, (int)(nmemb * size), file, line, func);
+    hash_table_add(xmalloc_table, (uintptr_t)ptr, nmemb * size, file, line, func);
   return ptr;
 }
 
 void
 xfree_impl(void *ptr, const char *file, int line, const char *func)
 {
+  uintptr_t key = (uintptr_t)ptr;
   /*LINTED*/(void)&file;
   /*LINTED*/(void)&line;
   /*LINTED*/(void)&func;
   xmalloc_init();
 
   if (ptr != NULL)
-    hash_table_del(xmalloc_table, ptr);
+    hash_table_del(xmalloc_table, key);
   free(ptr);
 }
 
@@ -332,6 +331,7 @@ void *
 xrealloc_impl(void *ptr, size_t new_size, const char *file, int line,
 	      const char *func)
 {
+  uintptr_t key = (uintptr_t)ptr;
   void *new_ptr;
 
   xmalloc_init();
@@ -353,10 +353,11 @@ xrealloc_impl(void *ptr, size_t new_size, const char *file, int line,
     xmalloc_fail_after--;
 
   new_ptr = realloc(ptr, new_size);
-  if (new_ptr != NULL)
+  if (new_ptr != NULL && new_ptr != ptr)
     {
-      hash_table_del(xmalloc_table, ptr); /* -Wuse-after-free is false alarm */
-      hash_table_add(xmalloc_table, new_ptr, (int)new_size, file, line, func);
+      hash_table_del(xmalloc_table, key);
+      key = (uintptr_t)new_ptr;
+      hash_table_add(xmalloc_table, key, new_size, file, line, func);
     }
   return new_ptr;
 }

--- a/src/extra/tre/xmalloc.h
+++ b/src/extra/tre/xmalloc.h
@@ -1,13 +1,12 @@
 /*
-  xmalloc.h - Simple malloc debugging library API
+ * xmalloc.h - Simple malloc debugging library API
+ *
+ * This software is released under a BSD-style license.
+ * See the file LICENSE for details and copyright.
+ */
 
-  This software is released under a BSD-style license.
-  See the file LICENSE for details and copyright.
-
-*/
-
-#ifndef _XMALLOC_H
-#define _XMALLOC_H 1
+#ifndef TRE_XMALLOC_H
+#define TRE_XMALLOC_H
 
 void *xmalloc_impl(size_t size, const char *file, int line, const char *func);
 void *xcalloc_impl(size_t nmemb, size_t size, const char *file, int line,
@@ -72,6 +71,6 @@ void xmalloc_configure(int fail_after);
 #endif /* !MALLOC_DEBUGGING */
 #endif /* !XMALLOC_INTERNAL */
 
-#endif /* _XMALLOC_H */
+#endif /* TRE_XMALLOC_H */
 
 /* EOF */


### PR DESCRIPTION
This updates the bundled TRE in `src/extra/tre` from its TRE 0.8.0 base (2009) to current upstream, and shrinks the R-specific patch layer to three files.

## Motivation

Upstream TRE is actively maintained again, and since 0.9.0 (Sep 2024) it has absorbed most of R's historical local patches: the byte-mode interfaces (`tre_regcompb`/`tre_regncompb`/`tre_regexecb`/`tre_regnexecb`/`tre_regaexecb`) and `REG_USEBYTES`, the 8-bit optimizations in 8-bit mode (PR#14408), the `tre_copy_ast` class-copy fix (PR#16009), the `tre_parse_int` overflow fix, the `WCHAR_MAX`/AIX workaround, and several matcher fixes. Refreshing the copy picks up seventeen years of upstream development (including a parser rewrite, a hard pattern-length cap, and better large-pattern capacity) and makes future syncs mechanical.

## Provenance

The sources are taken verbatim from the `r-integration` branch of https://github.com/kevinushey/tre at 899ad4894a, which is laurikari/tre master (2026-05-23, post-0.9.0) plus five pull requests pending upstream that restore behaviors R had patched in locally:

- [#144](https://github.com/laurikari/tre/pull/144) convert `tre_ast_to_tnfa()` to iteration (R change from ~2016)
- [#145](https://github.com/laurikari/tre/pull/145) grow the approx matcher's delete deque dynamically (fixes a stack buffer overflow / hang with >512-state patterns and large `max.distance`)
- [#146](https://github.com/laurikari/tre/pull/146) make `REG_LITERAL` match the empty pattern (`regexec("", x, fixed = TRUE)`)
- [#148](https://github.com/laurikari/tre/pull/148) fix `ALIGN()` pointer truncation/under-alignment on LLP64 (64-bit Windows)
- [#149](https://github.com/laurikari/tre/pull/149) do not use the system `wctype()` on Windows (CRT lacks the "blank" class; `iswprint(L'\t')` is wrong)

`tre-filter.[ch]` (referenced by nothing) and `include/tre/regex.h` (R includes `tre/tre.h` directly) are omitted.

## R-specific layer (down from ~500 changed lines to three files)

- `tre-internal.h`: `assert()` remapped to `Rf_error()` so failed invariants raise an R error instead of aborting; `rlocale.h` included under `USE_RI18N_FNS` *or* `USE_RI18N_CASE`, since R's configure selects the two independently and AIX takes the former without the latter, with `Ri18n_towlower`/`Ri18n_towupper` used under `USE_RI18N_CASE`; `HAVE_ISWBLANK` asserted here rather than in `tre-config.h`, which `tre.h` includes and which would otherwise make an unprefixed `HAVE_*` macro visible to `grep.c`, `agrep.c`, `dcf.c` and `platform.c`; `"tre.h"` include for the flat layout.
- `tre-compile.c`: `tre_version()` reports `"R_fixes"`.
- `tre-config.h`: R-maintained static config (upstream generates it); `TRE_USE_ALLOCA` deliberately not defined, as before; `TRE_VERSION` carries the upstream commit.

No Makefile changes were needed; `R_changes` is rewritten to document the new provenance.

## User-visible changes

- `extSoftVersion()` now reports `TRE 0.9.0-899ad48 R_fixes (BSD)`. The commit is included because these sources are post-0.9.0 plus the pull requests above, so a bare `0.9.0` would not identify them.
- Upstream caps patterns at 65536 characters (`TRE_MAX_RE`), returning `REG_ESPACE` beyond that. In practice this is a capacity *increase*: the old copy failed a 63,000-char alternation and a 20,000-char catenation with "Out of memory", both of which now compile and match (tested up to the cap).
- Bound expressions parse differently, from upstream's parser rewrite:
  - `{n,}` with `n` > `RE_DUP_MAX` (255) is now rejected with `REG_BADMAX`. The old copy checked only the maximum, so `grepl("a{300,}", strrep("a", 400))` was `TRUE` and is now an "invalid regular expression" error. `{n,m}` with `m` > 255 was already rejected; only the error code changes there (`REG_BADBR` -> `REG_BADMAX`).
  - `{,}` and `{,~n}` now mean "zero or more" rather than "exactly one": `regexpr("a{,}", "aaa")` matches 3 characters where it used to match 1, and `agrep()`/`aregexec()` patterns using `{,~n}` accept a wider language. POSIX does not define `{,}` as an interval at all, so upstream's reading is defensible, but it is a change.
  - Relatedly, `{,m}` now allows `m` copies rather than `m+1`, which is a fix: `regexpr("a{,3}", "aaaa")` matched 4 characters and now matches 3.

  These are upstream's behavior, not R-side choices, and are documented in `R_changes`.

## Validation (macOS arm64)

- Full R build with no warnings from the TRE sources.
- `reg-tests-1a` through `1e`, `reg-encodings`, and `reg-tests-2` pass identically to an unmodified trunk build (`1e` fails identically on both in my environment for an unrelated locale/translation reason).
- Targeted probes agree with the old copy: `regexec(fixed = TRUE)` incl. empty pattern, `agrep`/`agrepl`/`aregexec`/`adist` incl. >512-state cases that hang stock upstream, `useBytes` and latin1 paths, `ignore.case` over Latin-1/Greek/Cyrillic/supplementary-plane characters (exercising the `Ri18n` case tables), `[[:blank:]]`/`[[:print:]]` classes.
- The same sources pass upstream's own test suite (75,774 retest cases) in both alloca and no-alloca configurations.

Windows and Linux builds have not been tested locally; the Windows-relevant pieces (`ssize_t` via `sys/types.h`, the wctype opt-out, LLP64 alignment) are addressed in the sources, and CI should exercise them.

Related: with the five PRs merged upstream and released, `--with-system-tre` against an unpatched upstream TRE becomes viable as well; this PR is the bundled-copy counterpart and does not depend on that.

