### PR TITLE
Use wide Windows APIs for locale handling

### DIFF
--- a/doc/NEWS.Rd
+++ b/doc/NEWS.Rd
@@ -294,6 +294,17 @@
 
       \item Fix for \PR{19035} (piping \code{postscript()} output)
       thanks to \I{Jeroen Ooms} and \I{Ivan Krylov}.
+
+      \item \code{Sys.setlocale()} on Windows now passes the locale name
+      to the C runtime as UTF-16, so that a name containing non-ASCII
+      characters -- such as \code{"Norwegian Bokmål_Norway.utf8"} or
+      \code{"Turkish_Türkiye.utf8"}, the default names on recent Windows
+      versions -- can be set from any locale, including \code{"C"}.
+      Previously the name was passed as bytes to be interpreted in the
+      \emph{current} locale, so that, e.g., restoring a locale saved by
+      \code{Sys.getlocale()} after switching to \code{"C"} failed.  On
+      all platforms, \code{Sys.getlocale()} and \code{Sys.setlocale()}
+      now return non-ASCII locale names marked as \abbr{UTF-8}.
     }
   }
 }

--- a/src/library/base/man/locales.Rd
+++ b/src/library/base/man/locales.Rd
@@ -89,7 +89,8 @@ Sys.setlocale (category = "LC_ALL", locale = "")
   A character string of length one describing the locale in use (after
   setting for \code{Sys.setlocale}), or an empty character string if the
   current locale settings are invalid or \code{NULL} if locale
-  information is unavailable.
+  information is unavailable.  A locale name containing non-ASCII
+  characters (as some do on Windows) is returned encoded in UTF-8.
 
   For \code{category = "LC_ALL"} the details of the string are
   system-specific: it might be a single locale name or a set of locale

--- a/src/main/platform.c
+++ b/src/main/platform.c
@@ -2188,10 +2188,24 @@ attribute_hidden SEXP do_unlink(SEXP call, SEXP op, SEXP args, SEXP env)
 }
 #endif
 
+#ifdef Win32
+# define LOCALE_CHAR wchar_t
+# define SETLOCALE _wsetlocale
+# define LOCALE_ARG wtransChar
+# define LOCALE_IS_C(x) (!wcscmp((x), L"C"))
+# define LOCALE_MKCHAR mkCharWUTF8
+#else
+# define LOCALE_CHAR char
+# define SETLOCALE setlocale
+# define LOCALE_ARG CHAR
+# define LOCALE_IS_C(x) (!strcmp((x), "C"))
+# define LOCALE_MKCHAR mkChar
+#endif
+
 attribute_hidden SEXP do_getlocale(SEXP call, SEXP op, SEXP args, SEXP rho)
 {
     int cat;
-    char *p = NULL;
+    const LOCALE_CHAR *p = NULL;
 
     checkArity(op, args);
     cat = asInteger(CAR(args));
@@ -2217,16 +2231,21 @@ attribute_hidden SEXP do_getlocale(SEXP call, SEXP op, SEXP args, SEXP rho)
 #endif
     default: cat = NA_INTEGER;
     }
-    if (cat != NA_INTEGER) p = setlocale(cat, NULL);
-    return mkString(p ? p : "");
+    if (cat != NA_INTEGER) p = SETLOCALE(cat, NULL);
+#ifdef Win32
+    SEXP string = p ? LOCALE_MKCHAR(p) : mkChar("");
+#else
+    const char *utf8 = reEnc(p ? p : "", CE_NATIVE, CE_UTF8, 1);
+    SEXP string = mkCharCE(utf8, CE_UTF8);
+#endif
+    return ScalarString(string);
 }
 
