### PR TITLE
is.na(), coerceVector(), anyNA(): vectorisable NA scans and coercions

### DIFF
--- a/src/main/coerce.c
+++ b/src/main/coerce.c
@@ -2370,15 +2370,31 @@ static bool anyNA(SEXP call, SEXP op, SEXP args, SEXP env)
     }
 
     R_xlen_t i, n = xlength(x);
+    /* Scan in chunks, accumulating the NA test branchlessly within a
+       chunk and only branching between chunks: a per-element early
+       exit is a data-dependent branch the compiler cannot vectorise
+       past.  ALTREP regions are at most 512 elements, so there the
+       chunk loop collapses to one test per region. */
+    const R_xlen_t chunksize = 1024;
     switch (xT) {
     case REALSXP:
     {
 	if(REAL_NO_NA(x))
 	    return false;
 	ITERATE_BY_REGION(x, xD, i, nbatch, double, REAL, {
-		for (int k = 0; k < nbatch; k++)
-		    if (ISNAN(xD[k]))
+		R_xlen_t k = 0;
+		while (k < nbatch) {
+		    R_xlen_t kend = k + chunksize;
+		    if (kend > nbatch)
+			kend = nbatch;
+
+		    int found = 0;
+		    for (; k < kend; k++)
+			found |= ISNAN(xD[k]);
+
+		    if (found)
 			return true;
+		}
 	    });
 	break;
     }
@@ -2387,16 +2403,41 @@ static bool anyNA(SEXP call, SEXP op, SEXP args, SEXP env)
 	if(INTEGER_NO_NA(x))
 	    return false;
 	ITERATE_BY_REGION(x, xI, i, nbatch, int, INTEGER, {
-		for (int k = 0; k < nbatch; k++)
-		    if (xI[k] == NA_INTEGER)
+		R_xlen_t k = 0;
+		while (k < nbatch) {
+		    R_xlen_t kend = k + chunksize;
+		    if (kend > nbatch)
+			kend = nbatch;
+
+		    int found = 0;
+		    for (; k < kend; k++)
+			found |= (xI[k] == NA_INTEGER);
+
+		    if (found)
 			return true;
+		}
 	    });
 	break;
     }
     case LGLSXP:
     {
-	for (i = 0; i < n; i++)
-	    if (LOGICAL_ELT(x, i) == NA_LOGICAL) return true;
+	if(LOGICAL_NO_NA(x))
+	    return false;
+	ITERATE_BY_REGION(x, xL, i, nbatch, int, LOGICAL, {
+		R_xlen_t k = 0;
+		while (k < nbatch) {
+		    R_xlen_t kend = k + chunksize;
+		    if (kend > nbatch)
+			kend = nbatch;
+
+		    int found = 0;
+		    for (; k < kend; k++)
+			found |= (xL[k] == NA_LOGICAL);
+
+		    if (found)
+			return true;
+		}
+	    });
 	break;
     }
     case CPLXSXP:

--- a/src/main/coerce.c
+++ b/src/main/coerce.c
@@ -30,6 +30,8 @@
 #include <Parse.h>
 #include <Defn.h> /*-- Maybe modularize into own Coerce.h ..*/
 #include <Internal.h>
+#include <R_ext/Itermacros.h>  /* ITERATE_BY_REGION; was included further
+				  down, where only anyNA() could see it */
 #include <float.h> /* for DBL_DIG */
 #define R_MSG_mode	_("invalid 'mode' argument")
 #define R_MSG_list_vec	_("applies only to lists and vectors")
