### PR TITLE
Use wide Windows APIs for locale handling

### DIFF
--- a/src/main/platform.c
+++ b/src/main/platform.c
@@ -2188,10 +2188,38 @@ attribute_hidden SEXP do_unlink(SEXP call, SEXP op, SEXP args, SEXP env)
 }
 #endif
 
+#ifdef Win32
+typedef wchar_t locale_char_t;
+# define SET_LOCALE _wsetlocale
+# define LOCALE_ARG wtransChar
+# define LOCALE_IS_C(x) (!wcscmp((x), L"C"))
+
+static SEXP locale_mkString(const locale_char_t *locale)
+{
+    if (!locale)
+	return mkString("");
+    if (utf8locale)
+	return ScalarString(mkCharWUTF8(locale));
+
+    size_t n = wcstombs(NULL, locale, 0);
+    if (n == (size_t)-1)
+	return ScalarString(mkCharWUTF8(locale));
+    char *res = R_alloc(n + 1, 1);
+    if (wcstombs(res, locale, n + 1) == (size_t)-1)
+	return ScalarString(mkCharWUTF8(locale));
+    return ScalarString(mkChar(res));
+}
+#else
+typedef char locale_char_t;
+# define SET_LOCALE setlocale
+# define LOCALE_ARG CHAR
+# define LOCALE_IS_C(x) (!strcmp((x), "C"))
+#endif
+
 attribute_hidden SEXP do_getlocale(SEXP call, SEXP op, SEXP args, SEXP rho)
 {
     int cat;
-    char *p = NULL;
+    const locale_char_t *p = NULL;
 
     checkArity(op, args);
     cat = asInteger(CAR(args));
@@ -2217,16 +2245,22 @@ attribute_hidden SEXP do_getlocale(SEXP call, SEXP op, SEXP args, SEXP rho)
 #endif
     default: cat = NA_INTEGER;
     }
-    if (cat != NA_INTEGER) p = setlocale(cat, NULL);
+    if (cat != NA_INTEGER) p = SET_LOCALE(cat, NULL);
+#ifdef Win32
+    return locale_mkString(p);
+#else
     return mkString(p ? p : "");
+#endif
 }
 
-/* Locale specs are always ASCII */
 attribute_hidden SEXP do_setlocale(SEXP call, SEXP op, SEXP args, SEXP rho)
 {
     SEXP locale = CADR(args), ans;
     int cat;
-    const char *p;
+    const locale_char_t *p, *l;
+#ifdef Win32
+    locale_char_t *locale_result = NULL;
+#endif
     bool warned = FALSE;
 
     checkArity(op, args);
@@ -2235,56 +2269,54 @@ attribute_hidden SEXP do_setlocale(SEXP call, SEXP op, SEXP args, SEXP rho)
 	error(_("invalid '%s' argument"), "category");
     if (!isString(locale) || LENGTH(locale) != 1)
 	error(_("invalid '%s' argument"), "locale");
+    l = (cat >= 1 && cat <= 6) ? LOCALE_ARG(STRING_ELT(locale, 0)) : NULL;
     switch(cat) {
     case 1:
     {
-	const char *l = CHAR(STRING_ELT(locale, 0));
 	cat = LC_ALL;
 	/* assume we can set LC_CTYPE iff we can set the rest */
-	if ((p = setlocale(LC_CTYPE, l))) {
-	    setlocale(LC_COLLATE, l);
+	if ((p = SET_LOCALE(LC_CTYPE, l))) {
+	    SET_LOCALE(LC_COLLATE, l);
 	    /* disable the collator when setting to C to take
 	       precedence over R_ICU_LOCALE */
-	    resetICUcollator(!strcmp(l, "C"));
-	    setlocale(LC_MONETARY, l);
-	    setlocale(LC_TIME, l);
+	    resetICUcollator(LOCALE_IS_C(l));
+	    SET_LOCALE(LC_MONETARY, l);
+	    SET_LOCALE(LC_TIME, l);
 	    dt_invalidate_locale();
 	    /* Need to return value of LC_ALL */
-	    p = setlocale(cat, NULL);
+	    p = SET_LOCALE(cat, NULL);
 	}
 	break;
     }
     case 2:
     {
-	const char *l = CHAR(STRING_ELT(locale, 0));
 	cat = LC_COLLATE;
-	p = setlocale(cat, l);
+	p = SET_LOCALE(cat, l);
 	/* disable the collator when setting to C to take
 	   precedence over R_ICU_LOCALE */
-	resetICUcollator(!strcmp(l, "C"));
+	resetICUcollator(LOCALE_IS_C(l));
 	break;
     }
     case 3:
 	cat = LC_CTYPE;
-	p = setlocale(cat, CHAR(STRING_ELT(locale, 0)));
+	p = SET_LOCALE(cat, l);
 	break;
     case 4:
 	cat = LC_MONETARY;
-	p = setlocale(cat, CHAR(STRING_ELT(locale, 0)));
+	p = SET_LOCALE(cat, l);
 	break;
     case 5:
 	cat = LC_NUMERIC;
 	{
-	    const char *new_lc_num = CHAR(STRING_ELT(locale, 0));
-	    if (strcmp(new_lc_num, "C")) /* do not complain about C locale - that's the only
-					    reliable way to restore sanity */
+	    if (!LOCALE_IS_C(l)) /* do not complain about C locale - that's the only
+				      reliable way to restore sanity */
 		warning(_("setting 'LC_NUMERIC' may cause R to function strangely"));
-	    p = setlocale(cat, new_lc_num);
+	    p = SET_LOCALE(cat, l);
 	}
 	break;
     case 6:
 	cat = LC_TIME;
-	p = setlocale(cat, CHAR(STRING_ELT(locale, 0)));
+	p = SET_LOCALE(cat, l);
 	dt_invalidate_locale();
 	break;
 #ifdef Win32
@@ -2322,6 +2354,14 @@ attribute_hidden SEXP do_setlocale(SEXP call, SEXP op, SEXP args, SEXP rho)
 	p = NULL; /* -Wall */
 	error(_("invalid '%s' argument"), "category");
     }
+#ifdef Win32
+    if (p) {
+	size_t n = wcslen(p) + 1;
+	locale_result = R_alloc(n, sizeof(locale_char_t));
+	memcpy(locale_result, p, n * sizeof(locale_char_t));
+    }
+    int oldCP = localeCP;
+#else
     PROTECT(ans = allocVector(STRSXP, 1));
     if (p) SET_STRING_ELT(ans, 0, mkChar(p));
     else  {
@@ -2330,8 +2370,6 @@ attribute_hidden SEXP do_setlocale(SEXP call, SEXP op, SEXP args, SEXP rho)
 	    warning(_("OS reports request to set locale to \"%s\" cannot be honored"),
 	            CHAR(STRING_ELT(locale, 0)));
     }
-#ifdef Win32
-    int oldCP = localeCP;
 #endif
     R_check_locale();
 #ifdef Win32
@@ -2343,9 +2381,20 @@ attribute_hidden SEXP do_setlocale(SEXP call, SEXP op, SEXP args, SEXP rho)
     }
 #endif
     invalidate_cached_recodings();
+
+#ifdef Win32
+    PROTECT(ans = locale_mkString(locale_result));
+    if (!locale_result && !warned)
+	warning(_("OS reports request to set locale to \"%s\" cannot be honored"),
+		CHAR(STRING_ELT(locale, 0)));
+#endif
     UNPROTECT(1);
     return ans;
 }
