### PR TITLE
halve the cost of interning strings: cache load factor, batched unserialize, generational cache sweep

### DIFF
--- a/doc/NEWS.Rd
+++ b/doc/NEWS.Rd
@@ -109,7 +109,9 @@
       about twice as fast.  The load
       factor and the initial size of the table can be set at startup
       with environment variables \env{R_CHARSXP_CACHE_LOAD_FACTOR} and
-      \env{R_CHARSXP_CACHE_INITIAL_SIZE}, see \code{?EnvVar}.
+      \env{R_CHARSXP_CACHE_INITIAL_SIZE}, and the size of the (fixed
+      size) symbol table with \env{R_SYMBOL_TABLE_SIZE}, see
+      \code{?EnvVar}.
     }
   }
 

--- a/doc/NEWS.Rd
+++ b/doc/NEWS.Rd
@@ -106,7 +106,11 @@
       bucket), and \code{unserialize()} and hence \code{readRDS()} read
       character vectors in batches which prefetch the cache entries
       they will need.  Reading a file of a million distinct strings is
-      about twice as fast.  The load
+      about twice as fast.  The garbage collector no longer sweeps the
+      whole cache on every collection, only the buckets holding strings
+      young enough to have died, which removes a per-collection cost
+      that grew with the number of strings a session had ever created.
+      The load
       factor and the initial size of the table can be set at startup
       with environment variables \env{R_CHARSXP_CACHE_LOAD_FACTOR} and
       \env{R_CHARSXP_CACHE_INITIAL_SIZE}, and the size of the (fixed

--- a/doc/NEWS.Rd
+++ b/doc/NEWS.Rd
@@ -99,6 +99,17 @@
       \item \code{rfree1way} also accepts \code{offset} terms equal to
       the number of simulated observations, allowing to sample from more
       complex models.
+
+      \item Creating character strings is faster: the internal cache of
+      \code{CHARSXP}s now doubles its hash table at 0.75 strings per
+      bucket rather than at 85\% bucket occupancy (about 1.9 per
+      bucket), and \code{unserialize()} and hence \code{readRDS()} read
+      character vectors in batches which prefetch the cache entries
+      they will need.  Reading a file of a million distinct strings is
+      about twice as fast.  The load
+      factor and the initial size of the table can be set at startup
+      with environment variables \env{R_CHARSXP_CACHE_LOAD_FACTOR} and
+      \env{R_CHARSXP_CACHE_INITIAL_SIZE}, see \code{?EnvVar}.
     }
   }
 

--- a/doc/manual/R-ints.texi
+++ b/doc/manual/R-ints.texi
@@ -1342,7 +1342,10 @@ usually a cache miss, so the table is doubled once it holds more than
 @code{R_CHARSXP_CACHE_LOAD_FACTOR} (default 0.75) strings per bucket.
 The initial number of buckets (default 65536) can be set with
 @code{R_CHARSXP_CACHE_INITIAL_SIZE}; both are read from the environment
-when @R{} starts.  Code which interns many strings at once, such as
+when @R{} starts.  Each bucket records the age (generation) of its
+youngest @code{CHARSXP}, so that a collection of the younger generations
+only sweeps the buckets which can contain a dead string rather than the
+whole cache.  Code which interns many strings at once, such as
 @code{unserialize}, can compute the hashes ahead of the lookups with
 @code{R_CharHash} and prefetch the buckets and chain heads, see
 @file{src/main/serialize.c}.

--- a/doc/manual/R-ints.texi
+++ b/doc/manual/R-ints.texi
@@ -1333,6 +1333,20 @@ requests to create a @code{CHARSXP} should be @emph{via} a call to
 @code{mkCharLenCE}.  Any encoding given in @code{mkCharLenCE} call will
 be ignored if the string's bytes are all @acronym{ASCII} characters.
 
+The cache is a hash table whose size is a power of two, with the
+@code{CHARSXP}s in each bucket chained through their @code{ATTRIB}
+fields.  The chains are weak: the garbage collector removes
+@code{CHARSXP}s which are no longer referenced from elsewhere.  A lookup
+walks the chain for its bucket and each @code{CHARSXP} visited is
+usually a cache miss, so the table is doubled once it holds more than
+@code{R_CHARSXP_CACHE_LOAD_FACTOR} (default 0.75) strings per bucket.
+The initial number of buckets (default 65536) can be set with
+@code{R_CHARSXP_CACHE_INITIAL_SIZE}; both are read from the environment
+when @R{} starts.  Code which interns many strings at once, such as
+@code{unserialize}, can compute the hashes ahead of the lookups with
+@code{R_CharHash} and prefetch the buckets and chain heads, see
+@file{src/main/serialize.c}.
+
 
 @node Warnings and errors
 @section Warnings and errors

--- a/src/include/Defn.h
+++ b/src/include/Defn.h
@@ -1594,6 +1594,7 @@ void R_ReleaseMSet(SEXP mset, int keepSize);
 extern0 SEXP	R_CurrentExpr;	    /* Currently evaluating expression */
 extern0 SEXP	R_ReturnedValue;    /* Slot for return-ing values */
 extern0 SEXP*	R_SymbolTable;	    /* The symbol table */
+extern0 int	R_SymbolTableSize;  /* its number of buckets, fixed at startup */
 #ifdef R_USE_SIGNALS
 extern0 RCNTXT R_Toplevel;	      /* Storage for the toplevel context */
 extern0 RCNTXT* R_ToplevelContext;  /* The toplevel context */

--- a/src/include/Defn.h
+++ b/src/include/Defn.h
@@ -925,6 +925,14 @@ extern0 SEXP    R_dot_GenericDefEnv;  /* ".GenericDefEnv" */
 
 extern0 SEXP	R_StringHash;       /* Global hash of CHARSXPs */
 extern0 R_xlen_t R_StringHashCount; /* number of CHARSXPs in it */
+/* One byte per bucket: the age of its youngest CHARSXP, where 0 is a
+   node in New space, 1 and 2 the old generations, and 3 an empty
+   bucket.  A collection of the generations up to some level only has
+   to sweep the buckets whose youngest node is that young, which is the
+   difference between touching every cached string on every collection
+   and touching the strings created since the last one. */
+extern0 unsigned char *R_StringHashAges;
+#define R_STRINGHASH_EMPTY 3
 
 
  /* writable char access for R internal use only */

--- a/src/include/Defn.h
+++ b/src/include/Defn.h
@@ -924,6 +924,7 @@ extern0 SEXP    R_dot_GenericCallEnv;  /* ".GenericCallEnv" */
 extern0 SEXP    R_dot_GenericDefEnv;  /* ".GenericDefEnv" */
 
 extern0 SEXP	R_StringHash;       /* Global hash of CHARSXPs */
+extern0 R_xlen_t R_StringHashCount; /* number of CHARSXPs in it */
 
 
  /* writable char access for R internal use only */
@@ -1850,6 +1851,13 @@ SEXP R_FindPackageEnv(SEXP info);
 Rboolean R_HasFancyBindings(SEXP rho); // envir.c
 void R_RestoreHashCount(SEXP rho); // envir.c
 SEXP R_lsInternal(SEXP, Rboolean); // envir.c