@@ -2286,22 +2288,28 @@ attribute_hidden SEXP do_isna(SEXP call, SEXP op, SEXP args, SEXP rho)
     int *pa = LOGICAL(ans);
     switch (TYPEOF(x)) {
     case LGLSXP:
-       for (i = 0; i < n; i++)
-	   pa[i] = (LOGICAL_ELT(x, i) == NA_LOGICAL);
+	ITERATE_BY_REGION(x, xl, il, nb, int, LOGICAL, {
+		for (R_xlen_t k = 0; k < nb; k++)
+		    pa[il + k] = (xl[k] == NA_LOGICAL);
+	    });
 	break;
     case INTSXP:
-	for (i = 0; i < n; i++)
-	    pa[i] = (INTEGER_ELT(x, i) == NA_INTEGER);
+	ITERATE_BY_REGION(x, xi, ii, nb, int, INTEGER, {
+		for (R_xlen_t k = 0; k < nb; k++)
+		    pa[ii + k] = (xi[k] == NA_INTEGER);
+	    });
 	break;
     case REALSXP:
-	for (i = 0; i < n; i++)
-	    pa[i] = ISNAN(REAL_ELT(x, i));
+	ITERATE_BY_REGION(x, xr, ir, nb, double, REAL, {
+		for (R_xlen_t k = 0; k < nb; k++)
+		    pa[ir + k] = ISNAN(xr[k]);
+	    });
 	break;
     case CPLXSXP:
-	for (i = 0; i < n; i++) {
-	    Rcomplex v = COMPLEX_ELT(x, i);
-	    pa[i] = (ISNAN(v.r) || ISNAN(v.i));
-	}
+	ITERATE_BY_REGION(x, xc, ic, nb, Rcomplex, COMPLEX, {
+		for (R_xlen_t k = 0; k < nb; k++)
+		    pa[ic + k] = (ISNAN(xc[k].r) || ISNAN(xc[k].i));
+	    });
 	break;
     case STRSXP:
 	for (i = 0; i < n; i++)
@@ -2364,8 +2372,6 @@ attribute_hidden SEXP do_isna(SEXP call, SEXP op, SEXP args, SEXP rho)
     UNPROTECT(2); /* args, ans */
     return ans;
 }
-
-#include <R_ext/Itermacros.h>
 
 // Check if x has missing values; the anyNA.default() method
 static bool anyNA(SEXP call, SEXP op, SEXP args, SEXP env)

--- a/src/main/coerce.c
+++ b/src/main/coerce.c
@@ -452,6 +452,21 @@ static SEXP coerceToSymbol(SEXP v)
     return ans;
 }
 