-/* Locale specs are always ASCII */
 attribute_hidden SEXP do_setlocale(SEXP call, SEXP op, SEXP args, SEXP rho)
 {
     SEXP locale = CADR(args), ans;
     int cat;
-    const char *p;
+    const LOCALE_CHAR *p, *l;
     bool warned = FALSE;
 
     checkArity(op, args);
@@ -2235,56 +2254,54 @@ attribute_hidden SEXP do_setlocale(SEXP call, SEXP op, SEXP args, SEXP rho)
 	error(_("invalid '%s' argument"), "category");
     if (!isString(locale) || LENGTH(locale) != 1)
 	error(_("invalid '%s' argument"), "locale");
+    l = LOCALE_ARG(STRING_ELT(locale, 0));
     switch(cat) {
     case 1:
     {
-	const char *l = CHAR(STRING_ELT(locale, 0));
 	cat = LC_ALL;
 	/* assume we can set LC_CTYPE iff we can set the rest */
-	if ((p = setlocale(LC_CTYPE, l))) {
-	    setlocale(LC_COLLATE, l);
+	if ((p = SETLOCALE(LC_CTYPE, l))) {
+	    SETLOCALE(LC_COLLATE, l);
 	    /* disable the collator when setting to C to take
 	       precedence over R_ICU_LOCALE */
-	    resetICUcollator(!strcmp(l, "C"));
-	    setlocale(LC_MONETARY, l);
-	    setlocale(LC_TIME, l);
+	    resetICUcollator(LOCALE_IS_C(l));
+	    SETLOCALE(LC_MONETARY, l);
+	    SETLOCALE(LC_TIME, l);
 	    dt_invalidate_locale();
 	    /* Need to return value of LC_ALL */
-	    p = setlocale(cat, NULL);
+	    p = SETLOCALE(cat, NULL);
 	}
 	break;
     }
     case 2:
     {
-	const char *l = CHAR(STRING_ELT(locale, 0));
 	cat = LC_COLLATE;
-	p = setlocale(cat, l);
+	p = SETLOCALE(cat, l);
 	/* disable the collator when setting to C to take
 	   precedence over R_ICU_LOCALE */
-	resetICUcollator(!strcmp(l, "C"));
+	resetICUcollator(LOCALE_IS_C(l));
 	break;
     }
     case 3:
 	cat = LC_CTYPE;
-	p = setlocale(cat, CHAR(STRING_ELT(locale, 0)));
+	p = SETLOCALE(cat, l);
 	break;
     case 4:
 	cat = LC_MONETARY;
-	p = setlocale(cat, CHAR(STRING_ELT(locale, 0)));
+	p = SETLOCALE(cat, l);
 	break;
     case 5:
 	cat = LC_NUMERIC;
 	{
-	    const char *new_lc_num = CHAR(STRING_ELT(locale, 0));
-	    if (strcmp(new_lc_num, "C")) /* do not complain about C locale - that's the only
-					    reliable way to restore sanity */
+	    if (!LOCALE_IS_C(l)) /* do not complain about C locale - that's the only
+				    reliable way to restore sanity */
 		warning(_("setting 'LC_NUMERIC' may cause R to function strangely"));
-	    p = setlocale(cat, new_lc_num);
+	    p = SETLOCALE(cat, l);
 	}
 	break;
     case 6:
 	cat = LC_TIME;
-	p = setlocale(cat, CHAR(STRING_ELT(locale, 0)));
+	p = SETLOCALE(cat, l);
 	dt_invalidate_locale();
 	break;
 #ifdef Win32
@@ -2302,19 +2319,19 @@ attribute_hidden SEXP do_setlocale(SEXP call, SEXP op, SEXP args, SEXP rho)
 # ifdef LC_MESSAGES
     case 7:
 	cat = LC_MESSAGES;
-	p = setlocale(cat, CHAR(STRING_ELT(locale, 0)));
+	p = SETLOCALE(cat, l);
 	break;
 # endif
 # ifdef LC_PAPER
     case 8:
 	cat = LC_PAPER;
-	p = setlocale(cat, CHAR(STRING_ELT(locale, 0)));
+	p = SETLOCALE(cat, l);
 	break;
 # endif
 # ifdef	LC_MEASUREMENT
     case 9:
 	cat = LC_MEASUREMENT;
-	p = setlocale(cat, CHAR(STRING_ELT(locale, 0)));
+	p = SETLOCALE(cat, l);
 	break;
 # endif
 #endif
@@ -2323,7 +2340,7 @@ attribute_hidden SEXP do_setlocale(SEXP call, SEXP op, SEXP args, SEXP rho)
 	error(_("invalid '%s' argument"), "category");
     }
     PROTECT(ans = allocVector(STRSXP, 1));
-    if (p) SET_STRING_ELT(ans, 0, mkChar(p));
+    if (p) SET_STRING_ELT(ans, 0, LOCALE_MKCHAR(p));
     else  {
 	SET_STRING_ELT(ans, 0, mkChar(""));
 	if (!warned)
@@ -2346,6 +2363,12 @@ attribute_hidden SEXP do_setlocale(SEXP call, SEXP op, SEXP args, SEXP rho)
     UNPROTECT(1);
     return ans;
 }
+
+#undef LOCALE_CHAR
+#undef SETLOCALE
+#undef LOCALE_ARG
+#undef LOCALE_IS_C
+#undef LOCALE_MKCHAR
 
 
 

--- a/src/main/platform.c
+++ b/src/main/platform.c
@@ -2188,18 +2188,25 @@ attribute_hidden SEXP do_unlink(SEXP call, SEXP op, SEXP args, SEXP env)
 }
 #endif
 
+/* Locale names are passed to the C library in its native encoding (UTF-16
+   on Windows) and returned to R as UTF-8, so that a name obtained from
+   Sys.getlocale() can be given back to Sys.setlocale() whatever the
+   current locale is.  With narrow locale names, a name containing
+   non-ASCII characters (as the Norwegian Bokmal and Turkish locales do
+   on recent versions of Windows) could not be set again once the C
+   locale was in effect. */
 #ifdef Win32
 # define R_LOCALE_CHAR wchar_t
 # define R_SETLOCALE _wsetlocale
 # define R_LOCALE_ARG wtransChar
 # define R_LOCALE_IS_C(x) (!wcscmp((x), L"C"))
-# define R_LOCALE_MKCHAR mkCharWUTF8
+# define R_LOCALE_MKCHAR(x) mkCharWUTF8(x)
 #else
 # define R_LOCALE_CHAR char
 # define R_SETLOCALE setlocale
-# define R_LOCALE_ARG CHAR
+# define R_LOCALE_ARG translateChar
 # define R_LOCALE_IS_C(x) (!strcmp((x), "C"))
-# define R_LOCALE_MKCHAR mkChar
+# define R_LOCALE_MKCHAR(x) mkCharCE(reEnc((x), CE_NATIVE, CE_UTF8, 1), CE_UTF8)
 #endif
 
 attribute_hidden SEXP do_getlocale(SEXP call, SEXP op, SEXP args, SEXP rho)
@@ -2232,13 +2239,7 @@ attribute_hidden SEXP do_getlocale(SEXP call, SEXP op, SEXP args, SEXP rho)
     default: cat = NA_INTEGER;
     }
     if (cat != NA_INTEGER) p = R_SETLOCALE(cat, NULL);