+
+/* interning many strings at once, see the CHARSXP cache in envir.c */
+unsigned int R_CharHash(const char *name, int len);
+void R_CharHashPrefetchBucket(unsigned int hash);
+void R_CharHashPrefetchChain(unsigned int hash);
+SEXP R_mkCharLenCEHash(const char *name, int len, cetype_t enc,
+		       unsigned int hash);
 
 void R_XDREncodeDouble(double d, void *buf);
 double R_XDRDecodeDouble(void *buf);

--- a/src/library/base/man/EnvVar.Rd
+++ b/src/library/base/man/EnvVar.Rd
@@ -86,6 +86,14 @@
       rehashing the cache as it grows.  Read at startup only.}
     \item{\env{R_COMPLETION}:}{Optional.  If set to \code{FALSE},
       command-line completion is not used.  (Not used by the macOS GUI.)}
+    \item{\env{R_SYMBOL_TABLE_SIZE}:}{Optional.  The number of buckets
+      in \R's internal symbol table, rounded up to a prime, between 1024
+      and \eqn{2^{26}} (default 49157).  The table does not grow, and
+      symbols are never removed, so a session which creates many more
+      symbols than that, for example by using an environment with a
+      million keys, looks them up faster with a larger table.  A session
+      with the standard packages attached holds about ten thousand
+      symbols.  Read at startup only.}
     \item{\env{R_DEFAULT_PACKAGES}:}{A comma-separated list of packages
       which are to be attached in every session.  See \code{\link{options}}.}
     \item{\env{R_DOC_DIR}:}{The location of the \R \file{doc}

--- a/src/library/base/man/EnvVar.Rd
+++ b/src/library/base/man/EnvVar.Rd
@@ -73,6 +73,17 @@
       \code{!is.na(\link{Sys.getenv}("R_BATCH", NA))}.}
     \item{\env{R_BROWSER}:}{The path to the default browser.  Used to
       set the default value of \code{\link{options}("browser")}.}
+    \item{\env{R_CHARSXP_CACHE_LOAD_FACTOR}:}{Optional.  The number of
+      cached strings per hash bucket beyond which \R's internal cache
+      of character strings doubles its hash table, between 0.1 and 10
+      (default 0.75).  Smaller values make creating strings faster at
+      the cost of a larger table.  Read at startup only; see the
+      \sQuote{R Internals} manual.}
+    \item{\env{R_CHARSXP_CACHE_INITIAL_SIZE}:}{Optional.  The initial
+      number of buckets in that hash table, rounded up to a power of
+      two, between 1024 and \eqn{2^{30}} (default 65536).  Setting this
+      to about the number of distinct strings a session will use avoids
+      rehashing the cache as it grows.  Read at startup only.}
     \item{\env{R_COMPLETION}:}{Optional.  If set to \code{FALSE},
       command-line completion is not used.  (Not used by the macOS GUI.)}
     \item{\env{R_DEFAULT_PACKAGES}:}{A comma-separated list of packages

--- a/src/main/envir.c
+++ b/src/main/envir.c
@@ -4642,11 +4642,14 @@ static unsigned int char_hash(const char *s, int len)
        differ only in a running number djb2 leaves those correlated, so
        such keys land in neighbouring buckets and their chains are about
        20% longer than for random keys.  Do not be tempted to fix that
-       with a finalizer mix (or a prime table size): the correlation
-       means a run of such strings is inserted, and later walked by the
-       garbage collector, in nearly sequential memory order, and mixing
-       the bits made collections with millions of cached strings four
-       times slower. */
+       with a finalizer mix, a prime table size or an open-addressed
+       table (which needs the mix): the correlation is what lets a run
+       of such keys walk the bucket array sequentially.  With a million
+       cached strings, mixing the bits took inserting consecutive keys
+       from 87 to 168 ns and looking them up in creation order from 29
+       to 42 ns, gained nothing on random keys, and made full
+       collections 10% slower, since the sweep visits the cache in
+       bucket order. */
     return h;
 }
 

--- a/src/main/envir.c
+++ b/src/main/envir.c
@@ -4598,6 +4598,23 @@ attribute_hidden SEXP mkCharWUTF8(const wchar_t *wname)
 static unsigned int char_hash_size = 65536;
 static unsigned int char_hash_mask = 65535;
 
+/* The table doubles once it holds more than char_hash_load cached
+   strings per bucket.  A lookup walks a chain of CHARSXPs scattered
+   over the heap, each of them a cache miss, and an insertion walks the
+   whole chain, so the load factor matters more to the cost of
+   interning a string than anything else in mkCharLenCE().  The table
+   used to double at 85% bucket occupancy, about 1.9 strings per bucket,
+   which cost about twice as much per lookup as the current default.
+   Both the load factor and the initial size can be set from the
+   environment when R starts up. */
+static double char_hash_load = 0.75;
+#define CHAR_HASH_LOAD_MIN 0.1
+#define CHAR_HASH_LOAD_MAX 10.0
+#define CHAR_HASH_SIZE_MIN 1024
+#define CHAR_HASH_SIZE_MAX 1073741824 /* 2^30, the largest power of two
+					 a VECSXP could hold before long
+					 vectors */
+
 static unsigned int char_hash(const char *s, int len)
 {
     /* djb2 as from http://www.cse.yorku.ca/~oz/hash.html */
@@ -4606,12 +4623,74 @@ static unsigned int char_hash(const char *s, int len)
     unsigned int h = 5381;
     for (p = (char *) s, i = 0; i < len; p++, i++)
 	h = ((h << 5) + h) + (*p);
+    /* The bucket is selected by the low bits alone, and for keys which
+       differ only in a running number djb2 leaves those correlated, so
+       such keys land in neighbouring buckets and their chains are about
+       20% longer than for random keys.  Do not be tempted to fix that
+       with a finalizer mix (or a prime table size): the correlation
+       means a run of such strings is inserted, and later walked by the
+       garbage collector, in nearly sequential memory order, and mixing
+       the bits made collections with millions of cached strings four
+       times slower. */
     return h;
 }
 
 attribute_hidden void InitStringHash(void)
 {
+    const char *arg;
+
+    /* out-of-range values are ignored, as for the R_GC_* variables */
+    arg = getenv("R_CHARSXP_CACHE_LOAD_FACTOR");
+    if (arg != NULL && arg[0]) {
+	double load = atof(arg);
+	if (CHAR_HASH_LOAD_MIN <= load && load <= CHAR_HASH_LOAD_MAX)
+	    char_hash_load = load;
+    }
+    arg = getenv("R_CHARSXP_CACHE_INITIAL_SIZE");
+    if (arg != NULL && arg[0]) {
+	double size = atof(arg);
+	if (CHAR_HASH_SIZE_MIN <= size && size <= CHAR_HASH_SIZE_MAX) {
+	    unsigned int n = CHAR_HASH_SIZE_MIN;
+	    while (n < size)
+		n *= 2;
+	    char_hash_size = n;
+	    char_hash_mask = n - 1;
+	}
+    }
+
     R_StringHash = R_NewHashTable(char_hash_size);
+    R_StringHashCount = 0;
+}
+
+/* Helpers for code which interns many strings in a row, such as
+   unserialize().  Computing the hash ahead of the lookup lets the
+   caller prefetch the bucket, and a little later the head of its
+   chain, so that the cache misses which dominate mkCharLenCE() overlap
+   with other work.  A resize between the prefetch and the lookup only
+   wastes the prefetch. */
+
+#if defined(__GNUC__) || defined(__clang__)
+# define PREFETCH(p) __builtin_prefetch(p)
+#else
+# define PREFETCH(p) do { } while (0)
+#endif
+
+attribute_hidden unsigned int R_CharHash(const char *name, int len)
+{
+    return char_hash(name, len);
+}
+
+attribute_hidden void R_CharHashPrefetchBucket(unsigned int hash)
+{
+    PREFETCH(VECTOR_PTR_RO(R_StringHash) + (hash & char_hash_mask));
+}
+
+attribute_hidden void R_CharHashPrefetchChain(unsigned int hash)
+{
+    SEXP chain = VECTOR_ELT(R_StringHash, hash & char_hash_mask);
+
+    if (chain != R_NilValue)
+	PREFETCH(chain);
 }
 
 /* #define DEBUG_GLOBAL_STRING_HASH 1 */
