### PR TITLE
Detect binary package format by magic bytes when unpacking

### DIFF
--- a/src/library/utils/R/install.bin.R
+++ b/src/library/utils/R/install.bin.R
@@ -96,7 +96,15 @@
     }
 
     ## not sure why the above was used - possibly it pre-dates utils::untar()?
-    untar <- function(what, where) utils::untar(what, exdir=where)
+    ## binary packages can be tarballs or zip files: dispatch on the
+    ## magic bytes as the file extension is not reliable
+    untar <- function(what, where) {
+        magic <- readBin(what, "raw", n = 4L)
+        if (identical(magic, as.raw(c(0x50, 0x4b, 0x03, 0x04))))
+            unzip(what, exdir = where)
+        else
+            utils::untar(what, exdir = where)
+    }
 
     unpackPkg <- function(pkg, pkgname, lib, lock = FALSE)
     {

--- a/src/library/utils/R/windows/install.packages.R
+++ b/src/library/utils/R/windows/install.packages.R
@@ -24,7 +24,12 @@ unpackPkgZip <- function(pkg, pkgname, lib, libs_only = FALSE,
     .zip.unpack <- function(zipname, dest)
     {
         if(file.exists(zipname)) {
-            if((unzip <- getOption("unzip")) != "internal") {
+            ## binary packages can be zip files or tarballs: dispatch on
+            ## the magic bytes as the file extension is not reliable
+            magic <- readBin(zipname, "raw", n = 4L)
+            if(!identical(magic, as.raw(c(0x50, 0x4b, 0x03, 0x04))))
+                utils::untar(zipname, exdir = dest)
+            else if((unzip <- getOption("unzip")) != "internal") {
                 system(paste(shQuote(unzip), "-oq", zipname, "-d", dest),
                        show.output.on.console = FALSE, invisible = TRUE)
             } else unzip(zipname, exdir = dest)


### PR DESCRIPTION
Follow-up to the custom-binaries work (7cd9a82a76): both binary unpackers currently assume the archive format from context rather than from the file itself.

- `unpackPkgZip()` (win.binary path) always runs unzip, so a custom binary tarball served from a `bin/windows/...` repository cannot be unpacked there.
- The `untar` wrapper in `.install.binary()` passes everything to `utils::untar()`. Zip files (as currently served by r-universe for `windows.binary.clang-aarch64`) only extract by accident when `untar()` falls back to an external bsdtar (e.g. `tar.exe` from System32), which auto-detects zip. With `TAR=internal` or a GNU tar this fails.

This patch makes both sides sniff the 4-byte zip signature (`PK\x03\x04`) and dispatch to `unzip()` or `utils::untar()` accordingly, keeping the existing `getOption("unzip")` handling for zips in `unpackPkgZip()`. `untar()` already detects gzip/bzip2/xz/zstd tarballs by magic bytes itself, so with this change the archive format of a binary repository no longer depends on platform conventions or the local tar implementation. This also benefits `R CMD INSTALL` on Windows, which routes `*.zip` files through `unpackPkgZip()`.

Tested: both files parse; the dispatch extracts a zip and a tar.gz correctly, and an empty/truncated file is not misdetected as zip (falls through to the usual `untar()` error).

🤖 Generated with [Claude Code](https://claude.com/claude-code)