### PR TITLE
speed up readRDS and saveRDS with buffered I/O and direct XDR coding

### DIFF
--- a/doc/NEWS.Rd
+++ b/doc/NEWS.Rd
@@ -100,13 +100,15 @@
       the number of simulated observations, allowing to sample from more
       complex models.
 
-      \item \code{readRDS()} reads files and \abbr{URL}s through a
-      read-ahead buffer instead of issuing one connection read per
-      serialized item, and decodes \abbr{XDR} numbers with byte
-      arithmetic rather than through the \abbr{XDR} library one value
-      at a time.  Objects made of many small elements are read about
-      three times faster, and large numeric vectors from uncompressed
-      files several times faster.
+      \item \code{readRDS()} and \code{saveRDS()} are faster.
+      \code{readRDS()} reads files and \abbr{URL}s through a read-ahead
+      buffer instead of issuing one connection read per serialized
+      item, \code{saveRDS()} likewise buffers its output, and both
+      encode and decode \abbr{XDR} numbers with byte arithmetic rather
+      than through the \abbr{XDR} library one value at a time.  Objects
+      made of many small elements are read about three times faster
+      and written up to three times faster, and large numeric vectors
+      in uncompressed files are read and written several times faster.
     }
   }
 

--- a/doc/NEWS.Rd
+++ b/doc/NEWS.Rd
@@ -99,6 +99,14 @@
       \item \code{rfree1way} also accepts \code{offset} terms equal to
       the number of simulated observations, allowing to sample from more
       complex models.
+
+      \item \code{readRDS()} reads files and \abbr{URL}s through a
+      read-ahead buffer instead of issuing one connection read per
+      serialized item, and decodes \abbr{XDR} numbers with byte
+      arithmetic rather than through the \abbr{XDR} library one value
+      at a time.  Objects made of many small elements are read about
+      three times faster, and large numeric vectors from uncompressed
+      files several times faster.
     }
   }
 

--- a/src/include/Defn.h
+++ b/src/include/Defn.h
@@ -1851,9 +1851,6 @@ Rboolean R_HasFancyBindings(SEXP rho); // envir.c
 void R_RestoreHashCount(SEXP rho); // envir.c
 SEXP R_lsInternal(SEXP, Rboolean); // envir.c
 
-void R_XDREncodeDouble(double d, void *buf);
-void R_XDREncodeInteger(int i, void *buf);
-
 # define allocCharsxp		Rf_allocCharsxp
 # define asBool2	       	Rf_asBool2
 # define asRbool		Rf_asRbool

--- a/src/include/Defn.h
+++ b/src/include/Defn.h
@@ -1852,9 +1852,7 @@ void R_RestoreHashCount(SEXP rho); // envir.c
 SEXP R_lsInternal(SEXP, Rboolean); // envir.c
 
 void R_XDREncodeDouble(double d, void *buf);
-double R_XDRDecodeDouble(void *buf);
 void R_XDREncodeInteger(int i, void *buf);
-int R_XDRDecodeInteger(void *buf);
 
 # define allocCharsxp		Rf_allocCharsxp
 # define asBool2	       	Rf_asBool2

--- a/src/library/base/R/lazyload.R
+++ b/src/library/base/R/lazyload.R
@@ -40,7 +40,7 @@ lazyLoadDBexec <- function(filebase, fun, filter)
         if (! is.character(file)) halt("bad file name")
         con <- gzfile(file, "rb")
         on.exit(close(con))
-        .Internal(unserializeFromConn(con, baseenv()))
+        .Internal(unserializeFromConn(con, baseenv(), TRUE))
     }
     `parent.env<-` <-
         function (env, value) .Internal(`parent.env<-`(env, value))

--- a/src/library/base/R/serialize.R
+++ b/src/library/base/R/serialize.R
@@ -48,13 +48,17 @@ saveRDS <-
 
 readRDS <- function(file, refhook = NULL)
 {
+    ## Reading ahead through a buffer discards bytes beyond the end of
+    ## the object, so it is only used for connections created here.
     if(is.character(file)) {
         con <- gzfile(file, "rb")
         on.exit(close(con))
-    } else if (inherits(file, "connection"))
-	con <- if(inherits(file, "url")) gzcon(file) else file
-    else stop("bad 'file' argument")
-    .Internal(unserializeFromConn(con, refhook))
+        buffered <- TRUE
+    } else if (inherits(file, "connection")) {
+        buffered <- inherits(file, "url")
+        con <- if(buffered) gzcon(file) else file
+    } else stop("bad 'file' argument")
+    .Internal(unserializeFromConn(con, refhook, buffered))
 }
 
 infoRDS <- function(file)

--- a/src/library/base/baseloader.R
+++ b/src/library/base/baseloader.R
@@ -36,7 +36,7 @@
         if (! is.character(file)) halt("bad file name")
         con <- gzfile(file, "rb")
         on.exit(close(con))
-        .Internal(unserializeFromConn(con, baseenv()))
+        .Internal(unserializeFromConn(con, baseenv(), TRUE))
     }
     `parent.env<-` <-
         function (env, value) .Internal(`parent.env<-`(env, value))

--- a/src/main/names.c
+++ b/src/main/names.c
@@ -689,7 +689,7 @@ FUNTAB R_FunTab[] =
 {"loadFromConn2",    do_loadFromConn2,0, 111,	3,	{PP_FUNCALL, PREC_FN,	0}},
 {"loadInfoFromConn2",do_loadFromConn2,1, 11,	1,	{PP_FUNCALL, PREC_FN,	0}},
 {"serializeToConn",	 do_serializeToConn,	0, 111,	5,	{PP_FUNCALL, PREC_FN,	0}},