-#ifdef Win32
-    SEXP string = p ? R_LOCALE_MKCHAR(p) : mkChar("");
-#else
-    const char *utf8 = reEnc(p ? p : "", CE_NATIVE, CE_UTF8, 1);
-    SEXP string = mkCharCE(utf8, CE_UTF8);
-#endif
-    return ScalarString(string);
+    return ScalarString(p ? R_LOCALE_MKCHAR(p) : mkChar(""));
 }
 
 attribute_hidden SEXP do_setlocale(SEXP call, SEXP op, SEXP args, SEXP rho)

--- a/src/main/platform.c
+++ b/src/main/platform.c
@@ -2189,23 +2189,23 @@ attribute_hidden SEXP do_unlink(SEXP call, SEXP op, SEXP args, SEXP env)
 #endif
 
 #ifdef Win32
-# define LOCALE_CHAR wchar_t
-# define SETLOCALE _wsetlocale
-# define LOCALE_ARG wtransChar
-# define LOCALE_IS_C(x) (!wcscmp((x), L"C"))
-# define LOCALE_MKCHAR mkCharWUTF8
+# define R_LOCALE_CHAR wchar_t
+# define R_SETLOCALE _wsetlocale
+# define R_LOCALE_ARG wtransChar
+# define R_LOCALE_IS_C(x) (!wcscmp((x), L"C"))
+# define R_LOCALE_MKCHAR mkCharWUTF8
 #else
