### PR TITLE
anchor altstring elt results on the R_alloc stack

### DIFF
--- a/src/include/Defn.h
+++ b/src/include/Defn.h
@@ -2377,6 +2377,7 @@ Rboolean R_SetMaxNSize(R_size_t);
 R_size_t R_Decode2Long(char *p, int *ierr);
 void R_SetPPSize(R_size_t);
 void R_SetNconn(int);
+void R_VStackAnchor(SEXP);
 
 void R_expand_binding_value(SEXP);
 #ifdef IMMEDIATE_PROMISE_VALUES

--- a/src/main/altrep.c
+++ b/src/main/altrep.c
@@ -528,6 +528,14 @@ SEXP /*attribute_hidden*/ ALTSTRING_ELT(SEXP x, R_xlen_t i)
 
     val = ALTSTRING_DISPATCH(Elt, x, i);
 
+    /* The method may have returned a freshly created CHARSXP that
+       nothing else references.  Anchor it on the R_alloc stack, while
+       GC is still disabled, so it lives at least until the enclosing
+       vmaxset() -- the same lifetime callers already respect for
+       translateChar() results. */
+    if (val != NULL && val != NA_STRING && val != R_BlankString)
+	R_VStackAnchor(val);
+
     R_GCEnabled = enabled;
     return val;
 }

--- a/src/main/memory.c
+++ b/src/main/memory.c
@@ -2318,6 +2318,16 @@ void vmaxset(const void *ovmax)
     R_VStack = (SEXP) ovmax;
 }
 
+/* Anchor an otherwise unreferenced object on the R_alloc stack so that,
+   like R_alloc memory, it stays alive until the enclosing vmaxset().
+   Cached CHARSXPs chain the string hash through their ATTRIB field, so
+   they cannot be linked in directly the way R_alloc's RAWSXPs are; a
+   cons cell carries the reference instead. */
+attribute_hidden void R_VStackAnchor(SEXP s)
+{
+    R_VStack = CONS(s, R_VStack);
+}
+
 char *R_alloc(size_t nelem, int eltsize)
 {
     R_size_t size = nelem * eltsize;


### PR DESCRIPTION
## Motivation

[Bugzilla 19135](https://bugs.r-project.org/show_bug.cgi?id=19135) reports segfaults in `charmatch()` and `substr()` with ALTREP string vectors whose `Elt` method returns a freshly created CHARSXP on each call (as e.g. vroom and arrow do).

The root cause: for an ordinary STRSXP, an element CHARSXP is kept alive by the vector that holds it, and base code relies on that pervasively -- it takes `CHAR()` / `translateChar()` pointers from elements and keeps using them across later allocations. For an ALTREP string, `ALTSTRING_ELT()` disables GC only *during* the method dispatch; once it returns, a CHARSXP the class did not anchor is referenced by nothing (the CHARSXP cache is weak), and the next allocation can collect it. Both examples in the bug report are ASan-confirmed use-after-free: `strncmp()` in `do_charmatch` reads the freed element after the latin1 target's UTF-8 translation triggers GC, and `do_substr`'s `mkCharLenCE()` allocates the result CHARSXP first and then `memcpy`s from the freed source element.

Fixing this caller-by-caller is not practical: 50+ files under `src/main` hold element `char *`s across allocations, and `do_pmatch` alone holds pointers to *every* element of both vectors at once (its `in[]`/`tar[]` arrays). Requiring every class to anchor (as base's own `deferred_string` does, by memoizing each element into its expanded STRSXP) is a documentation fix that leaves existing classes broken.

## The change

`ALTSTRING_ELT()` now anchors the method's result on the R_alloc stack -- a new internal helper `R_VStackAnchor()` does `R_VStack = CONS(val, R_VStack)` -- while GC is still disabled. The element thereby gets the same lifetime contract callers already respect for `translateChar()` results: valid until the enclosing `vmaxset()`.

The scoping comes entirely from machinery that already exists:

* `eval.c` brackets every BUILTIN/SPECIAL application with `vmaxget()`/`vmaxset()`, so anchors never outlive the primitive that created them;
* contexts save and restore vmax on unwind, so error paths release anchors;
* the per-iteration `vmaxset()` calls already present in string loops (e.g. `do_charmatch`) trim anchors as they go, keeping loops O(1) in retained memory.

Notes on the design:

* The anchored CHARSXP is the genuine interned one, so pointer-identity semantics are untouched (`Seql()`'s cached-pointer fast path, `el == lastel` checks, factor level identity). `vmaxset()` never frees -- it only drops the stack's reference -- so an anchored element stored into a live object simply stays alive, and an unreferenced one is reclaimed by the weak CHARSXP cache exactly as usual. (A cached CHARSXP cannot be chained through ATTRIB the way `R_alloc`'s RAWSXPs are, because the cache's hash chain occupies that field -- hence the cons cell.)
* The push cannot lose the value: with GC disabled `R_gc_internal()` only grows heap limits, and independently `cons()` protects its arguments.
* `NA_STRING` and `R_BlankString` (permanent objects) are skipped to avoid flooding the stack for sparse columns.
* Cost is one cons cell per `Elt` dispatch, on the ALTREP path only -- small next to the `mkChar()` a string `Elt` method typically performs. If desired, a future class flag ("Elt results are stable") could let classes like `deferred_string` skip it.
* `ALTLIST_ELT()` has the same theoretical hole and could receive the same treatment in a follow-up.

## Validation

On an ASan build (aarch64-apple-darwin), using the bug report's minimal ALTREP class:

* Both MREs from the report -- previously `heap-use-after-free` (freed by `ReleaseLargeFreeVectors` during GC, read by `strncmp`/`memcpy`) -- now run clean with correct results, as does the small-string variant under `gctorture(TRUE)`.
* A multi-element variant (200 distinct fresh elements) exercising `do_pmatch`'s simultaneous `in[]`/`tar[]` pointer arrays runs clean -- the case a "most recent element" one-slot cache could not handle.
* Scope check: a 256MB ALTREP element is reclaimed as soon as the enclosing builtin returns (4.1MB Vcells residual after `gc()`), confirming anchors do not accumulate.
* A `deferred_string`/wrapper gauntlet under `gctorture(TRUE)` (paste, factor, match, sort, unique, substr, charmatch, grepl, nchar, serialize round trip) passes with unchanged results.