-{"unserializeFromConn",	 do_unserializeFromConn, 0, 11,	2,	{PP_FUNCALL, PREC_FN,	0}},
+{"unserializeFromConn",	 do_unserializeFromConn, 0, 11,	3,	{PP_FUNCALL, PREC_FN,	0}},
 {"serializeInfoFromConn",do_unserializeFromConn, 1, 11,	1,	{PP_FUNCALL, PREC_FN,	0}},
 {"deparse",	do_deparse,	0,	11,	5,	{PP_FUNCALL, PREC_FN,	0}},
 {"dput",	do_dput,	0,	111,	3,	{PP_FUNCALL, PREC_FN,	0}},

--- a/src/main/saveload.c
+++ b/src/main/saveload.c
@@ -2212,20 +2212,6 @@ attribute_hidden void R_XDREncodeDouble(double d, void *buf)
 	error(_("XDR write failed"));
 }
 
-attribute_hidden double R_XDRDecodeDouble(void *buf)
-{
-    XDR xdrs;
-    double d;
-    int success;
-
-    xdrmem_create(&xdrs, (char *) buf, R_XDR_DOUBLE_SIZE, XDR_DECODE);
-    success = xdr_double(&xdrs, &d);
-    xdr_destroy(&xdrs);
-    if (! success)
-	error(_("XDR read failed"));
-    return d;
-}
-
 attribute_hidden void R_XDREncodeInteger(int i, void *buf)
 {
     XDR xdrs;
@@ -2236,19 +2222,6 @@ attribute_hidden void R_XDREncodeInteger(int i, void *buf)
     xdr_destroy(&xdrs);
     if (! success)
 	error(_("XDR write failed"));
-}
-
-attribute_hidden int R_XDRDecodeInteger(void *buf)
-{
-    XDR xdrs;
-    int i, success;
-
-    xdrmem_create(&xdrs, (char *) buf, R_XDR_INTEGER_SIZE, XDR_DECODE);
-    success = xdr_int(&xdrs, &i);
-    xdr_destroy(&xdrs);
-    if (! success)
-	error(_("XDR read failed"));
-    return i;
 }
 
 /* Next two were used in gnomeGUI package, are in Rinterface.h  */

--- a/src/main/saveload.c
+++ b/src/main/saveload.c
@@ -2195,35 +2195,6 @@ attribute_hidden SEXP do_load(SEXP call, SEXP op, SEXP args, SEXP env)
     return val;
 }
 
-/* defined in Rinternals.h
-#define R_XDR_DOUBLE_SIZE 8
-#define R_XDR_INTEGER_SIZE 4
-*/
-
-attribute_hidden void R_XDREncodeDouble(double d, void *buf)
-{
-    XDR xdrs;
-    int success;
-
-    xdrmem_create(&xdrs, (char *) buf, R_XDR_DOUBLE_SIZE, XDR_ENCODE);
-    success = xdr_double(&xdrs, &d);
-    xdr_destroy(&xdrs);
-    if (! success)
-	error(_("XDR write failed"));
-}
-
-attribute_hidden void R_XDREncodeInteger(int i, void *buf)
-{
-    XDR xdrs;
-    int success;
-
-    xdrmem_create(&xdrs, (char *) buf, R_XDR_INTEGER_SIZE, XDR_ENCODE);
-    success = xdr_int(&xdrs, &i);
-    xdr_destroy(&xdrs);
-    if (! success)
-	error(_("XDR write failed"));
-}
-
 /* Next two were used in gnomeGUI package, are in Rinterface.h  */
 void R_SaveGlobalEnvToFile(const char *name)
 {

--- a/src/main/serialize.c
+++ b/src/main/serialize.c
@@ -375,6 +375,63 @@ static void OutString(R_outpstream_t stream, const char *s, int length)
  * Basic Input Routines
  */
 
+/* XDR integers are big-endian two's complement and XDR doubles are
+   big-endian IEEE 754, so they can be decoded with plain byte
+   arithmetic.  This avoids a round trip through the XDR library for
+   every value, which is a function pointer dispatch per element and
+   dominates the cost of reading large numeric vectors.  Assembling
+   the value from bytes is endianness-neutral, and compilers reduce it
+   to a byte swap. */
+
+static R_INLINE int DecodeXDRInteger(const unsigned char *p)
+{
+    unsigned int u = ((unsigned int) p[0] << 24) |
+	((unsigned int) p[1] << 16) |
+	((unsigned int) p[2] << 8) |
+	(unsigned int) p[3];
+    int i;
+
+    memcpy(&i, &u, sizeof(int));
+    return i;
+}
+
+static R_INLINE double DecodeXDRDouble(const unsigned char *p)
+{
+    uint64_t u = ((uint64_t) p[0] << 56) |
+	((uint64_t) p[1] << 48) |
+	((uint64_t) p[2] << 40) |
+	((uint64_t) p[3] << 32) |
+	((uint64_t) p[4] << 24) |
+	((uint64_t) p[5] << 16) |
+	((uint64_t) p[6] << 8) |
+	(uint64_t) p[7];
+    double d;
+
+    memcpy(&d, &u, sizeof(double));
+    return d;
+}
+
+/* Vectors are decoded in place: the raw XDR bytes are read straight
+   into the destination and converted there. */
+
+static R_INLINE void DecodeXDRIntegerVec(int *x, R_xlen_t n)
+{
+    for (R_xlen_t i = 0; i < n; i++) {
+	unsigned char b[sizeof(int)];
+	memcpy(b, x + i, sizeof(int));
+	x[i] = DecodeXDRInteger(b);
+    }
+}
+
+static R_INLINE void DecodeXDRDoubleVec(double *x, R_xlen_t n)
+{
+    for (R_xlen_t i = 0; i < n; i++) {
+	unsigned char b[sizeof(double)];
+	memcpy(b, x + i, sizeof(double));
+	x[i] = DecodeXDRDouble(b);
+    }
+}
+
 static void InWord(R_inpstream_t stream, char * buf, int size)
 {
     int c, i;
@@ -413,7 +470,7 @@ static int InInteger(R_inpstream_t stream)
 	return i;
     case R_pstream_xdr_format:
 	stream->InBytes(stream, buf, R_XDR_INTEGER_SIZE);
-	return R_XDRDecodeInteger(buf);
+	return DecodeXDRInteger((unsigned char *) buf);
     default:
 	return NA_INTEGER;
     }
@@ -456,7 +513,7 @@ static double InReal(R_inpstream_t stream)
 	return d;
     case R_pstream_xdr_format:
 	stream->InBytes(stream, buf, R_XDR_DOUBLE_SIZE);
-	return R_XDRDecodeDouble(buf);
+	return DecodeXDRDouble((unsigned char *) buf);
     default:
 	return NA_REAL;
     }