+
+#undef SET_LOCALE
+#undef LOCALE_ARG
+#undef LOCALE_IS_C
 
 
 

--- a/tests/reg-encodings.R
+++ b/tests/reg-encodings.R
@@ -429,6 +429,35 @@ if(!is.null(lc <- lcct) && nzchar(lc)) Sys.setlocale("LC_CTYPE", lc) # revert
 ## <chars>(a1)[3:4] were different in R <= 4.6.0
 
 
+## Sys.[gs]etlocale() handle non-ASCII locale names and their encoding
+if(onWindows && UTF8) local({
+    old <- c(ctype = Sys.getlocale("LC_CTYPE"),
+	     time = Sys.getlocale("LC_TIME"))
+    on.exit({
+	invisible(Sys.setlocale("LC_CTYPE", old[["ctype"]]))
+	invisible(Sys.setlocale("LC_TIME", old[["time"]]))
+    })
+
+    ## UCRT may expand this ASCII alias to a name containing "Bokm\u00e5l".
+    setloc <- suppressWarnings(Sys.setlocale("LC_TIME", "Norwegian_Norway.UTF-8"))
+    if(nzchar(setloc) && any(as.integer(charToRaw(setloc)) > 127L)) {
+	getloc <- Sys.getlocale("LC_TIME")
+	stopifnot(identical(Encoding(getloc), "UTF-8"),
+		  identical(Encoding(setloc), "UTF-8"))
+
+	## A declared UTF-8 locale name is converted to UTF-16 before the CRT
+	## sees it, even when the current native encoding is not UTF-8.
+	setloc <- enc2utf8(setloc)
+	invisible(Sys.setlocale("LC_CTYPE", "C"))
+	setloc2 <- suppressWarnings(Sys.setlocale("LC_TIME", setloc))
+	getloc2 <- Sys.getlocale("LC_TIME")
+	invisible(Sys.setlocale("LC_CTYPE", old[["ctype"]]))
+	stopifnot(nzchar(setloc2), identical(getloc2, setloc2),
+		  identical(Sys.getlocale("LC_TIME"), setloc))
+    }
+})
+
+
 
 
 ## PR#19112 -- writeChar() overflows its output buffer .. multibyte ..


### PR DESCRIPTION
## Summary

Windows UCRT locale names are not necessarily ASCII. Canonical names can contain non-ASCII text such as `Bokmål`, which makes the narrow `setlocale()` boundary fragile and can lose encoding information.

This change is limited to the implementations of `Sys.getlocale()` and `Sys.setlocale()`:

- use `_wsetlocale()` on Windows through a small platform adapter;
- convert R locale arguments to UTF-16 with `wtransChar()`, so declared UTF-8 strings are accepted even when the current native encoding is not UTF-8;
- copy the CRT-owned wide result before `R_check_locale()` can invalidate it;
- convert results after locale state has been refreshed, using the active native encoding and a lossless UTF-8 fallback.

The existing `R_check_locale()` implementation and Unix behavior are unchanged.

## Regression coverage

The Windows-only regression test uses the `Norwegian_Norway.UTF-8` alias when available. It checks that non-ASCII return values from both locale functions are marked as UTF-8, then temporarily switches `LC_CTYPE` to `C` and verifies that the explicitly UTF-8 locale name can still be passed to `Sys.setlocale()` and queried with `Sys.getlocale()`.

The test remains conditional because the locale and its canonical spelling depend on the Windows installation.

## Validation

- `src/main/platform.c` compiles locally with the same five pre-existing warnings as the baseline.
- `tests/reg-encodings.R` parses successfully.
- GitHub Windows and cross-platform builds exercise the platform-specific path.