-# define LOCALE_CHAR char
-# define SETLOCALE setlocale
-# define LOCALE_ARG CHAR
-# define LOCALE_IS_C(x) (!strcmp((x), "C"))
-# define LOCALE_MKCHAR mkChar
+# define R_LOCALE_CHAR char
+# define R_SETLOCALE setlocale
+# define R_LOCALE_ARG CHAR
+# define R_LOCALE_IS_C(x) (!strcmp((x), "C"))
+# define R_LOCALE_MKCHAR mkChar
 #endif
 
 attribute_hidden SEXP do_getlocale(SEXP call, SEXP op, SEXP args, SEXP rho)
 {
     int cat;
-    const LOCALE_CHAR *p = NULL;
+    const R_LOCALE_CHAR *p = NULL;
 
     checkArity(op, args);
     cat = asInteger(CAR(args));
@@ -2231,9 +2231,9 @@ attribute_hidden SEXP do_getlocale(SEXP call, SEXP op, SEXP args, SEXP rho)
 #endif
     default: cat = NA_INTEGER;
     }
-    if (cat != NA_INTEGER) p = SETLOCALE(cat, NULL);
+    if (cat != NA_INTEGER) p = R_SETLOCALE(cat, NULL);
 #ifdef Win32
-    SEXP string = p ? LOCALE_MKCHAR(p) : mkChar("");
+    SEXP string = p ? R_LOCALE_MKCHAR(p) : mkChar("");
 #else
     const char *utf8 = reEnc(p ? p : "", CE_NATIVE, CE_UTF8, 1);
     SEXP string = mkCharCE(utf8, CE_UTF8);