@@ -1520,24 +1577,18 @@ static SEXP InStringVec(R_inpstream_t stream, SEXP ref_table)
     return s;
 }
 
-/* use static buffer to reuse storage */
 static R_INLINE void
 InIntegerVec(R_inpstream_t stream, SEXP obj, R_xlen_t length)
 {
     switch (stream->type) {
     case R_pstream_xdr_format:
     {
-	static char buf[CHUNK_SIZE * sizeof(int)];
+	int *x = INTEGER(obj);
 	R_xlen_t done, this;
-	XDR xdrs;
 	for (done = 0; done < length; done += this) {
 	    this = min2(CHUNK_SIZE, length - done);
-	    stream->InBytes(stream, buf, (int)(sizeof(int) * this));
-	    xdrmem_create(&xdrs, buf, (int)(this * sizeof(int)), XDR_DECODE);
-	    for(int cnt = 0; cnt < this; cnt++)
-		if(!xdr_int(&xdrs, INTEGER(obj) + done + cnt))
-		    error(_("XDR read failed"));
-	    xdr_destroy(&xdrs);
+	    stream->InBytes(stream, x + done, (int)(sizeof(int) * this));
+	    DecodeXDRIntegerVec(x + done, this);
 	}
 	break;
     }
@@ -1563,17 +1614,12 @@ InRealVec(R_inpstream_t stream, SEXP obj, R_xlen_t length)
     switch (stream->type) {
     case R_pstream_xdr_format:
     {
-	static char buf[CHUNK_SIZE * sizeof(double)];
+	double *x = REAL(obj);
 	R_xlen_t done, this;
-	XDR xdrs;
 	for (done = 0; done < length; done += this) {
 	    this = min2(CHUNK_SIZE, length - done);
-	    stream->InBytes(stream, buf, (int)(sizeof(double) * this));
-	    xdrmem_create(&xdrs, buf, (int)(this * sizeof(double)), XDR_DECODE);
-	    for(R_xlen_t cnt = 0; cnt < this; cnt++)
-		if(!xdr_double(&xdrs, REAL(obj) + done + cnt))
-		    error(_("XDR read failed"));
-	    xdr_destroy(&xdrs);
+	    stream->InBytes(stream, x + done, (int)(sizeof(double) * this));
+	    DecodeXDRDoubleVec(x + done, this);
 	}
 	break;
     }
@@ -1599,20 +1645,13 @@ InComplexVec(R_inpstream_t stream, SEXP obj, R_xlen_t length)
     switch (stream->type) {
     case R_pstream_xdr_format:
     {
-	static char buf[CHUNK_SIZE * sizeof(Rcomplex)];
+	Rcomplex *x = COMPLEX(obj);
 	R_xlen_t done, this;
-	XDR xdrs;
-	Rcomplex *output = COMPLEX(obj);
 	for (done = 0; done < length; done += this) {
 	    this = min2(CHUNK_SIZE, length - done);
-	    stream->InBytes(stream, buf, (int)(sizeof(Rcomplex) * this));
-	    xdrmem_create(&xdrs, buf, (int)(this * sizeof(Rcomplex)), XDR_DECODE);
-	    for(R_xlen_t cnt = 0; cnt < this; cnt++) {
-		if(!xdr_double(&xdrs, &(output[done+cnt].r)) ||
-		   !xdr_double(&xdrs, &(output[done+cnt].i)))
-		    error(_("XDR read failed"));
-	    }
-	    xdr_destroy(&xdrs);
+	    stream->InBytes(stream, x + done, (int)(sizeof(Rcomplex) * this));
+	    /* an Rcomplex is two consecutive doubles */
+	    DecodeXDRDoubleVec((double *) (x + done), 2 * this);
 	}
 	break;
     }
@@ -2483,9 +2522,9 @@ static void CheckOutConn(Rconnection con)
 	error(_("cannot write to this connection"));
 }
 
-static void InBytesConn(R_inpstream_t stream, void *buf, int length)
+static void ReadConnBytes(Rconnection con, R_inpstream_t stream,
+			  void *buf, int length)
 {
-    Rconnection con = (Rconnection) stream->data;
     CheckInConn(con);
     if (con->text) {
 	int i;
@@ -2516,10 +2555,9 @@ static void InBytesConn(R_inpstream_t stream, void *buf, int length)
     }
 }
 
-static int InCharConn(R_inpstream_t stream)
+static int ReadConnChar(Rconnection con)
 {
     char buf[1];
-    Rconnection con = (Rconnection) stream->data;
     CheckInConn(con);
     if (con->text)
 	return Rconn_fgetc(con);
@@ -2529,6 +2567,127 @@ static int InCharConn(R_inpstream_t stream)
 		    con->description);
 	return buf[0];
     }
+}
+
+static void InBytesConn(R_inpstream_t stream, void *buf, int length)
+{
+    ReadConnBytes((Rconnection) stream->data, stream, buf, length);
+}
+
+static int InCharConn(R_inpstream_t stream)
+{
+    return ReadConnChar((Rconnection) stream->data);
+}
+
+/* Buffered connection input streams.
+
+   Reading every flags word, length and CHARSXP with its own
+   con->read() call is expensive, most of all for compressed
+   connections: zlib only takes its fast path when asked for at least
+   258 bytes of output, and each call pays for inflate() setup and a
+   crc32 update.  Objects made of many small elements spend most of
+   their time there, so a read-ahead buffer amortizes that cost.
+
+   Bytes read past the end of the serialized object are discarded, so
+   the buffer can only be used by callers which own the connection and
+   close it afterwards, such as readRDS() with a file name.  Streams
+   reading from a shared connection must keep consuming it exactly. */
+
+#define CONIN_BUFSIZE 65536
+/* requests at least this large are read straight into the caller's
+   memory: they are already efficient and would only be copied twice */
+#define CONIN_DIRECT_MIN 4096
+
+typedef struct conin_st {
+    Rconnection con;
+    unsigned char *buf;
+    size_t pos; /* next unread byte in buf */
+    size_t len; /* number of bytes held in buf */
+} *conin_t;
+
+static R_INLINE bool UseConnBuffer(conin_t cin, R_inpstream_t stream)
+{
+    /* Only binary formats are buffered.  The ascii format reads
+       through Rconn_getline() and text-mode connections through
+       Rconn_fgetc(), neither of which would see buffered bytes.  The
+       format is not known until the header has been read, and nothing
+       is buffered before then. */
+    return !cin->con->text &&
+	(stream->type == R_pstream_xdr_format ||
+	 stream->type == R_pstream_binary_format);
+}
+
+static void InBytesConnBuffered(R_inpstream_t stream, void *buf, int length)
+{
+    conin_t cin = stream->data;
+    Rconnection con = cin->con;
+
+    if (!UseConnBuffer(cin, stream)) {
+	ReadConnBytes(con, stream, buf, length);
+	return;
+    }
+    CheckInConn(con);
+    if (length <= 0)
+	return;
+
+    unsigned char *dst = buf;
+    size_t need = (size_t) length;
+    size_t avail = cin->len - cin->pos;
+    if (avail >= need) {
+	memcpy(dst, cin->buf + cin->pos, need);
+	cin->pos += need;
+	return;
+    }
+
+    /* drain the buffer, then read the rest directly or refill */
+    memcpy(dst, cin->buf + cin->pos, avail);
+    dst += avail;
+    need -= avail;
+    cin->pos = cin->len = 0;
+
+    if (need >= CONIN_DIRECT_MIN) {
+	if (need != con->read(dst, 1, need, con))
+	    error(_("error reading from connection '%s'"),
+		  con->description);
+	return;
+    }
+
+    while (cin->len < need) {
+	size_t n = con->read(cin->buf + cin->len, 1,
+			     CONIN_BUFSIZE - cin->len, con);
+	if (n == 0 || n > CONIN_BUFSIZE - cin->len)
+	    error(_("error reading from connection '%s'"),
+		  con->description);
+	cin->len += n;
+    }
+    memcpy(dst, cin->buf, need);
+    cin->pos = need;
+}
+
+static int InCharConnBuffered(R_inpstream_t stream)
+{
+    conin_t cin = stream->data;
+
+    /* Single characters are only read by the ascii format, which is
+       never buffered, but never skip over bytes already read ahead. */
+    if (cin->pos < cin->len)
+	return cin->buf[cin->pos++];
+    return ReadConnChar(cin->con);
+}
+
+static void InitBufferedConnInPStream(R_inpstream_t stream, conin_t cin,
+				      Rconnection con,
+				      SEXP (*phook)(SEXP, SEXP), SEXP pdata)
+{
+    CheckInConn(con);
+    cin->con = con;
+    cin->buf = (unsigned char *) R_alloc(CONIN_BUFSIZE, 1);
+    cin->pos = cin->len = 0;
+
+    R_pstream_format_t type =
+	con->text ? R_pstream_ascii_format : R_pstream_any_format;
+    R_InitInPStream(stream, (R_pstream_data_t) cin, type,
+		    InCharConnBuffered, InBytesConnBuffered, phook, pdata);
 }
 
 static void OutBytesConn(R_outpstream_t stream, void *buf, int length)
@@ -2684,20 +2843,21 @@ static SEXP checkNotPromise(SEXP val)
     return val;
 }
 