@@ -4742,6 +4821,14 @@ static void reportInvalidString(SEXP cval, int actionWhenInvalid)
 
 SEXP mkCharLenCE(const char *name, int len, cetype_t enc)
 {
+    return R_mkCharLenCEHash(name, len, enc, char_hash(name, len));
+}
+
+/* As mkCharLenCE(), with the hash of the bytes already computed by
+   R_CharHash(), for callers which prefetch ahead of the lookup. */
+attribute_hidden SEXP
+R_mkCharLenCEHash(const char *name, int len, cetype_t enc, unsigned int hash)
+{
     SEXP cval, chain;
     unsigned int hashcode;
     int need_enc;
@@ -4790,7 +4877,7 @@ SEXP mkCharLenCE(const char *name, int len, cetype_t enc)
     default: need_enc = 0;
     }
 
-    hashcode = char_hash(name, len) & char_hash_mask;
+    hashcode = hash & char_hash_mask;
 
     /* Search for a cached value */
     cval = R_NilValue;
@@ -4833,14 +4920,15 @@ SEXP mkCharLenCE(const char *name, int len, cetype_t enc)
 	/* this is a destructive modification */
 	chain = SET_CXTAIL(cval, chain);
 	SET_VECTOR_ELT(R_StringHash, hashcode, chain);
+	R_StringHashCount++;
 
 	/* resize the hash table if necessary with the new entry still
 	   protected.
 	   Maximum possible power of two is 2^30 for a VECSXP.
 	   FIXME: this has changed with long vectors.
 	*/
-	if (R_HashSizeCheck(R_StringHash)
-	    && char_hash_size < 1073741824 /* 2^30 */)
+	if ((double) R_StringHashCount > char_hash_load * char_hash_size
+	    && char_hash_size < CHAR_HASH_SIZE_MAX)
 	    R_StringHash_resize(char_hash_size * 2);
 
 	if (checkValid && !IS_ASCII(cval)) {

--- a/src/main/envir.c
+++ b/src/main/envir.c
@@ -4615,6 +4615,21 @@ static double char_hash_load = 0.75;
 					 a VECSXP could hold before long
 					 vectors */
 
+static unsigned char *NewStringHashAges(unsigned int size);
+
+/* Bucket heads are stored without the old-to-new write barrier.  The
+   cache is weak and the collector maintains it explicitly (see
+   RunGenCollect), so recording the table as an old node with young
+   children is not needed for correctness, and it is expensive: the
+   collector would forward every bucket head on every collection, which
+   touches a header per bucket, and would keep young heads alive through
+   the minor collections which should have reclaimed them. */
+static R_INLINE void SetStringHashBucket(SEXP table, unsigned int i,
+					 SEXP chain)
+{
+    ((SEXP *) STDVEC_DATAPTR(table))[i] = chain;
+}
+
 static unsigned int char_hash(const char *s, int len)
 {
     /* djb2 as from http://www.cse.yorku.ca/~oz/hash.html */
@@ -4660,6 +4675,19 @@ attribute_hidden void InitStringHash(void)
 
     R_StringHash = R_NewHashTable(char_hash_size);
     R_StringHashCount = 0;
+    R_StringHashAges = NewStringHashAges(char_hash_size);
+}
+
+/* Ages for a new table of the given size, all marked as holding a new
+   node so that the next collection sweeps every bucket and records the
+   truth.  The collector copes with NULL by sweeping everything. */
+static unsigned char *NewStringHashAges(unsigned int size)
+{
+    unsigned char *ages = (unsigned char *) malloc(size);
+
+    if (ages != NULL)
+	memset(ages, 0, size);
+    return ages;
 }
 
 /* Helpers for code which interns many strings in a row, such as
@@ -4716,6 +4744,7 @@ static void R_StringHash_resize(unsigned int newsize)
        therefore the only point where GC can occur. */
     new_table = R_NewHashTable(newsize);
     newmask = newsize - 1;
+    unsigned char *new_ages = NewStringHashAges(newsize);
 
     /* transfer chains from old table to new table */
     for (counter = 0; counter < LENGTH(old_table); counter++) {
@@ -4725,19 +4754,18 @@ static void R_StringHash_resize(unsigned int newsize)
 	    next = CXTAIL(chain);
 	    new_hashcode = char_hash(CHAR(val), LENGTH(val)) & newmask;
 	    new_chain = VECTOR_ELT(new_table, new_hashcode);
-	    /* If using a primary slot then increase HASHPRI */
-	    if (ISNULL(new_chain))
-		SET_HASHPRI(new_table, HASHPRI(new_table) + 1);
 	    /* move the current chain link to the new chain */
 	    /* this is a destructive modification */
 	    new_chain = SET_CXTAIL(val, new_chain);
-	    SET_VECTOR_ELT(new_table, new_hashcode, new_chain);
+	    SetStringHashBucket(new_table, new_hashcode, new_chain);
 	    chain = next;
 	}
     }
     R_StringHash = new_table;
     char_hash_size = newsize;
     char_hash_mask = newmask;
+    free(R_StringHashAges);
+    R_StringHashAges = new_ages;
 #ifdef DEBUG_GLOBAL_STRING_HASH
     newsize = HASHSIZE(new_table);
     newpri = HASHPRI(new_table);
@@ -4915,12 +4943,12 @@ R_mkCharLenCEHash(const char *name, int len, cetype_t enc, unsigned int hash)
 	SET_CACHED(cval);  /* Mark it */
 	/* add the new value to the cache */
 	chain = VECTOR_ELT(R_StringHash, hashcode);
-	if (ISNULL(chain))
-	    SET_HASHPRI(R_StringHash, HASHPRI(R_StringHash) + 1);
 	/* this is a destructive modification */
 	chain = SET_CXTAIL(cval, chain);
-	SET_VECTOR_ELT(R_StringHash, hashcode, chain);
+	SetStringHashBucket(R_StringHash, hashcode, chain);
 	R_StringHashCount++;