@@ -2245,7 +2245,7 @@ attribute_hidden SEXP do_setlocale(SEXP call, SEXP op, SEXP args, SEXP rho)
 {
     SEXP locale = CADR(args), ans;
     int cat;
-    const LOCALE_CHAR *p, *l;
+    const R_LOCALE_CHAR *p, *l;
     bool warned = FALSE;
 
     checkArity(op, args);
@@ -2254,54 +2254,54 @@ attribute_hidden SEXP do_setlocale(SEXP call, SEXP op, SEXP args, SEXP rho)
 	error(_("invalid '%s' argument"), "category");
     if (!isString(locale) || LENGTH(locale) != 1)
 	error(_("invalid '%s' argument"), "locale");
-    l = LOCALE_ARG(STRING_ELT(locale, 0));
+    l = R_LOCALE_ARG(STRING_ELT(locale, 0));
     switch(cat) {
     case 1:
     {
 	cat = LC_ALL;
 	/* assume we can set LC_CTYPE iff we can set the rest */
-	if ((p = SETLOCALE(LC_CTYPE, l))) {
-	    SETLOCALE(LC_COLLATE, l);
+	if ((p = R_SETLOCALE(LC_CTYPE, l))) {
+	    R_SETLOCALE(LC_COLLATE, l);
 	    /* disable the collator when setting to C to take
 	       precedence over R_ICU_LOCALE */
-	    resetICUcollator(LOCALE_IS_C(l));
-	    SETLOCALE(LC_MONETARY, l);
-	    SETLOCALE(LC_TIME, l);
+	    resetICUcollator(R_LOCALE_IS_C(l));
+	    R_SETLOCALE(LC_MONETARY, l);
+	    R_SETLOCALE(LC_TIME, l);
 	    dt_invalidate_locale();
 	    /* Need to return value of LC_ALL */
-	    p = SETLOCALE(cat, NULL);
+	    p = R_SETLOCALE(cat, NULL);
 	}
 	break;
     }
     case 2:
     {
 	cat = LC_COLLATE;
-	p = SETLOCALE(cat, l);
+	p = R_SETLOCALE(cat, l);
 	/* disable the collator when setting to C to take
 	   precedence over R_ICU_LOCALE */
-	resetICUcollator(LOCALE_IS_C(l));
+	resetICUcollator(R_LOCALE_IS_C(l));
 	break;
     }
     case 3:
 	cat = LC_CTYPE;
-	p = SETLOCALE(cat, l);
+	p = R_SETLOCALE(cat, l);
 	break;
     case 4:
 	cat = LC_MONETARY;
-	p = SETLOCALE(cat, l);
+	p = R_SETLOCALE(cat, l);
 	break;
     case 5:
 	cat = LC_NUMERIC;
 	{
-	    if (!LOCALE_IS_C(l)) /* do not complain about C locale - that's the only
+	    if (!R_LOCALE_IS_C(l)) /* do not complain about C locale - that's the only
 				    reliable way to restore sanity */
 		warning(_("setting 'LC_NUMERIC' may cause R to function strangely"));
-	    p = SETLOCALE(cat, l);
+	    p = R_SETLOCALE(cat, l);
 	}
 	break;
     case 6:
 	cat = LC_TIME;
-	p = SETLOCALE(cat, l);
+	p = R_SETLOCALE(cat, l);
 	dt_invalidate_locale();
 	break;
 #ifdef Win32
@@ -2319,19 +2319,19 @@ attribute_hidden SEXP do_setlocale(SEXP call, SEXP op, SEXP args, SEXP rho)
 # ifdef LC_MESSAGES
     case 7:
 	cat = LC_MESSAGES;
-	p = SETLOCALE(cat, l);
+	p = R_SETLOCALE(cat, l);
 	break;
 # endif
 # ifdef LC_PAPER
     case 8:
 	cat = LC_PAPER;
-	p = SETLOCALE(cat, l);
+	p = R_SETLOCALE(cat, l);
 	break;
 # endif
 # ifdef	LC_MEASUREMENT
     case 9:
 	cat = LC_MEASUREMENT;
-	p = SETLOCALE(cat, l);
+	p = R_SETLOCALE(cat, l);
 	break;
 # endif
 #endif
@@ -2340,7 +2340,7 @@ attribute_hidden SEXP do_setlocale(SEXP call, SEXP op, SEXP args, SEXP rho)
 	error(_("invalid '%s' argument"), "category");
     }
     PROTECT(ans = allocVector(STRSXP, 1));
-    if (p) SET_STRING_ELT(ans, 0, LOCALE_MKCHAR(p));
+    if (p) SET_STRING_ELT(ans, 0, R_LOCALE_MKCHAR(p));
     else  {
 	SET_STRING_ELT(ans, 0, mkChar(""));
 	if (!warned)
@@ -2364,11 +2364,11 @@ attribute_hidden SEXP do_setlocale(SEXP call, SEXP op, SEXP args, SEXP rho)
     return ans;
 }
 
-#undef LOCALE_CHAR
-#undef SETLOCALE
-#undef LOCALE_ARG
-#undef LOCALE_IS_C
-#undef LOCALE_MKCHAR
+#undef R_LOCALE_CHAR
+#undef R_SETLOCALE
+#undef R_LOCALE_ARG
+#undef R_LOCALE_IS_C
+#undef R_LOCALE_MKCHAR
 
 
 

--- a/tests/reg-encodings.R
+++ b/tests/reg-encodings.R
@@ -429,6 +429,35 @@ if(!is.null(lc <- lcct) && nzchar(lc)) Sys.setlocale("LC_CTYPE", lc) # revert
 ## <chars>(a1)[3:4] were different in R <= 4.6.0
 
 
+## Sys.[gs]etlocale() handle non-ASCII locale names and their encoding
+if(onWindows && UTF8) local({
+    old <- c(ctype = Sys.getlocale("LC_CTYPE"),
+	     time = Sys.getlocale("LC_TIME"))
+    on.exit({
+	invisible(Sys.setlocale("LC_CTYPE", old[["ctype"]]))
+	invisible(Sys.setlocale("LC_TIME", old[["time"]]))
+    })
+
+    ## UCRT may expand this ASCII alias to a name containing "Bokm\u00e5l".
+    setloc <- suppressWarnings(Sys.setlocale("LC_TIME", "Norwegian_Norway.UTF-8"))
+    if(nzchar(setloc) && any(as.integer(charToRaw(setloc)) > 127L)) {
+	getloc <- Sys.getlocale("LC_TIME")
+	stopifnot(identical(Encoding(getloc), "UTF-8"),
+		  identical(Encoding(setloc), "UTF-8"))
+
+	## A declared UTF-8 locale name is converted to UTF-16 before the CRT
+	## sees it, even when the current native encoding is not UTF-8.
+	setloc <- enc2utf8(setloc)
+	invisible(Sys.setlocale("LC_CTYPE", "C"))
+	setloc2 <- suppressWarnings(Sys.setlocale("LC_TIME", setloc))
+	getloc2 <- Sys.getlocale("LC_TIME")
+	invisible(Sys.setlocale("LC_CTYPE", old[["ctype"]]))
+	stopifnot(nzchar(setloc2), identical(getloc2, setloc2),
+		  identical(Sys.getlocale("LC_TIME"), setloc))
+    }
+})
+
+
 
 
 ## PR#19112 -- writeChar() overflows its output buffer .. multibyte ..

--- a/tests/reg-encodings.R
+++ b/tests/reg-encodings.R
@@ -438,18 +438,17 @@ if(onWindows && UTF8) local({
 	invisible(Sys.setlocale("LC_TIME", old[["time"]]))
     })
 
-    ## UCRT may expand this ASCII alias to a name containing "Bokm\u00e5l".
-    setloc <- suppressWarnings(Sys.setlocale("LC_TIME", "Norwegian_Norway.UTF-8"))
-    if(nzchar(setloc) && any(as.integer(charToRaw(setloc)) > 127L)) {
+    locale <- enc2utf8("Norwegian Bokm\u00e5l_Norway.utf8")
+    setloc <- suppressWarnings(Sys.setlocale("LC_TIME", locale))
+    if(nzchar(setloc)) {
 	getloc <- Sys.getlocale("LC_TIME")
 	stopifnot(identical(Encoding(getloc), "UTF-8"),
 		  identical(Encoding(setloc), "UTF-8"))
 
 	## A declared UTF-8 locale name is converted to UTF-16 before the CRT
 	## sees it, even when the current native encoding is not UTF-8.
-	setloc <- enc2utf8(setloc)
 	invisible(Sys.setlocale("LC_CTYPE", "C"))
-	setloc2 <- suppressWarnings(Sys.setlocale("LC_TIME", setloc))
+	setloc2 <- suppressWarnings(Sys.setlocale("LC_TIME", locale))
 	getloc2 <- Sys.getlocale("LC_TIME")
 	invisible(Sys.setlocale("LC_CTYPE", old[["ctype"]]))
 	stopifnot(nzchar(setloc2), identical(getloc2, setloc2),

--- a/tests/reg-encodings.R
+++ b/tests/reg-encodings.R
@@ -430,13 +430,11 @@ if(!is.null(lc <- lcct) && nzchar(lc)) Sys.setlocale("LC_CTYPE", lc) # revert
 
 
 ## Sys.[gs]etlocale() handle non-ASCII locale names and their encoding
-if(onWindows && UTF8) local({
-    old <- c(ctype = Sys.getlocale("LC_CTYPE"),
-	     time = Sys.getlocale("LC_TIME"))
-    on.exit({
-	invisible(Sys.setlocale("LC_CTYPE", old[["ctype"]]))
-	invisible(Sys.setlocale("LC_TIME", old[["time"]]))
-    })
+if(onWindows) local({
+    cats <- c("LC_COLLATE", "LC_CTYPE", "LC_MONETARY", "LC_TIME")
+    old <- vapply(cats, Sys.getlocale, "")
+    on.exit(for(category in cats)
+	invisible(Sys.setlocale(category, old[[category]])))
 
     locale <- enc2utf8("Norwegian Bokm\u00e5l_Norway.utf8")
     setloc <- suppressWarnings(Sys.setlocale("LC_TIME", locale))
@@ -450,8 +448,17 @@ if(onWindows && UTF8) local({
 	invisible(Sys.setlocale("LC_CTYPE", "C"))
 	setloc2 <- suppressWarnings(Sys.setlocale("LC_TIME", locale))
 	getloc2 <- Sys.getlocale("LC_TIME")
-	invisible(Sys.setlocale("LC_CTYPE", old[["ctype"]]))
+	invisible(Sys.setlocale("LC_CTYPE", old[["LC_CTYPE"]]))
 	stopifnot(nzchar(setloc2), identical(getloc2, setloc2),
+		  identical(Sys.getlocale("LC_TIME"), setloc))
+
+	## "LC_ALL" sets each category from the one name and reports the
+	## resulting compound locale, again from the C locale.
+	invisible(Sys.setlocale("LC_CTYPE", "C"))
+	setall <- suppressWarnings(Sys.setlocale("LC_ALL", locale))
+	stopifnot(nzchar(setall), identical(Encoding(setall), "UTF-8"),
+		  identical(Sys.getlocale("LC_CTYPE"), setloc),
+		  identical(Sys.getlocale("LC_COLLATE"), setloc),
 		  identical(Sys.getlocale("LC_TIME"), setloc))
     }
 })


### PR DESCRIPTION
## Summary

- Use `_wsetlocale()` for `Sys.getlocale()` and `Sys.setlocale()` on Windows.
- Translate the R locale argument to UTF-16 once with `wtransChar()` and reuse it across locale categories.
- Return `Sys.getlocale()` results as UTF-8 on every platform, converting native locale names with `reEnc()` outside Windows.
- Keep the implementation localized to `src/main/platform.c` through small `R_`-prefixed platform macros.

This supersedes #311, which retained the narrow Windows locale APIs.

## Regression coverage

The Windows-only regression test directly uses the canonical `Norwegian Bokmål_Norway.utf8` locale name, spelling the non-ASCII character as `\u00e5` in the source. It verifies that both locale APIs return UTF-8 strings, then switches `LC_CTYPE` to `C` and confirms that the declared UTF-8 locale name can still be passed through `Sys.setlocale()` and read back unchanged.

The checks remain conditional because locale availability depends on the Windows installation.

## Validation

- `git diff --check`
- Compiled `src/main/platform.c` successfully in a freshly configured out-of-tree macOS build (`make -C src/main platform.o`).
- Parsed and ran `tests/reg-encodings.R` successfully on macOS; the Windows-only regression block is skipped there.

## Follow-up

A further commit addresses review findings:

- On POSIX, `R_LOCALE_ARG` was `CHAR`, so with `Sys.getlocale()` now returning UTF-8 a non-ASCII name would no longer round-trip through `Sys.setlocale()` in a non-UTF-8 locale. It is now `translateChar()`, the counterpart of `wtransChar()`; both return either the CHARSXP's own data or `R_alloc()`ed memory, which is what makes hoisting the translated name above the `switch` safe.
- `R_LOCALE_MKCHAR` performs the native-to-UTF-8 conversion on POSIX, so `Sys.setlocale()` returns the same encoding as `Sys.getlocale()` there too, and `do_getlocale()` loses its remaining `#ifdef Win32`. ASCII names are unaffected: `mkCharLenCE()` does not mark them, so `Encoding()` still reports `"unknown"` for them.
- The regression test runs in every Windows session, not only UTF-8 ones -- a non-UTF-8 session with a `.utf8` locale name is the case the UTF-16 conversion helps most -- and now also covers `"LC_ALL"`, the one branch with its own sequence of category calls and a re-read of the compound result.
- NEWS entry, and a sentence in `?Sys.getlocale` on the UTF-8 return value.

Validated on macOS against a full build of the branch: `tests/reg-encodings.R` passes, and `Sys.setlocale(cat, Sys.getlocale(cat))` round-trips for every category, with ASCII names returned unmarked as before. The Windows block still relies on CI.