-/* unserializeFromConn(conn, hook) used from readRDS().
+/* unserializeFromConn(conn, hook, buffered) used from readRDS().
    It became public in R 2.13.0, and that version added support for
    connections internally */
 attribute_hidden SEXP
 do_unserializeFromConn(SEXP call, SEXP op, SEXP args, SEXP env)
 {
-    /* 0 .. unserializeFromConn(conn, hook) */
+    /* 0 .. unserializeFromConn(conn, hook, buffered) */
     /* 1 .. serializeInfoFromConn(conn) */
 
     struct R_inpstream_st in;
+    struct conin_st cin;
     Rconnection con;
     SEXP fun, ans;
     SEXP (*hook)(SEXP, SEXP);
-    bool wasopen;
+    bool wasopen, buffered;
     RCNTXT cntxt;
 
     checkArity(op, args);
@@ -2725,7 +2885,15 @@ do_unserializeFromConn(SEXP call, SEXP op, SEXP args, SEXP env)
 
     fun = PRIMVAL(op) == 0 ? CADR(args) : R_NilValue;
     hook = fun != R_NilValue ? CallHook : NULL;
-    R_InitConnInPStream(&in, con, R_pstream_any_format, hook, fun);
+
+    /* The caller asks for buffering only when it owns the connection
+       and closes it afterwards, so reading ahead cannot lose bytes
+       that anything else expects to find. */
+    buffered = PRIMVAL(op) == 0 && asRbool(CADDR(args), call);
+    if (buffered)
+	InitBufferedConnInPStream(&in, &cin, con, hook, fun);
+    else
+	R_InitConnInPStream(&in, con, R_pstream_any_format, hook, fun);
     ans = PRIMVAL(op) == 0 ? R_Unserialize(&in) : R_SerializeInfo(&in);
     if(!wasopen) {
 	PROTECT(ans); /* paranoia about next line */

--- a/src/main/serialize.c
+++ b/src/main/serialize.c
@@ -236,6 +236,54 @@ static int Rsnprintf(char *buf, size_t size, const char *format, ...)
  * Basic Output Routines
  */
 
+/* XDR integers are big-endian two's complement and XDR doubles are
+   big-endian IEEE 754, so they can be encoded and decoded with plain
+   byte arithmetic.  This avoids a round trip through the XDR library
+   for every value, which is a function pointer dispatch per element
+   and dominates the cost of writing and reading large numeric
+   vectors.  Working byte by byte is endianness-neutral, and compilers
+   reduce it to a byte swap. */
+
+static R_INLINE void EncodeXDRInteger(int i, unsigned char *p)
+{
+    unsigned int u;
+
+    memcpy(&u, &i, sizeof(int));
+    p[0] = (unsigned char) (u >> 24);
+    p[1] = (unsigned char) (u >> 16);
+    p[2] = (unsigned char) (u >> 8);
+    p[3] = (unsigned char) u;
+}
+
+static R_INLINE void EncodeXDRDouble(double d, unsigned char *p)
+{
+    uint64_t u;
+
+    memcpy(&u, &d, sizeof(double));
+    p[0] = (unsigned char) (u >> 56);
+    p[1] = (unsigned char) (u >> 48);
+    p[2] = (unsigned char) (u >> 40);
+    p[3] = (unsigned char) (u >> 32);
+    p[4] = (unsigned char) (u >> 24);
+    p[5] = (unsigned char) (u >> 16);
+    p[6] = (unsigned char) (u >> 8);
+    p[7] = (unsigned char) u;
+}
+
+static R_INLINE void
+EncodeXDRIntegerVec(const int *x, R_xlen_t n, unsigned char *p)
+{
+    for (R_xlen_t i = 0; i < n; i++)
+	EncodeXDRInteger(x[i], p + i * sizeof(int));
+}
+
+static R_INLINE void
+EncodeXDRDoubleVec(const double *x, R_xlen_t n, unsigned char *p)
+{
+    for (R_xlen_t i = 0; i < n; i++)
+	EncodeXDRDouble(x[i], p + i * sizeof(double));
+}
+
 static void OutInteger(R_outpstream_t stream, int i)
 {
     char buf[128];
@@ -252,7 +300,7 @@ static void OutInteger(R_outpstream_t stream, int i)
 	stream->OutBytes(stream, &i, sizeof(int));
 	break;
     case R_pstream_xdr_format:
-	R_XDREncodeInteger(i, buf);
+	EncodeXDRInteger(i, (unsigned char *) buf);
 	stream->OutBytes(stream, buf, R_XDR_INTEGER_SIZE);
 	break;
     default:
@@ -299,7 +347,7 @@ static void OutReal(R_outpstream_t stream, double d)
 	stream->OutBytes(stream, &d, sizeof(double));
 	break;
     case R_pstream_xdr_format:
-	R_XDREncodeDouble(d, buf);
+	EncodeXDRDouble(d, (unsigned char *) buf);
 	stream->OutBytes(stream, buf, R_XDR_DOUBLE_SIZE);
 	break;
     default:
@@ -375,13 +423,7 @@ static void OutString(R_outpstream_t stream, const char *s, int length)
  * Basic Input Routines
  */
 
-/* XDR integers are big-endian two's complement and XDR doubles are
-   big-endian IEEE 754, so they can be decoded with plain byte
-   arithmetic.  This avoids a round trip through the XDR library for
-   every value, which is a function pointer dispatch per element and
-   dominates the cost of reading large numeric vectors.  Assembling
-   the value from bytes is endianness-neutral, and compilers reduce it
-   to a byte swap. */
+/* Counterparts of EncodeXDRInteger() and EncodeXDRDouble() above. */
 
 static R_INLINE int DecodeXDRInteger(const unsigned char *p)
 {
@@ -957,9 +999,6 @@ static void OutStringVec(R_outpstream_t stream, SEXP s, SEXP ref_table)
     }
 }
 
-#include <rpc/types.h>
-#include <rpc/xdr.h>
-
 #define CHUNK_SIZE 8096
 
 #define min2(a, b) ((a) < (b)) ? (a) : (b)
@@ -972,17 +1011,13 @@ OutIntegerVec(R_outpstream_t stream, SEXP s, R_xlen_t length)
     switch (stream->type) {
     case R_pstream_xdr_format:
     {
-	static char buf[CHUNK_SIZE * sizeof(int)];
+	static unsigned char buf[CHUNK_SIZE * sizeof(int)];
+	const int *x = INTEGER(s);
 	R_xlen_t done, this;
-	XDR xdrs;
 	for (done = 0; done < length; done += this) {
 	    IF_IC_R_CheckUserInterrupt();
 	    this = min2(CHUNK_SIZE, length - done);
-	    xdrmem_create(&xdrs, buf, (int)(this * sizeof(int)), XDR_ENCODE);
-	    for(int cnt = 0; cnt < this; cnt++)
-		if(!xdr_int(&xdrs, INTEGER(s) + done + cnt))
-		    error(_("XDR write failed"));
-	    xdr_destroy(&xdrs);
+	    EncodeXDRIntegerVec(x + done, this, buf);
 	    stream->OutBytes(stream, buf, (int)(sizeof(int) * this));
 	}
 	break;
@@ -1014,17 +1049,13 @@ OutRealVec(R_outpstream_t stream, SEXP s, R_xlen_t length)
     switch (stream->type) {
     case R_pstream_xdr_format:
     {
-	static char buf[CHUNK_SIZE * sizeof(double)];
+	static unsigned char buf[CHUNK_SIZE * sizeof(double)];
+	const double *x = REAL(s);
 	R_xlen_t done, this;
-	XDR xdrs;
 	for (done = 0; done < length; done += this) {
 	    IF_IC_R_CheckUserInterrupt();
 	    this = min2(CHUNK_SIZE, length - done);
-	    xdrmem_create(&xdrs, buf, (int)(this * sizeof(double)), XDR_ENCODE);
-	    for(int cnt = 0; cnt < this; cnt++)
-		if(!xdr_double(&xdrs, REAL(s) + done + cnt))
-		    error(_("XDR write failed"));
-	    xdr_destroy(&xdrs);
+	    EncodeXDRDoubleVec(x + done, this, buf);
 	    stream->OutBytes(stream, buf, (int)(sizeof(double) * this));
 	}
 	break;
@@ -1055,21 +1086,15 @@ OutComplexVec(R_outpstream_t stream, SEXP s, R_xlen_t length)
     switch (stream->type) {
     case R_pstream_xdr_format:
     {
-	static char buf[CHUNK_SIZE * sizeof(Rcomplex)];
+	static unsigned char buf[CHUNK_SIZE * sizeof(Rcomplex)];
+	const Rcomplex *x = COMPLEX(s);
 	R_xlen_t done, this;
-	XDR xdrs;
-	Rcomplex *c = COMPLEX(s);
 	for (done = 0; done < length; done += this) {
 	    IF_IC_R_CheckUserInterrupt();
 	    this = min2(CHUNK_SIZE, length - done);
-	    xdrmem_create(&xdrs, buf, (int)(this * sizeof(Rcomplex)), XDR_ENCODE);
-	    for(int cnt = 0; cnt < this; cnt++) {
-		if(!xdr_double(&xdrs, &(c[done+cnt].r)) ||
-		   !xdr_double(&xdrs, &(c[done+cnt].i)))
-		    error(_("XDR write failed"));
-	    }
+	    /* an Rcomplex is two consecutive doubles */
+	    EncodeXDRDoubleVec((const double *) (x + done), 2 * this, buf);
 	    stream->OutBytes(stream, buf, (int)(sizeof(Rcomplex) * this));
-	    xdr_destroy(&xdrs);
 	}
 	break;
     }
@@ -2749,6 +2774,62 @@ void R_InitConnInPStream(R_inpstream_t stream,  Rconnection con,
 		    InCharConn, InBytesConn, phook, pdata);
 }
 
+/*
+ * Persistent Buffered Binary Connection Streams
+ */
+
+/**** should eventually come from a public header file */
+size_t R_WriteConnection(Rconnection con, void *buf, size_t n);
+
+#define BCONBUFSIZ 4096
+
+typedef struct bconbuf_st {
+    Rconnection con;
+    int count;
+    unsigned char buf[BCONBUFSIZ];
+} *bconbuf_t;
+
+static void flush_bcon_buffer(bconbuf_t bb)
+{
+    if (R_WriteConnection(bb->con, bb->buf, bb->count) != bb->count)
+	error(_("error writing to connection"));
+    bb->count = 0;
+}
+
+static void OutCharBB(R_outpstream_t stream, int c)
+{
+    bconbuf_t bb = stream->data;
+    if (bb->count >= BCONBUFSIZ)
+	flush_bcon_buffer(bb);
+    bb->buf[bb->count++] = (char) c;
+}
+
+static void OutBytesBB(R_outpstream_t stream, void *buf, int length)
+{
+    bconbuf_t bb = stream->data;
+    if (bb->count + length > BCONBUFSIZ)
+	flush_bcon_buffer(bb);
+    if (length <= BCONBUFSIZ) {
+	if (length)
+	    memcpy(bb->buf + bb->count, buf, length);
+	bb->count += length;
+    }
+    else if (R_WriteConnection(bb->con, buf, length) != length)
+	error(_("error writing to connection"));
+}
+
+static void InitBConOutPStream(R_outpstream_t stream, bconbuf_t bb,
+			       Rconnection con,
+			       R_pstream_format_t type, int version,
+			       SEXP (*phook)(SEXP, SEXP), SEXP pdata)
+{
+    CheckOutConn(con);
+    bb->count = 0;
+    bb->con = con;
+    R_InitOutPStream(stream, (R_pstream_data_t) bb, type, version,
+		     OutCharBB, OutBytesBB, phook, pdata);
+}
+
 /* ought to quote the argument, but it should only be an ENVSXP or STRSXP */
 static SEXP CallHook(SEXP x, SEXP fun)
 {
@@ -2774,10 +2855,11 @@ do_serializeToConn(SEXP call, SEXP op, SEXP args, SEXP env)
     /* serializeToConn(object, conn, ascii, version, hook) */
 
     SEXP object, fun;
-    bool ascii, wasopen;
+    bool ascii, wasopen, buffered;
     int version;
     Rconnection con;
     struct R_outpstream_st out;
+    struct bconbuf_st bbs;
     R_pstream_format_t type;
     SEXP (*hook)(SEXP, SEXP);
     RCNTXT cntxt;
@@ -2829,8 +2911,17 @@ do_serializeToConn(SEXP call, SEXP op, SEXP args, SEXP env)
     if(!con->canwrite)
 	error(_("connection not open for writing"));
 
-    R_InitConnOutPStream(&out, con, type, version, hook, fun);
+    /* Binary-mode output is buffered, as every serialized item would
+       otherwise be its own con->write() call.  Text-mode connections
+       keep the unbuffered stream so that Rconn_printf() re-encodes. */
+    buffered = !con->text;
+    if (buffered)
+	InitBConOutPStream(&out, &bbs, con, type, version, hook, fun);
+    else
+	R_InitConnOutPStream(&out, con, type, version, hook, fun);
     R_Serialize(object, &out);
+    if (buffered)
+	flush_bcon_buffer(&bbs);
     if(!wasopen) {endcontext(&cntxt); con->close(con);}
 
     return R_NilValue;
@@ -2902,61 +2993,6 @@ do_unserializeFromConn(SEXP call, SEXP op, SEXP args, SEXP env)
 	UNPROTECT(1);
     }
     return checkNotPromise(ans);
-}
-
-/*
- * Persistent Buffered Binary Connection Streams
- */
-
-/**** should eventually come from a public header file */
-size_t R_WriteConnection(Rconnection con, void *buf, size_t n);
-
-#define BCONBUFSIZ 4096
-
-typedef struct bconbuf_st {
-    Rconnection con;
-    int count;
-    unsigned char buf[BCONBUFSIZ];
-} *bconbuf_t;
-
-static void flush_bcon_buffer(bconbuf_t bb)
-{
-    if (R_WriteConnection(bb->con, bb->buf, bb->count) != bb->count)
-	error(_("error writing to connection"));
-    bb->count = 0;
-}
-
-static void OutCharBB(R_outpstream_t stream, int c)
-{
-    bconbuf_t bb = stream->data;
-    if (bb->count >= BCONBUFSIZ)
-	flush_bcon_buffer(bb);
-    bb->buf[bb->count++] = (char) c;
-}
-
-static void OutBytesBB(R_outpstream_t stream, void *buf, int length)
-{
-    bconbuf_t bb = stream->data;
-    if (bb->count + length > BCONBUFSIZ)
-	flush_bcon_buffer(bb);
-    if (length <= BCONBUFSIZ) {
-	if (length)
-	    memcpy(bb->buf + bb->count, buf, length);
-	bb->count += length;
-    }
-    else if (R_WriteConnection(bb->con, buf, length) != length)
-	error(_("error writing to connection"));
-}
-
-static void InitBConOutPStream(R_outpstream_t stream, bconbuf_t bb,
-			       Rconnection con,
-			       R_pstream_format_t type, int version,
-			       SEXP (*phook)(SEXP, SEXP), SEXP pdata)
-{
-    bb->count = 0;
-    bb->con = con;
-    R_InitOutPStream(stream, (R_pstream_data_t) bb, type, version,
-		     OutCharBB, OutBytesBB, phook, pdata);
 }
 
 /* only for use by serialize(), with binary write to a socket connection */

--- a/tests/reg-tests-1e.R
+++ b/tests/reg-tests-1e.R
@@ -3700,8 +3700,9 @@ stopifnot(
 )
 
 ## readRDS() reads through a buffer when it created the connection itself,
-## and XDR numbers are decoded in place: exercise chunk boundaries, the
-## direct-read path for long strings and every representation of NA.
+## saveRDS() writes through one, and XDR numbers are encoded and decoded
+## without the XDR library: exercise chunk boundaries, the direct-read
+## path for long strings and every representation of NA.
 tf <- tempfile(fileext = ".rds")
 x <- list(i = c(NA, .Machine$integer.max, -.Machine$integer.max, 1:20000),
           d = c(-1.5, NA, NaN, Inf, -Inf, .Machine$double.xmax,
@@ -3721,15 +3722,19 @@ for(compress in c(list(TRUE, FALSE, "bzip2", "xz"),
 xa <- x[c("i", "l", "s", "r", "small", "f")]
 saveRDS(xa, tf, ascii = TRUE)
 stopifnot(identical(readRDS(tf), xa))
-## a connection supplied by the caller must still be consumed exactly
+## a connection supplied by the caller must still be consumed exactly, and
+## buffered output must be flushed before anything written after it
 con <- file(tf, "wb"); saveRDS(1:3, con); saveRDS(x, con); saveRDS("end", con)
+writeBin(as.raw(1:4), con)
 close(con)
 con <- file(tf, "rb")
 stopifnot(identical(readRDS(con), 1:3), identical(readRDS(con), x),
-          identical(readRDS(con), "end"))
+          identical(readRDS(con), "end"),
+          identical(readBin(con, "raw", 8L), as.raw(1:4)))
 close(con)
 unlink(tf)
-## readRDS() issued one connection read per serialized item in R <= 4.6.x
+## readRDS() and saveRDS() issued one connection read or write per
+## serialized item in R <= 4.6.x
 
 
 ## keep at end

--- a/tests/reg-tests-1e.R
+++ b/tests/reg-tests-1e.R
@@ -3699,6 +3699,39 @@ stopifnot(
     identical(drop(aperm(a, c(1, 2, 3), resize = FALSE)), aperm(m, c(1, 2), resize = FALSE))
 )
 
+## readRDS() reads through a buffer when it created the connection itself,
+## and XDR numbers are decoded in place: exercise chunk boundaries, the
+## direct-read path for long strings and every representation of NA.
+tf <- tempfile(fileext = ".rds")
+x <- list(i = c(NA, .Machine$integer.max, -.Machine$integer.max, 1:20000),
+          d = c(-1.5, NA, NaN, Inf, -Inf, .Machine$double.xmax,
+                .Machine$double.xmin, seq(0, 1, length.out = 20000)),
+          z = complex(real = c(NA, 1:20000), imaginary = c(NaN, -(1:20000))),
+          l = c(NA, TRUE, FALSE)[rep_len(1:3, 20000)],
+          s = c(NA, "", strrep("a", 5000), paste0("s", 1:20000)),
+          r = as.raw(0:255),
+          small = replicate(500, list(a = 1L, b = 2.5), simplify = FALSE),
+          f = factor(c("b", "a", NA)))
+for(compress in c(list(TRUE, FALSE, "bzip2", "xz"),
+                  if(isTRUE(capabilities("zstd"))) "zstd")) {
+    saveRDS(x, tf, compress = compress)
+    stopifnot(identical(readRDS(tf), x))
+}
+## the ascii format is not buffered (doubles need not round trip exactly)
+xa <- x[c("i", "l", "s", "r", "small", "f")]
+saveRDS(xa, tf, ascii = TRUE)
+stopifnot(identical(readRDS(tf), xa))
+## a connection supplied by the caller must still be consumed exactly
+con <- file(tf, "wb"); saveRDS(1:3, con); saveRDS(x, con); saveRDS("end", con)
+close(con)
+con <- file(tf, "rb")
+stopifnot(identical(readRDS(con), 1:3), identical(readRDS(con), x),
+          identical(readRDS(con), "end"))
+close(con)
+unlink(tf)
+## readRDS() issued one connection read per serialized item in R <= 4.6.x
+
+
 ## keep at end
 rbind(last =  proc.time() - .pt,
       total = proc.time())


### PR DESCRIPTION
## Summary

Profiling `readRDS()` and `saveRDS()` (macOS `sample`, `-O2` build) showed two avoidable costs on each side of the serialization path:

1. **One connection read or write per serialized item.** Every flags word, every length and every CHARSXP body is its own `con->read()` call from `InBytesConn()`, and its own `con->write()` from `OutBytesConn()`. Binary-mode connections have no buffer, so on a `gzfile` each read is an `inflate()` call for 4 or 8 bytes. zlib only uses `inflate_fast` when asked for at least 258 bytes of output, so these reads always take its slow path and also pay `updatewindow` and a `crc32` update per call. For a list of 200,000 short numeric vectors, about 60% of `readRDS()` time was in `inflate`, `R_gzread`, `crc32` and the call chain around them, and inflating the same bytes in one call took 8 ms instead of 21 ms. On the write side, `saveRDS(compress = FALSE)` of item-heavy objects was about twice as slow as one bulk write of the same bytes through the same connection.

2. **Per-element XDR coding through the RPC function table.** `InRealVec()` copied each chunk into a static buffer and called `xdr_double()` per element, which on macOS is an out-of-line call into `libsystem_info` that itself calls `xdrmem_getlong` twice; `OutRealVec()` did the same with `xdrmem_putlong`. Reading 160 MB of uncompressed doubles spent about 80% of its time there, writing about 50%. The scalar path had the same shape: `R_XDRDecodeInteger()` did `xdrmem_create`, `xdr_int` and `xdr_destroy` for every flags word and length.

## Changes

- Connection input streams gain a 64 KB read-ahead buffer (`InBytesConnBuffered`). Requests of 4 KB or more are read straight into the destination since they are already efficient. Only the binary formats are buffered; the `ascii` format and text-mode connections keep their existing paths byte for byte.
- Bytes read past the end of the object are discarded, so the input buffer is only used when the caller owns the connection. `.Internal(unserializeFromConn(con, hook))` gains a third argument `buffered`; `readRDS()` passes `TRUE` for file names and URLs (where it creates the `gzfile()` or `gzcon()` itself) and `FALSE` for a connection supplied by the caller, which is still consumed exactly. Repeated `unserialize(con)` on a shared connection, as `parallel` does on sockets, is unaffected. The bootstrap copies of `readRDS` in `baseloader.R` and `lazyload.R` pass `TRUE`.
- `serializeToConn()` writes binary-mode connections through the buffered output stream that `serialize()` already used for sockets, flushing at the end, so anything written to a shared connection afterwards still follows the object. Output buffering is always safe, so it needs no ownership flag. Text-mode connections keep the unbuffered stream so `Rconn_printf()` handles re-encoding.
- XDR integers and doubles are encoded and decoded with byte arithmetic (`EncodeXDRInteger`, `DecodeXDRDouble`, and friends), which compilers reduce to a byte swap and vectorize. Vectors are read straight into `INTEGER()`/`REAL()`/`COMPLEX()` and converted in place, and encoded chunk by chunk into the existing static buffer. `serialize.c` no longer uses the XDR library at all, and the now unused `R_XDREncode*`/`R_XDRDecode*` helpers are removed from `saveload.c` (they were `attribute_hidden`, and commented out of `Rinternals.h` long ago).
- Regression tests in `tests/reg-tests-1e.R` cover chunk boundaries, every NA representation, long strings through the direct-read path, all compression types, the `ascii` format, and a shared connection holding several objects followed by raw bytes. A NEWS entry is included.

## Measurements

aarch64 macOS, `-O2`, best of 3, seconds. "in memory" is `unserialize()` of the same bytes already in a raw vector, which bounds what the read path can gain.

Reading:

| object | gz before | gz after | gz in memory | uncompressed before | uncompressed after |
|---|---|---|---|---|---|
| 1e6 distinct strings | 0.356 | 0.306 | 0.257 | 0.360 | 0.290 |
| data.frame, 1e6 rows | 0.249 | 0.161 | 0.153 | 0.207 | 0.145 |
| list of 2e5 length-3 doubles | 0.046 | 0.015 | 0.014 | 0.019 | 0.006 |
| 2e7 doubles | 0.340 | 0.238 | 0.246 | 0.070 | 0.012 |
| 5e7 integers | 0.505 | 0.413 | 0.431 | 0.114 | 0.016 |
| 500 `lm` fits | 0.016 | 0.006 | 0.005 | 0.017 | 0.006 |

Writing (gzip output is dominated by deflate itself, so the gain there is smaller):

| object | gz before | gz after | uncompressed before | uncompressed after | `serialize(x, NULL)` before | after |
|---|---|---|---|---|---|---|
| 1e6 distinct strings | 0.307 | 0.247 | 0.078 | 0.028 | 0.027 | 0.021 |
| data.frame, 1e6 rows | 1.054 | 0.988 | 0.084 | 0.029 | 0.033 | 0.023 |
| list of 2e5 length-3 doubles | 0.157 | 0.142 | 0.019 | 0.007 | 0.007 | 0.004 |
| 2e7 doubles | 10.5 | 10.5 | 0.091 | 0.031 | 0.083 | 0.023 |
| 5e7 integers | 8.03 | 7.92 | 0.141 | 0.046 | 0.122 | 0.044 |
| 500 `lm` fits | 0.023 | 0.014 | 0.016 | 0.006 | 0.006 | 0.004 |

`readRDS()` on a tiny file is unchanged at about 28 us per call, so the buffer allocation costs nothing measurable there.

## Notes

- `readRDS(url(...))` over HTTP could not be exercised here (no network in the environment); for that path only the flag passed to the internal changes, and `gzcon_read()` already loops until the request is satisfied or EOF. `url("file://...")` returns a `file` connection, so it does not take that branch.
- `save()`/`load()` go through their own code in `saveload.c` and are untouched.
- `gzfile()` opens the file twice on read (once in `comp_type_from_file()` to sniff the magic bytes, then again in `R_gzopen()`), which is about a third of the fixed cost of `readRDS()` on a tiny file. Removing it means threading a pre-opened `FILE *` through `gzio.h` and the four compressed-file connection classes for roughly 9 us per call, so it is left alone.