+	if (R_StringHashAges != NULL)
+	    R_StringHashAges[hashcode] = 0; /* the bucket now holds a new node */
 
 	/* resize the hash table if necessary with the new entry still
 	   protected.

--- a/src/main/envir.c
+++ b/src/main/envir.c
@@ -3172,7 +3172,7 @@ static int BuiltinSize(int all, int intern)
     int count = 0;
     SEXP s;
     int j;
-    for (j = 0; j < HSIZE; j++) {
+    for (j = 0; j < R_SymbolTableSize; j++) {
 	for (s = R_SymbolTable[j]; s != R_NilValue; s = CDR(s)) {
 	    if (intern) {
 		if (INTERNAL(CAR(s)) != R_NilValue)
@@ -3193,7 +3193,7 @@ BuiltinNames(int all, int intern, SEXP names, int *indx)
 {
     SEXP s;
     int j;
-    for (j = 0; j < HSIZE; j++) {
+    for (j = 0; j < R_SymbolTableSize; j++) {
 	for (s = R_SymbolTable[j]; s != R_NilValue; s = CDR(s)) {
 	    if (intern) {
 		if (INTERNAL(CAR(s)) != R_NilValue)
@@ -3213,7 +3213,7 @@ BuiltinValues(int all, int intern, SEXP values, int *indx)
 {
     SEXP s, vl;
     int j;
-    for (j = 0; j < HSIZE; j++) {
+    for (j = 0; j < R_SymbolTableSize; j++) {
 	for (s = R_SymbolTable[j]; s != R_NilValue; s = CDR(s)) {
 	    if (intern) {
 		if (INTERNAL(CAR(s)) != R_NilValue) {
@@ -3694,7 +3694,7 @@ void R_LockEnvironment(SEXP env, Rboolean bindings)
 	if (bindings) {
 	    SEXP s;
 	    int j;
-	    for (j = 0; j < HSIZE; j++)
+	    for (j = 0; j < R_SymbolTableSize; j++)
 		for (s = R_SymbolTable[j]; s != R_NilValue; s = CDR(s))
 		    if(SYMVALUE(CAR(s)) != R_UnboundValue)
 			LOCK_BINDING(CAR(s));

--- a/src/main/memory.c
+++ b/src/main/memory.c
@@ -1879,6 +1879,7 @@ static int RunGenCollect(R_size_t size_needed)
     {
 	SEXP t;
 	int nc = 0;
+	R_xlen_t ne = 0;
 	for (i = 0; i < LENGTH(R_StringHash); i++) {
 	    s = VECTOR_ELT_0(R_StringHash, i);
 	    t = R_NilValue;
@@ -1893,12 +1894,14 @@ static int RunGenCollect(R_size_t size_needed)
 		}
 		FORWARD_NODE(s);
 		FORWARD_NODE(CXHEAD(s));
+		ne++;
 		t = s;
 		s = CXTAIL(s);
 	    }
 	    if(VECTOR_ELT_0(R_StringHash, i) != R_NilValue) nc++;
 	}
 	SET_TRUELENGTH(R_StringHash, nc); /* SET_HASHPRI, really */
+	R_StringHashCount = ne;
     }
     /* chains are known to be marked so don't need to scan again */
     FORWARD_AND_PROCESS_ONE_NODE(R_StringHash, VECSXP);

--- a/src/main/memory.c
+++ b/src/main/memory.c
@@ -1923,8 +1923,6 @@ static int RunGenCollect(R_size_t size_needed)
 		    removed++;
 		    continue;
 		}
-		FORWARD_NODE(s);
-		FORWARD_NODE(CXHEAD(s));
 		unsigned char age = (unsigned char) (NODE_GENERATION(s) + 1);
 		if (age < youngest)
 		    youngest = age;

--- a/src/main/memory.c
+++ b/src/main/memory.c
@@ -1874,13 +1874,43 @@ static int RunGenCollect(R_size_t size_needed)
 
     DEBUG_CHECK_NODE_COUNTS("after processing forwarded list");
 
-    /* process CHARSXP cache */
+    /* process CHARSXP cache: drop the CHARSXPs which did not survive.
+       Only nodes of the generations being collected can have died, and
+       each bucket records the age of its youngest node, so the buckets
+       whose youngest node is older than that are skipped without being
+       touched.  For the survivors the sweep records the age they will
+       have once this collection has promoted them, which is their
+       generation index plus one: nodes moved out of a collected old
+       generation already carry their new index (see the unmark loop
+       above) and nodes from New space are about to enter Old[0]. */
     if (R_StringHash != NULL) /* in case of GC during initialization */
     {
 	SEXP t;
-	int nc = 0;
-	R_xlen_t ne = 0;
-	for (i = 0; i < LENGTH(R_StringHash); i++) {
+	unsigned char *ages = R_StringHashAges;
+	int level = num_old_gens_to_collect;
+	R_xlen_t removed = 0;
+	int n = LENGTH(R_StringHash);
+	for (i = 0; i < n; i++) {
+	    if (ages != NULL) {
+		/* Eight buckets at a time: ages are 0 to 3, so a word
+		   holds no age 0 if it has no zero byte, and no age 0 or
+		   1 if every byte has bit 1 set. */
+		if (level < 2 && i % 8 == 0 && i + 8 <= n) {
+		    uint64_t w;
+		    memcpy(&w, ages + i, 8);
+		    bool none = level == 0 ?
+			((w - 0x0101010101010101ULL) & ~w &
+			 0x8080808080808080ULL) == 0 :
+			(w & 0x0202020202020202ULL) == 0x0202020202020202ULL;
+		    if (none) {
+			i += 7;
+			continue;
+		    }
+		}
+		if (ages[i] > level)
+		    continue;
+	    }
+	    unsigned char youngest = R_STRINGHASH_EMPTY;
 	    s = VECTOR_ELT_0(R_StringHash, i);
 	    t = R_NilValue;
 	    while (s != R_NilValue) {
@@ -1890,18 +1920,21 @@ static int RunGenCollect(R_size_t size_needed)
 		    else
 			CXTAIL(t) = CXTAIL(s);
 		    s = CXTAIL(s);
+		    removed++;
 		    continue;
 		}
 		FORWARD_NODE(s);
 		FORWARD_NODE(CXHEAD(s));
-		ne++;
+		unsigned char age = (unsigned char) (NODE_GENERATION(s) + 1);
+		if (age < youngest)
+		    youngest = age;
 		t = s;
 		s = CXTAIL(s);
 	    }
-	    if(VECTOR_ELT_0(R_StringHash, i) != R_NilValue) nc++;
+	    if (ages != NULL)
+		ages[i] = youngest;
 	}
-	SET_TRUELENGTH(R_StringHash, nc); /* SET_HASHPRI, really */
-	R_StringHashCount = ne;
+	R_StringHashCount -= removed;
     }
     /* chains are known to be marked so don't need to scan again */
     FORWARD_AND_PROCESS_ONE_NODE(R_StringHash, VECSXP);