+/* Every coercion branch below has the same shape: run an element
+   converter over the source, a region at a time.  Reading through the
+   element-at-a-time accessors instead costs a dispatch per element for
+   an ALTREP source, and for any source a per-element branch on the
+   header that the compiler cannot hoist past the writes to the answer,
+   which is enough to stop the loop vectorising.
+
+   A RAWSXP source relies on Rbyte widening to int in the call, as it
+   did through the explicit cast this replaced. */
+#define COERCE_BY_REGION(v, pa, etype, vtype, CONV)			\
+    ITERATE_BY_REGION(v, cbr_p, cbr_i, cbr_n, etype, vtype, {		\
+	    for (R_xlen_t k = 0; k < cbr_n; k++)			\
+		pa[cbr_i + k] = CONV(cbr_p[k], &warn);			\
+	})
+
 static SEXP coerceToLogical(SEXP v)
 {
     SEXP ans;
@@ -468,22 +483,13 @@ static SEXP coerceToLogical(SEXP v)
     SHALLOW_DUPLICATE_ATTRIB(ans, v);
     switch (TYPEOF(v)) {
     case INTSXP:
-	for (i = 0; i < n; i++) {
-//	    if ((i+1) % NINTERRUPT == 0) R_CheckUserInterrupt();
-	    pa[i] = LogicalFromInteger(INTEGER_ELT(v, i), &warn);
-	}
+	COERCE_BY_REGION(v, pa, int, INTEGER, LogicalFromInteger);
 	break;
     case REALSXP:
-	for (i = 0; i < n; i++) {
-//	    if ((i+1) % NINTERRUPT == 0) R_CheckUserInterrupt();
-	    pa[i] = LogicalFromReal(REAL_ELT(v, i), &warn);
-	}
+	COERCE_BY_REGION(v, pa, double, REAL, LogicalFromReal);
 	break;
     case CPLXSXP:
-	for (i = 0; i < n; i++) {
-//	    if ((i+1) % NINTERRUPT == 0) R_CheckUserInterrupt();
-	    pa[i] = LogicalFromComplex(COMPLEX_ELT(v, i), &warn);
-	}
+	COERCE_BY_REGION(v, pa, Rcomplex, COMPLEX, LogicalFromComplex);
 	break;
     case STRSXP:
 	for (i = 0; i < n; i++) {
@@ -492,10 +498,7 @@ static SEXP coerceToLogical(SEXP v)
 	}
 	break;
     case RAWSXP:
-	for (i = 0; i < n; i++) {
-//	    if ((i+1) % NINTERRUPT == 0) R_CheckUserInterrupt();
-	    pa[i] = LogicalFromInteger((int)RAW_ELT(v, i), &warn);
-	}
+	COERCE_BY_REGION(v, pa, Rbyte, RAW, LogicalFromInteger);
 	break;
     default:
 	UNIMPLEMENTED_TYPE("coerceToLogical", v);
@@ -521,22 +524,13 @@ static SEXP coerceToInteger(SEXP v)
     SHALLOW_DUPLICATE_ATTRIB(ans, v);
     switch (TYPEOF(v)) {
     case LGLSXP:
-	for (i = 0; i < n; i++) {
-//	    if ((i+1) % NINTERRUPT == 0) R_CheckUserInterrupt();
-	    pa[i] = IntegerFromLogical(LOGICAL_ELT(v, i), &warn);
-	}
+	COERCE_BY_REGION(v, pa, int, LOGICAL, IntegerFromLogical);
 	break;
     case REALSXP:
-	for (i = 0; i < n; i++) {
-//	    if ((i+1) % NINTERRUPT == 0) R_CheckUserInterrupt();
-	    pa[i] = IntegerFromReal(REAL_ELT(v, i), &warn);
-	}
+	COERCE_BY_REGION(v, pa, double, REAL, IntegerFromReal);
 	break;
     case CPLXSXP:
-	for (i = 0; i < n; i++) {
-//	    if ((i+1) % NINTERRUPT == 0) R_CheckUserInterrupt();
-	    pa[i] = IntegerFromComplex(COMPLEX_ELT(v, i), &warn);
-	}
+	COERCE_BY_REGION(v, pa, Rcomplex, COMPLEX, IntegerFromComplex);
 	break;
     case STRSXP:
 	for (i = 0; i < n; i++) {
@@ -574,22 +568,13 @@ static SEXP coerceToReal(SEXP v)
     SHALLOW_DUPLICATE_ATTRIB(ans, v);
     switch (TYPEOF(v)) {
     case LGLSXP:
-	for (i = 0; i < n; i++) {
-//	    if ((i+1) % NINTERRUPT == 0) R_CheckUserInterrupt();
-	    pa[i] = RealFromLogical(LOGICAL_ELT(v, i), &warn);
-	}
+	COERCE_BY_REGION(v, pa, int, LOGICAL, RealFromLogical);
 	break;
     case INTSXP:
-	for (i = 0; i < n; i++) {
-//	    if ((i+1) % NINTERRUPT == 0) R_CheckUserInterrupt();
-	    pa[i] = RealFromInteger(INTEGER_ELT(v, i), &warn);
-	}
+	COERCE_BY_REGION(v, pa, int, INTEGER, RealFromInteger);
 	break;
     case CPLXSXP:
-	for (i = 0; i < n; i++) {
-//	    if ((i+1) % NINTERRUPT == 0) R_CheckUserInterrupt();
-	    pa[i] = RealFromComplex(COMPLEX_ELT(v, i), &warn);
-	}
+	COERCE_BY_REGION(v, pa, Rcomplex, COMPLEX, RealFromComplex);
 	break;
     case STRSXP:
 	for (i = 0; i < n; i++) {
@@ -598,10 +583,7 @@ static SEXP coerceToReal(SEXP v)
 	}
 	break;
     case RAWSXP:
-	for (i = 0; i < n; i++) {
-//	    if ((i+1) % NINTERRUPT == 0) R_CheckUserInterrupt();
-	    pa[i] = RealFromInteger((int)RAW_ELT(v, i), &warn);
-	}
+	COERCE_BY_REGION(v, pa, Rbyte, RAW, RealFromInteger);
 	break;
     default:
 	UNIMPLEMENTED_TYPE("coerceToReal", v);
@@ -633,16 +615,10 @@ static SEXP coerceToComplex(SEXP v)
 	}
 	break;
     case INTSXP:
-	for (i = 0; i < n; i++) {
-//	    if ((i+1) % NINTERRUPT == 0) R_CheckUserInterrupt();
-	    pa[i] = ComplexFromInteger(INTEGER_ELT(v, i), &warn);
-	}
+	COERCE_BY_REGION(v, pa, int, INTEGER, ComplexFromInteger);
 	break;
     case REALSXP:
-	for (i = 0; i < n; i++) {
-//	    if ((i+1) % NINTERRUPT == 0) R_CheckUserInterrupt();
-	    pa[i] = ComplexFromReal(REAL_ELT(v, i), &warn);
-	}
+	COERCE_BY_REGION(v, pa, double, REAL, ComplexFromReal);
 	break;
     case STRSXP:
 	for (i = 0; i < n; i++) {
@@ -651,10 +627,7 @@ static SEXP coerceToComplex(SEXP v)
 	}
 	break;
     case RAWSXP:
-	for (i = 0; i < n; i++) {
-//	    if ((i+1) % NINTERRUPT == 0) R_CheckUserInterrupt();
-	    pa[i] = ComplexFromInteger((int)RAW_ELT(v, i), &warn);
-	}
+	COERCE_BY_REGION(v, pa, Rbyte, RAW, ComplexFromInteger);
 	break;
     default:
 	UNIMPLEMENTED_TYPE("coerceToComplex", v);

--- a/tests/reg-tests-1e.R
+++ b/tests/reg-tests-1e.R
@@ -3745,6 +3745,27 @@ local({
 ## these loops used the element-at-a-time accessors too
 
 
+## anyNA() accumulates the NA test branchlessly over 1024-element
+## chunks and only branches between chunks, so the answer must not
+## depend on where an NA falls relative to a chunk boundary.  A
+## materialized vector is scanned as one region, so the chunking
+## itself is what these positions probe.
+local({
+    n <- 5000L
+    for(pos in c(1L, 1023L, 1024L, 1025L, 2048L, 4097L, n)) {
+        i <- rep.int(1L, n);    i[pos] <- NA; stopifnot(anyNA(i))
+        d <- rep.int(1,  n);    d[pos] <- NA; stopifnot(anyNA(d))
+        l <- rep.int(TRUE, n);  l[pos] <- NA; stopifnot(anyNA(l))
+        d[pos] <- NaN;                        stopifnot(anyNA(d))
+    }
+    stopifnot(!anyNA(rep.int(1L, n)), !anyNA(rep.int(1, n)),
+              !anyNA(rep.int(TRUE, n)), !anyNA(logical(0)),
+              !anyNA(seq_len(n)), !anyNA(as.numeric(seq_len(n))))
+})
+## the per-element early exit could not vectorise; LGLSXP also read
+## one element at a time
+
+
 
 ## keep at end
 rbind(last =  proc.time() - .pt,

--- a/tests/reg-tests-1e.R
+++ b/tests/reg-tests-1e.R
@@ -3715,6 +3715,36 @@ local({
 ## vector meant one dispatch per element
 
 
+## the coerceTo*() loops read their source a region at a time for the
+## same reason, so every conversion must agree with itself across the
+## 512-element region boundary and whether or not the source is ALTREP
+local({
+    n <- 2000L
+    mat <- function(x) x[seq_along(x)]        # force materialization
+    ii <- c(1L, 513L, 1025L, n)
+    ## the sources that matter are the ones with no data pointer, so
+    ## that they really are read in several batches: a materialized
+    ## vector is one region starting at 0 and hides an offset slip
+    src <- list(seq_len(n), as.numeric(seq_len(n)),
+                rep_len(c(TRUE, FALSE, NA), n),
+                { v <- mat(seq_len(n)); v[ii] <- NA; v },
+                { v <- as.numeric(seq_len(n)); v[ii] <- c(NA, NaN, Inf, -Inf); v },
+                complex(real = as.numeric(seq_len(n)), imaginary = 0),
+                as.raw(rep_len(0:255, n)))
+    to <- list(as.logical, as.integer, as.numeric, as.complex, as.character)
+    for(v in src) for(f in to) {
+        a <- suppressWarnings(f(v))
+        b <- suppressWarnings(f(mat(v)))
+        stopifnot(identical(a, b), length(a) == n)
+    }
+    ## and spelled out, in case both sides ever go wrong the same way
+    stopifnot(identical(suppressWarnings(as.integer(as.numeric(seq_len(n)))), seq_len(n)),
+              identical(as.numeric(mat(seq_len(n))), as.numeric(seq_len(n))),
+              all(as.logical(seq_len(n))))
+})
+## these loops used the element-at-a-time accessors too
+
+
 
 ## keep at end
 rbind(last =  proc.time() - .pt,

--- a/tests/reg-tests-1e.R
+++ b/tests/reg-tests-1e.R
@@ -3685,6 +3685,36 @@ sys.load.image(tf, FALSE); rm(tf, save)
 ## had called .Internal(RNGkind(..)) with wrong number of args
 
 
+## is.na() reads its argument a region at a time, as anyNA() does, so
+## the answer must not depend on whether the vector is ALTREP.  n must
+## exceed the 512-element region buffer, or an ALTREP vector is read in
+## a single batch starting at 0 and an offset slip cannot show up.
+local({
+    n <- 2000L
+    mat <- function(x) x[seq_along(x)]        # force materialization
+    ii <- c(1L, 513L, 1025L, n)               # spread across the batches
+    for(v in list(seq_len(n), as.numeric(seq_len(n)), as.character(seq_len(n)))) {
+        stopifnot(identical(is.na(v), is.na(mat(v))),
+                  identical(anyNA(v), anyNA(mat(v))),
+                  !any(is.na(v)))
+        w <- mat(v); w[ii] <- NA
+        stopifnot(identical(which(is.na(w)), ii), anyNA(w))
+        u <- v; u[ii] <- NA                   # still ALTREP-derived
+        stopifnot(identical(which(is.na(u)), ii))
+    }
+    ## NaN is missing for is.na() but not for is.nan(), and both must
+    ## survive the batching
+    d <- c(1, NA, NaN, Inf, -Inf, 0, -0)
+    stopifnot(identical(is.na (d), c(FALSE, TRUE,  TRUE, rep(FALSE, 4))),
+              identical(is.nan(d), c(FALSE, FALSE, TRUE, rep(FALSE, 4))),
+              identical(is.na(d[0]), logical(0)),
+              identical(is.na(complex(real = c(1, NaN, 1), imaginary = c(1, 1, NA))),
+                        c(FALSE, TRUE, TRUE)))
+})
+## is.na() used the element-at-a-time accessors, which for an ALTREP
+## vector meant one dispatch per element
+
+
 
 ## keep at end
 rbind(last =  proc.time() - .pt,


### PR DESCRIPTION
`is.na()` and the `coerceVector()` conversions read their argument through the element-at-a-time accessors, which inline to

```c
ALTREP(x) ? ALTREAL_ELT(x, i) : REAL0(x)[i]
```

For an ALTREP source that is a virtual dispatch per element. For *any* source it is a per-element branch on the object header that the compiler cannot hoist past the writes to the answer, which is enough to stop the loop vectorising.

`anyNA()` already reads by region. These now do too. A third commit then reshapes `anyNA()`'s own inner loop, which turned out to be the next bottleneck (see below).

## Why `is.na()` in particular

The `#include <R_ext/Itermacros.h>` sat *below* `do_isna()`, immediately above `anyNA()` — presumably added when `anyNA()` was. So `ITERATE_BY_REGION` was not in scope where `is.na()` is written. Moving the include to the top of the file is half the fix.

## Measurements

10^7 elements, one build, before -> after (macOS/arm64, clang):

| | before | after |
| --- | --- | --- |
| `is.na(1:n)` | 12.6 ms | **1.1 ms** |
| `is.na(<materialized integer>)` | 2.9 ms | **0.8 ms** |
| `is.na(as.numeric(1:n))` | 12.4 ms | **2.0 ms** |
| `is.na(<materialized double>)` | 2.9 ms | **1.3 ms** |
| `is.na(<logical>)` | 2.9 ms | **0.8 ms** |
| `is.na(<complex>)` | 2.9 ms | 2.7 ms |
| `as.numeric(integer)` | 4.4 ms | **1.4 ms** |
| `as.logical(integer)` | 3.9 ms | **0.9 ms** |
| `as.numeric(logical)` | 4.4 ms | **1.6 ms** |
| `as.logical(double)` | 3.3 ms | **1.6 ms** |
| `as.numeric(raw)` | 4.2 ms | **2.7 ms** |
| `as.complex(double)` | 3.4 ms | **2.3 ms** |
| `as.integer(double)` | 6.0 ms | **4.0 ms** |
| `as.numeric(complex)` | 5.0 ms | 5.0 ms |

The materialized cases improve as well, so this is not only about ALTREP. The two that do not move are already memory-bound at 16 bytes an element; `as.integer(double)` gains least because `IntegerFromReal`'s range checks dominate. Nothing measured got slower.

## The second commit

Fourteen loops across `coerceToLogical`/`Integer`/`Real`/`Complex` have the same form -- run an element converter over the source -- so they go through one `COERCE_BY_REGION` macro rather than fourteen copies of the same iteration. Net -56 lines.

`coerceToString` is left alone: there is no `STRING_GET_REGION`. `coerceToRaw` is left alone too: it does its range handling inline rather than calling a converter, so it does not fit the macro.

## The third commit: `anyNA()`

Prompted by Gabriel Becker's question on Bugzilla (PR#19141): with the first commit applied, `is.na()` over 10^7 integers takes 0.85 ms while `anyNA()` takes 2.6 ms, even though `anyNA()` allocates nothing. It is not dispatch -- `anyNA()` already reads by region -- it is the shape of the inner loop. `if (xI[k] == NA_INTEGER) return true;` is a data-dependent branch per element, so the compiler cannot vectorise past it. The commit accumulates the NA test branchlessly over 1024-element chunks and branches only between chunks: the inner loop vectorises again, and the early exit survives at chunk granularity (a bounded cost well under a microsecond).

10^7 elements, no NAs unless said otherwise:

| | before | after |
| --- | --- | --- |
| `anyNA(<integer>)` | 2.60 ms | **0.50 ms** |
| `anyNA(<integer>)`, NA at 100 | ~0 ms | ~0 ms |
| `anyNA(<double>)` | 2.55 ms | **1.00 ms** |
| `anyNA(<logical>)` | 3.35 ms | **0.55 ms** |

`anyNA()` is again at least as fast as `is.na()` everywhere. Three adjacent things fixed in passing: the `LGLSXP` arm read `LOGICAL_ELT()` an element at a time, so it now uses region iteration like the others; it gains the `LOGICAL_NO_NA()` short-circuit the `INTSXP` and `REALSXP` arms already had (an O(1) ALTREP metadata query, constant false for ordinary vectors); and the induction variable becomes `R_xlen_t`, since on the `DATAPTR` path `nbatch` is the full vector length and `int` overflows past 2^31 elements. `CPLXSXP` and `STRSXP` are left alone (complex is memory-bound at 16 bytes an element, and there is no `STRING_GET_REGION`).

The test note below inverts for `anyNA()`: the interesting boundary is the 1024-element chunk, not the 512-element region, and on the `DATAPTR` path the whole vector is one region -- so here *materialized* vectors are exactly what probes the chunk arithmetic. The new block places NAs at positions 1, 1023, 1024, 1025, 2048, 4097 and n. Also checked: empty vectors, NaN vs NA for doubles, recursive lists, and an ALTREP logical wrapper with the no-NA metadata bit set (verified O(1)). `reg-tests-1e.R` passes end to end after the change.

## Tests, and a trap worth knowing about

Both changes are behaviour-preserving, so the additions to `reg-tests-1e.R` are guards rather than reproducers. Two things about how they are written:

**The source must have no data pointer, and must be longer than 512.** `GET_REGION_BUFSIZE` is 512, and a materialized vector takes the `DATAPTR_OR_NULL` path -- a single region starting at index 0. A test using materialized vectors therefore cannot see a dropped batch offset. I wrote both tests that way first, and both passed against a deliberately broken build before I checked.

**The conversion has to actually reach the loop.** `as.numeric(seq_len(n))` short-circuits to a compact realseq without entering `coerceToReal` at all, so the tests use conversions that do enter it (`as.integer(as.numeric(seq_len(n)))`, `as.logical(seq_len(n))`).

Both tests were then verified to fail when the region offset is dropped from the write.

## Checked

`make test-Reg` (22/22) and `make test-Examples` for base, tools, utils, grDevices, graphics, stats, datasets, methods, grid, splines and stats4. `tcltk` fails on this machine for an unrelated reason (x86_64 Tk against an arm64 build) and fails identically on an unmodified checkout.

## Related, not included

While looking at this I measured `ISNA()`, which is 6x more expensive than the same test written inline (9.3 ms vs 1.5 ms over 10^7 doubles; `ISNAN()` is 1.1 ms because it inlines to `isnan()`). `R_IsNA` is an exported out-of-line function, so a package cannot inline it. Giving `ISNA` an inline definition in the header while keeping the function exported for ABI would close that, but it touches an installed header and is a separate discussion.

One thing that looked optimizable and is not: `R_NaN_is_R_NA()` checks only the low word against 1954, which reads like an oversight but is load-bearing. `NA_real_` is `7ff00000000007a2`, and `NA_real_ + 1` is `7ff80000000007a2` -- the FPU sets the quiet bit, so only the payload survives arithmetic. Comparing the full 64-bit pattern, the obvious speedup, would make `NA + 1` stop being `NA`.