--- a/src/main/memory.c
+++ b/src/main/memory.c
@@ -1786,7 +1786,7 @@ static int RunGenCollect(R_size_t size_needed)
     FORWARD_NODE(R_print.na_string_noquote);
 
     if (R_SymbolTable != NULL)             /* in case of GC during startup */
-	for (i = 0; i < HSIZE; i++) {      /* Symbol table */
+	for (i = 0; i < R_SymbolTableSize; i++) { /* Symbol table */
 	    FORWARD_NODE(R_SymbolTable[i]);
 	    SEXP s;
 	    for (s = R_SymbolTable[i]; s != R_NilValue; s = CDR(s))

--- a/src/main/names.c
+++ b/src/main/names.c
@@ -1216,11 +1216,35 @@ static SEXP mkSymMarker(SEXP pname)
     return ans;
 }
 
+/* the smallest prime not less than n, for n >= 2 */
+static int next_prime(int n)
+{
+    for (;; n++) {
+	int prime = 1;
+	for (int d = 2; d * d <= n; d++)
+	    if (n % d == 0) {
+		prime = 0;
+		break;
+	    }
+	if (prime)
+	    return n;
+    }
+}
+
 /* initialize the symbol table */
 attribute_hidden void InitNames(void)
 {
-    /* allocate the symbol table */
-    if (!(R_SymbolTable = (SEXP *) calloc(HSIZE, sizeof(SEXP))))
+    /* allocate the symbol table; R_SYMBOL_TABLE_SIZE in the environment
+       overrides the default number of buckets, rounded up to a prime
+       since the hash is reduced by division */
+    R_SymbolTableSize = HSIZE;
+    const char *arg = getenv("R_SYMBOL_TABLE_SIZE");
+    if (arg != NULL && arg[0]) {
+	double size = atof(arg);
+	if (1024 <= size && size <= 67108864 /* 2^26 */)
+	    R_SymbolTableSize = next_prime((int) size);
+    }
+    if (!(R_SymbolTable = (SEXP *) calloc(R_SymbolTableSize, sizeof(SEXP))))
 	R_Suicide("couldn't allocate memory for symbol table");
 
     /* Create marker values */
@@ -1244,7 +1268,7 @@ attribute_hidden void InitNames(void)
     MARK_NOT_MUTABLE(R_BlankScalarString);
 
     /* Initialize the symbol Table */
-    for (int i = 0; i < HSIZE; i++) R_SymbolTable[i] = R_NilValue;
+    for (int i = 0; i < R_SymbolTableSize; i++) R_SymbolTable[i] = R_NilValue;
 
     /* Set up a set of globals so that a symbol table search can be
        avoided when matching something like dim or dimnames. */
@@ -1265,6 +1289,15 @@ attribute_hidden void InitNames(void)
 
 
 /*  install - probe the symbol table */
+/* The symbol table is a chained hash table with a fixed number of
+   buckets, chosen when R starts up (see InitNames).  Symbols are never
+   removed.  Walking a chain costs about three cache misses per node
+   (the cons cell, the symbol and its print name), so a session which
+   creates many more symbols than there are buckets, such as one
+   holding an environment with a million keys, pays for it on every
+   lookup.  A session with the standard packages attached holds about
+   ten thousand symbols. */
+
 /*  If "name" is not found, it is installed in the symbol table.
     The symbol corresponding to the string "name" is returned. */
 
@@ -1274,7 +1307,7 @@ SEXP install(const char *name)
     int i, hashcode;
 
     hashcode = R_Newhashpjw(name);
-    i = hashcode % HSIZE;
+    i = hashcode % R_SymbolTableSize;
     /* Check to see if the symbol is already present;  if it is, return it. */
     for (sym = R_SymbolTable[i]; sym != R_NilValue; sym = CDR(sym))
 	if (strcmp(name, CHAR(PRINTNAME(CAR(sym)))) == 0) return (CAR(sym));
@@ -1307,7 +1340,7 @@ SEXP installNoTrChar(SEXP charSXP)
     } else {
 	hashcode = HASHVALUE(charSXP);
     }
-    i = hashcode % HSIZE;
+    i = hashcode % R_SymbolTableSize;
     /* Check to see if the symbol is already present;  if it is, return it. */
     for (sym = R_SymbolTable[i]; sym != R_NilValue; sym = CDR(sym))
 	if (strcmp(CHAR(charSXP), CHAR(PRINTNAME(CAR(sym)))) == 0) return (CAR(sym));

--- a/src/main/serialize.c
+++ b/src/main/serialize.c
@@ -1775,6 +1775,21 @@ ReadChar(R_inpstream_t stream, char *buf, int length, int levs)
     return mkCharLenCE(buf, length, CE_NATIVE);
 }
 
+/* Read the body of a CHARSXP whose length is known */
+static SEXP ReadCharsxp(R_inpstream_t stream, int length, int levs)
+{
+    /* these are currently limited to 2^31 -1 bytes */
+    if (length < 1000) {
+	char cbuf[length+1];
+	return ReadChar(stream, cbuf, length, levs);
+    } else {
+	char *cbuf = CallocCharBuf(length);
+	SEXP s = ReadChar(stream, cbuf, length, levs);
+	R_Free(cbuf);
+	return s;
+    }
+}
+
 static R_xlen_t ReadLENGTH (R_inpstream_t stream)
 {
     int len = InInteger(stream);
@@ -1884,6 +1899,134 @@ static SEXP ReadItem_Iterative(int flags, SEXP ref_table, R_inpstream_t stream)
     return sfirst;
 }
 
+
+/*
+ * Reading character vectors
+ *
+ * Nearly every element of a STRSXP is a plain CHARSXP, and the dominant
+ * cost of reading one is not the stream but the lookup in the CHARSXP
+ * cache: the hash bucket and the chain hanging off it are cache misses
+ * on memory scattered across the heap.  Elements are therefore read in
+ * batches.  The bytes of each string are read first, its hash computed
+ * and its bucket prefetched; when a batch is complete the heads of its
+ * chains are prefetched too, and the cache is only consulted after the
+ * next batch has been read, by which time the memory has arrived.
+ * Anything unusual -- attributes, references, strings which may need
+ * encoding translation, or long strings -- takes the general path
+ * element by element.  Elements are stored by index, so the order in
+ * which they are interned does not matter.
+ */
+
+#define STRBATCH_SIZE 16
+#define STRBATCH_SCRATCH 16384
+
+typedef struct {
+    R_xlen_t index;
+    int offset, length;
+    cetype_t enc;
+    unsigned int hash;
+} strbatch_item_t;
+
+typedef struct {
+    int n, used;
+    char *scratch;
+    strbatch_item_t item[STRBATCH_SIZE];
+} strbatch_t;
+
+static void InternStringBatch(SEXP s, strbatch_t *b)
+{
+    for (int i = 0; i < b->n; i++) {
+	strbatch_item_t *it = b->item + i;
+	SET_STRING_ELT(s, it->index,
+		       R_mkCharLenCEHash(b->scratch + it->offset, it->length,
+					 it->enc, it->hash));
+    }
+    b->n = 0;
+    b->used = 0;
+}
+
+/* the encoding ReadChar() would hand to mkCharLenCE() for these flags,
+   or CE_ANY when the string may need translating */
+static R_INLINE cetype_t BatchEncoding(int levs)
+{
+    if (levs & UTF8_MASK)
+	return CE_UTF8;
+    if (levs & LATIN1_MASK)
+	return CE_LATIN1;
+    if (levs & BYTES_MASK)
+	return CE_BYTES;
+    if (levs & ASCII_MASK)
+	return CE_NATIVE;
+    return CE_ANY;
+}
+
+static void ReadStringVec(SEXP ref_table, R_inpstream_t stream, SEXP s,
+			  R_xlen_t len)
+{
+    const void *vmax = vmaxget();
+    strbatch_t batches[2], *cur = &batches[0], *prev = &batches[1];
+
+    for (int i = 0; i < 2; i++) {
+	batches[i].n = batches[i].used = 0;
+	batches[i].scratch = R_alloc(STRBATCH_SCRATCH, 1);
+    }
+
+    for (R_xlen_t count = 0; count < len; count++) {
+	int flags = InInteger(stream);
+	SEXPTYPE type;
+	int levs, objf, hasattr, hastag;
+
+	UnpackFlags(flags, &type, &levs, &objf, &hasattr, &hastag);
+	if (type != CHARSXP || hasattr || objf) {
+	    SET_STRING_ELT(s, count,
+			   ReadItem_Recursive(flags, ref_table, stream));
+	    continue;
+	}
+
+	int length = InInteger(stream);
+	if (length < -1)
+	    error(_("invalid length"));
+	if (length == -1) {
+	    SET_STRING_ELT(s, count, NA_STRING);
+	    continue;
+	}
+	cetype_t enc = BatchEncoding(levs);
+	if (enc == CE_ANY || length >= STRBATCH_SCRATCH) {
+	    SET_STRING_ELT(s, count, ReadCharsxp(stream, length, levs));
+	    continue;
+	}
+
+	if (cur->n == STRBATCH_SIZE ||
+	    cur->used + length + 1 > STRBATCH_SCRATCH) {
+	    /* the current batch is complete: its buckets have had time
+	       to arrive, so prefetch the chain heads, then intern the
+	       previous batch and start a new one in its place */
+	    for (int i = 0; i < cur->n; i++)
+		R_CharHashPrefetchChain(cur->item[i].hash);
+	    InternStringBatch(s, prev);
+	    strbatch_t *tmp = prev;
+	    prev = cur;
+	    cur = tmp;
+	}
+
+	char *buf = cur->scratch + cur->used;
+	InString(stream, buf, length);
+	buf[length] = '\0';
+
+	strbatch_item_t *it = cur->item + cur->n++;
+	it->index = count;
+	it->offset = cur->used;
+	it->length = length;
+	it->enc = enc;
+	it->hash = R_CharHash(buf, length);
+	R_CharHashPrefetchBucket(it->hash);
+	cur->used += length + 1;
+    }
+
+    InternStringBatch(s, prev);
+    InternStringBatch(s, cur);
+    vmaxset(vmax);
+}
 
 static SEXP ReadItem_Recursive (int flags, SEXP ref_table, R_inpstream_t stream)
 {
@@ -2017,20 +2160,13 @@ static SEXP ReadItem_Recursive (int flags, SEXP ref_table, R_inpstream_t stream)
 	    }
 	    break;
 	case CHARSXP:
-	    /* these are currently limited to 2^31 -1 bytes */
 	    length = InInteger(stream);
 	    if (length < -1)
 		error(_("invalid length"));
 	    else if (length == -1)
 		PROTECT(s = NA_STRING);
-	    else if (length < 1000) {
-		char cbuf[length+1];
-		PROTECT(s = ReadChar(stream, cbuf, length, levs));
-	    } else {
-		char *cbuf = CallocCharBuf(length);
-		PROTECT(s = ReadChar(stream, cbuf, length, levs));
-		R_Free(cbuf);
-	    }
+	    else
+		PROTECT(s = ReadCharsxp(stream, length, levs));
 	    break;
 	case LGLSXP:
 	case INTSXP:
@@ -2052,8 +2188,7 @@ static SEXP ReadItem_Recursive (int flags, SEXP ref_table, R_inpstream_t stream)
 	    len = ReadLENGTH(stream);
 	    PROTECT(s = allocVector(type, len));
 	    R_ReadItemDepth++;
-	    for (count = 0; count < len; ++count)
-		SET_STRING_ELT(s, count, ReadItem(ref_table, stream));
+	    ReadStringVec(ref_table, stream, s, len);
 	    R_ReadItemDepth--;
 	    break;
 	case VECSXP:

--- a/src/main/serialize.c
+++ b/src/main/serialize.c
@@ -1917,7 +1917,9 @@ static SEXP ReadItem_Iterative(int flags, SEXP ref_table, R_inpstream_t stream)
  * which they are interned does not matter.
  */
 
-#define STRBATCH_SIZE 16
+/* 32 measured 2 to 4% faster than 16 for an in-memory unserialize() of
+   a million strings, and 64 the same as 32 */
+#define STRBATCH_SIZE 32
 #define STRBATCH_SCRATCH 16384
 
 typedef struct {

--- a/tests/reg-tests-1e.R
+++ b/tests/reg-tests-1e.R
@@ -3729,6 +3729,22 @@ Sys.unsetenv(c("R_CHARSXP_CACHE_LOAD_FACTOR", "R_CHARSXP_CACHE_INITIAL_SIZE",
                "R_SYMBOL_TABLE_SIZE"))
 stopifnot(identical(out, "ok"))
 unlink(tf)
+## The collector only sweeps the buckets of the cache which hold strings
+## young enough to have died: churn strings through several generations
+## with frequent collections of every level, then check that what is
+## looked up is what was kept.
+keep <- paste0("keep", 1:20000)
+gctorture2(step = 2000)
+for(i in 1:6) {
+    tmp <- paste0("tmp", i, "_", 1:20000)
+    keep2 <- paste0("keep", 1:20000)
+    rm(tmp)
+}
+gctorture2(step = 0)
+invisible(gc())
+stopifnot(identical(keep2, keep), identical(unique(c(keep, keep2)), keep),
+          identical(match(paste0("keep", c(1, 20000)), keep2), c(1L, 20000L)))
+rm(keep, keep2)
 ## new in R 4.7.0
 
 

--- a/tests/reg-tests-1e.R
+++ b/tests/reg-tests-1e.R
@@ -3699,6 +3699,34 @@ stopifnot(
     identical(drop(aperm(a, c(1, 2, 3), resize = FALSE)), aperm(m, c(1, 2), resize = FALSE))
 )
 
+## The CHARSXP cache doubles at a configurable load factor, and
+## unserialize() reads character vectors in batches which prefetch the
+## cache: strings of every encoding, NA, empty, repeated and long strings
+## must round trip with their encodings, and a session started with a
+## tiny table and a low load factor (forcing many resizes) must work.
+x <- c(NA, "", "ascii", "\u00e9l\u00e8ve", iconv("caf\u00e9", "UTF-8", "latin1"),
+       strrep("z", 20000), paste0("id", 1:5000), "\u00e9", "ascii")
+y <- "\xff\xfe"; Encoding(y) <- "bytes"; x <- c(x, y)
+tf <- tempfile(fileext = ".rds")
+for(compress in c(TRUE, FALSE)) {
+    saveRDS(x, tf, compress = compress)
+    r <- readRDS(tf)
+    stopifnot(identical(r, x), identical(Encoding(r), Encoding(x)))
+}
+saveRDS(x, tf, ascii = TRUE)
+r <- readRDS(tf)
+stopifnot(identical(r, x), identical(Encoding(r), Encoding(x)))
+writeLines(c('x <- paste0("s", 1:2e5)',
+             'stopifnot(!anyDuplicated(x), identical(match(x, rev(x)), rev(seq_along(x))))',
+             'cat("ok\\n")'), tf)
+Sys.setenv(R_CHARSXP_CACHE_LOAD_FACTOR = "0.2", R_CHARSXP_CACHE_INITIAL_SIZE = "1024")
+out <- system2(file.path(R.home("bin"), "Rscript"), c("--vanilla", tf), stdout = TRUE)
+Sys.unsetenv(c("R_CHARSXP_CACHE_LOAD_FACTOR", "R_CHARSXP_CACHE_INITIAL_SIZE"))
+stopifnot(identical(out, "ok"))
+unlink(tf)
+## new in R 4.7.0
+
+
 ## keep at end
 rbind(last =  proc.time() - .pt,
       total = proc.time())

--- a/tests/reg-tests-1e.R
+++ b/tests/reg-tests-1e.R
@@ -3718,10 +3718,15 @@ r <- readRDS(tf)
 stopifnot(identical(r, x), identical(Encoding(r), Encoding(x)))
 writeLines(c('x <- paste0("s", 1:2e5)',
              'stopifnot(!anyDuplicated(x), identical(match(x, rev(x)), rev(seq_along(x))))',
+             'e <- list2env(setNames(as.list(seq_along(x)), x))',
+             'stopifnot(identical(unname(unlist(mget(x[c(1, 77777, 2e5)], e))), c(1L, 77777L, 200000L)),',
+             '          identical(as.name(x[5]), as.symbol("s5")))',
              'cat("ok\\n")'), tf)
-Sys.setenv(R_CHARSXP_CACHE_LOAD_FACTOR = "0.2", R_CHARSXP_CACHE_INITIAL_SIZE = "1024")
+Sys.setenv(R_CHARSXP_CACHE_LOAD_FACTOR = "0.2", R_CHARSXP_CACHE_INITIAL_SIZE = "1024",
+           R_SYMBOL_TABLE_SIZE = "1024")
 out <- system2(file.path(R.home("bin"), "Rscript"), c("--vanilla", tf), stdout = TRUE)
-Sys.unsetenv(c("R_CHARSXP_CACHE_LOAD_FACTOR", "R_CHARSXP_CACHE_INITIAL_SIZE"))
+Sys.unsetenv(c("R_CHARSXP_CACHE_LOAD_FACTOR", "R_CHARSXP_CACHE_INITIAL_SIZE",
+               "R_SYMBOL_TABLE_SIZE"))
 stopifnot(identical(out, "ok"))
 unlink(tf)
 ## new in R 4.7.0


### PR DESCRIPTION
## Summary

After #315, string-heavy `readRDS()` is bound by the CHARSXP cache: over half the time is `mkCharLenCE()` and its `memcmp`, nearly all of it cache misses. A harness calling `mkCharLenCE()` directly on a million cached 13-character strings measured 30 ns per hit with everything in cache, 57 ns in allocation order, 90 ns in random order, and 158 ns per miss (allocate and insert). This PR roughly halves those, independently of #315, and makes the two knobs configurable.

## What was wrong

The cache is a power-of-two bucket array with the CHARSXPs of each bucket chained through their `ATTRIB` fields, so every chain node visited is a miss on a scattered heap object. The resize trigger counted *occupied buckets* and fired at 85%, which is about 1.9 entries per bucket. A temporary print at resize time confirmed the table lives between 1.0 and 1.9 entries per bucket for its whole life, and an insertion walks the whole chain, so each new string cost about two misses before it was even allocated.

## Changes

- **Load factor.** The table now counts its entries exactly (`R_StringHashCount`, maintained on insert and recomputed by the collector's sweep of the cache) and doubles at 0.75 entries per bucket. The occupancy-based `R_HashSizeCheck()` is still used for environment tables.
- **Configuration at startup.** `R_CHARSXP_CACHE_LOAD_FACTOR` (0.1 to 10, default 0.75) and `R_CHARSXP_CACHE_INITIAL_SIZE` (1024 to 2^30, rounded up to a power of two, default 65536) are read in `InitStringHash()`; out-of-range values are ignored, as for the `R_GC_*` variables. The initial size matters at the top end: a session that interns 50 million strings otherwise rehashes about 100 million entries on the way up. Documented in `?EnvVar` and the R Internals section on the cache.
- **Batched, prefetching reader in `unserialize()`.** `ReadStringVec()` reads the elements of a STRSXP in batches of 16: each string's bytes are read into scratch and hashed, its bucket prefetched; once a batch is complete the chain heads are prefetched, and the cache is consulted only after the *next* batch has been read, so the misses overlap with reading. Elements are stored by index, so interning order does not matter. Anything unusual (attributes, references, `OBJECT` bit, strings that may need encoding translation, strings of 16 KB or more) takes the general path element by element. Three hidden helpers in `envir.c` support this: `R_CharHash()`, the two prefetch functions, and `R_mkCharLenCEHash()`, which is `mkCharLenCE()` with a precomputed hash and now its implementation.
- Regression test: round trips of NA, empty, ASCII, UTF-8, latin1 and bytes-encoded strings, repeats and a 20 KB string through gzip, uncompressed and ascii formats, checking the declared encodings survive; and a child `Rscript` started with a 1024-bucket table and load factor 0.2, forcing many resizes.

## Tried and rejected: mixing the hash

`djb2` masked to a power of two leaves the low bits of keys that differ only in a running number correlated, so such keys cluster and their chains are about 20% longer than random keys'. Adding MurmurHash3's finalizer fixed that on paper (chain statistics for `id123456`-style keys went from 1.86 to 1.55 per occupied bucket) but made collections with millions of cached strings *four times slower* and inserts of sequential strings slower too: the correlation means a run of such strings lands in neighbouring buckets, so it is inserted, and later walked by the collector, in nearly sequential memory order. A prime table size would lose the same locality. This is recorded in a comment on `char_hash()`.

## Tried and rejected: open addressing with linear probing

An open-addressed table was implemented on top of this branch and measured: 16-byte slots holding the pointer and the full hash, so that a probe compares hashes without touching strings, backward-shift deletion driven from the collector's sweep, per-slot ages, and the table allocated with `R_Calloc` rather than as a VECSXP (a CHARSXP then never has an `ATTRIB`). It passed the stress tests but is not faster overall.

Linear probing cannot index by the low bits of `djb2`: keys that differ in a running number form runs of adjacent slots which coalesce into clusters, and a simulation of a million `string_N` keys at 48% load gives 28 probes per hit (maximum 4370); folding the high bits into the index still leaves 10 to 17. So the table has to mix the hash (Fibonacci hashing), and that gives up the locality the chained table gets for free from the same keys: consecutive keys land in consecutive buckets, so bulk inserts and allocation-order lookups walk the bucket array sequentially. Nanoseconds per `mkCharLenCE()` unless noted, a million cached strings, aarch64 macOS, `-O2`; the middle column is the chained table with only the mix added, to separate the two effects:

| case | chained, low bits (this PR) | chained + mix | open addressing + mix |
|---|---|---|---|
| hit, random order, random 8-letter words | 61 | 60 | 49 |
| hit, random order, zero-padded ids | 65 | 61 | 56 |
| hit, allocation order, `string_N` keys | 29 | 42 | 44 |
| miss, 1e6 consecutive keys | 87 | 168 | 156 |
| miss, 1e6 random keys | 173 | 175 | 154 |
| `readRDS()` of 1e6 `string_N` keys from gzip (s) | 0.139 | 0.137 | 0.135 |
| 3e6 short-lived strings in 600 rounds (ms) | 657 | 780 | 869 |
| full collection holding 1e6 strings (ms) | 39 | 43 | 37 |
| bytes of table per slot | 8 | 8 | 16 |

Open addressing wins 10 to 20% on random-order lookups and random-key misses, where the stored hash saves touching the other strings of a bucket, and loses 50 to 80% on consecutive-key inserts and allocation-order hits and 30% on string churn, at twice the table memory. `readRDS()` is within noise either way. The middle column also re-confirms the decision above not to mix the hash, for a second reason now that the third commit has made the collector's sweep cheap: the cost of mixing is the locality of inserts and lookups, not only the order of the sweep.

## Measurements

aarch64 macOS, `-O2`, this branch against its base (no #315 in either). Harness, ns per `mkCharLenCE()` call, a million cached strings:

| case | before | after |
|---|---|---|
| hit, everything in L1/L2 | 30 | 14 |
| hit, allocation order | 57 | 28 |
| hit, random order | 90 | 66 |
| miss (allocate, insert, grow) | 158 | 92 |

`readRDS()` of a million distinct strings, best of 5, seconds. The last row forces the old load factor through the new variable to show the batched reader on its own:

| build | gz | uncompressed | in memory |
|---|---|---|---|
| base | 0.234 | 0.197 | 0.148 |
| this PR | 0.147 | 0.108 | 0.056 |
| this PR with `R_CHARSXP_CACHE_LOAD_FACTOR=1.9` | 0.160 | 0.123 | 0.070 |

Cost of a collection against the number of cached strings (the collector scans every bucket and every chain on every collection):

| cached strings | partial GC before | after | full GC before | after |
|---|---|---|---|---|
| 1e6 | 7 ms | 11 ms | 30 ms | 35 ms |
| 5e6 | 30 ms | 39 ms | 104 ms | 115 ms |

The table is up to twice as large: about 12 bytes of bucket array per cached string instead of 5, against 56 or more for the CHARSXP itself. Objects without strings are unchanged.

## Second commit: configurable symbol table size

The symbol table (`R_SymbolTable`) has a fixed 49,157 buckets and never grows. Measured symbol counts: a base-only session holds 2,682 symbols, a default session 6,981, and one that has fitted and plotted models, run `example(lm)` and friends and attached every standard package about 11,000, a load of 0.23. So the default is fine for ordinary use. But symbols are never removed, and a session that interns a million of them (any environment with a million keys does) walks chains of about 20 on every lookup, at roughly three cache misses per node: 2 µs per lookup, which dominated the cost of such environments.

Rather than a growing table (a prototype worked, but the table is walked by code that forces promises and can install symbols mid-walk, so growing it safely needs more care than it is worth), the number of buckets can be set at startup with `R_SYMBOL_TABLE_SIZE`, rounded up to a prime. Measured with a million-key environment:

| | insert | `get()` | `mget()` |
|---|---|---|---|
| default 49,157 buckets | 3.5 µs | 2.6 µs | 2.1 µs |
| `R_SYMBOL_TABLE_SIZE=2000000` | 1.8 µs | 1.05 µs | 0.64 µs |

The default stays at 49,157: the collector scans every bucket on every collection, and a four-million-bucket table adds about 2 ms to each partial collection.

## Third commit: sweep only the young part of the cache

Every collection walked the whole cache to unlink dead strings, touching the header of every string a session had ever created. On top of that, bucket heads were stored with `SET_VECTOR_ELT`, whose write barrier put the (old) table on the old-to-new list, so every minor collection also forwarded every bucket head, touching a header per bucket and incidentally keeping young bucket heads alive through the collections that should have reclaimed them.

Two changes, measured independently below. Each bucket now carries one byte, the age of its youngest string: 0 on insert, and after a sweep the generation the survivors are about to be promoted to (their generation index plus one, valid at sweep time because the unmark loop has already advanced the index of nodes moved out of a collected old generation). A collection of level *g* sweeps only buckets whose youngest string has age at most *g*, checking eight ages per word. Promotion through old-to-new references and an escalated collection (`goto again`) can only make the recorded age a lower bound of the truth, which is the safe direction; a resize marks every bucket young so the next collection re-derives exact ages. And bucket heads are stored without the barrier, since the collector maintains the table explicitly.

Average over 20 explicit partial collections (`gc(full = FALSE)`; the average includes the occasional level-1 collection, whose cost is re-marking the strings and is the same in every column) in a session holding cached strings created in sequential order, which `djb2` places in adjacent buckets so the sweep walks them in allocation order, and in hash-random order, which is what a cache filled from data looks like:

| cached strings, order | barrier, no ages (before) | no barrier, no ages | no barrier, ages (this PR) |
|---|---|---|---|
| 1e6 sequential | 11 ms | 6 ms | 0.5 ms |
| 5e6 sequential | 40 ms | 25 ms | 1.6 ms |
| 1e6 random | | 25 ms | 1.6 ms |
| 5e6 random | | 86 ms | 14 ms |

Timed individually, a level-0 collection with 5e6 random strings costs about 77 ms without the ages and 1 to 2 ms with them. Total collector time during 4e6 small allocations, with `gc.time()`, in a session holding hash-random strings: 1e6 strings, 144 ms without the ages and 17 ms with them; 5e6 strings, 230 ms and 6 ms. Full collections drop about a quarter from the barrier change (120 to 87 ms at 5e6 sequential). In-memory `unserialize()` of a million distinct strings goes from 69 to 59 ms with the collector's share of the profile halved; `readRDS()` timings are within noise, since a bulk read of new strings still sweeps the buckets it just filled. A stress script under `gctorture2(step = 300)` churning strings through all generations with resizes, plus a smaller version in the regression tests, passes.

An earlier attempt to measure the barrier change alone set the ages pointer to NULL only at startup, and the first resize allocated a fresh array, so that build had the ages after the first 65,536 strings; the numbers above come from a build with the ages code removed entirely.

## Notes

- Composes with #315: on top of it, the same file reads in 0.114 s from gzip (0.356 s on trunk before either PR).

