### PR TITLE
anchor altstring elt results on a dedicated stack

### DIFF
--- a/src/include/Defn.h
+++ b/src/include/Defn.h
@@ -1427,7 +1427,7 @@ typedef struct RCNTXT {
     void (*cend)(void *);	/* C "on.exit" thunk */
     void *cenddata;		/* data for C "on.exit" thunk */
     void *vmax;		        /* top of R_alloc stack */
-    R_xlen_t eltanchortop;	/* R_EltAnchorTop value */
+    R_xlen_t vmaxtop;		/* vmaxtop value */
     int intsusp;                /* interrupts are suspended */
     int gcenabled;		/* R_GCEnabled value */
     int bcintactive;            /* R_BCIntActive value */
@@ -1588,8 +1588,8 @@ LibExtern int	R_PPStackSize	INI_as(R_PPSSIZE); /* The stack size (elements) */
 LibExtern int	R_PPStackTop;	    /* The top of the stack */
 LibExtern SEXP*	R_PPStack;	    /* The pointer protection stack */
 
-/* The ALTREP element anchor stack (see memory.c) */
-extern0 R_xlen_t R_EltAnchorTop INI_as(0); /* The top of the stack */
+/* The vmax protection stack (see memory.c) */
+extern0 R_xlen_t vmaxtop INI_as(0); /* The top of the stack */
 
 void R_ReleaseMSet(SEXP mset, int keepSize);
 
@@ -2381,8 +2381,8 @@ Rboolean R_SetMaxNSize(R_size_t);
 R_size_t R_Decode2Long(char *p, int *ierr);
 void R_SetPPSize(R_size_t);
 void R_SetNconn(int);
-void R_EltAnchorPush(SEXP);
-void R_EltAnchorRelease(R_xlen_t);
+void vmaxprotect(SEXP);
+void vmaxrelease(R_xlen_t);
 
 void R_expand_binding_value(SEXP);
 #ifdef IMMEDIATE_PROMISE_VALUES

--- a/src/include/Defn.h
+++ b/src/include/Defn.h
@@ -2377,6 +2377,7 @@ Rboolean R_SetMaxNSize(R_size_t);
 R_size_t R_Decode2Long(char *p, int *ierr);
 void R_SetPPSize(R_size_t);
 void R_SetNconn(int);
+void R_VStackAnchor(SEXP);
 
 void R_expand_binding_value(SEXP);
 #ifdef IMMEDIATE_PROMISE_VALUES

--- a/src/include/Defn.h
+++ b/src/include/Defn.h
@@ -1427,6 +1427,7 @@ typedef struct RCNTXT {
     void (*cend)(void *);	/* C "on.exit" thunk */
     void *cenddata;		/* data for C "on.exit" thunk */
     void *vmax;		        /* top of R_alloc stack */
+    R_xlen_t eltanchortop;	/* R_EltAnchorTop value */
     int intsusp;                /* interrupts are suspended */
     int gcenabled;		/* R_GCEnabled value */
     int bcintactive;            /* R_BCIntActive value */
@@ -1586,6 +1587,9 @@ extern0 int	R_Is_Running;	    /* for Windows memory manager */
 LibExtern int	R_PPStackSize	INI_as(R_PPSSIZE); /* The stack size (elements) */
 LibExtern int	R_PPStackTop;	    /* The top of the stack */
 LibExtern SEXP*	R_PPStack;	    /* The pointer protection stack */
+
+/* The ALTREP element anchor stack (see memory.c) */
+extern0 R_xlen_t R_EltAnchorTop INI_as(0); /* The top of the stack */
 
 void R_ReleaseMSet(SEXP mset, int keepSize);
 
@@ -2377,7 +2381,8 @@ Rboolean R_SetMaxNSize(R_size_t);
 R_size_t R_Decode2Long(char *p, int *ierr);
 void R_SetPPSize(R_size_t);
 void R_SetNconn(int);
-void R_VStackAnchor(SEXP);
+void R_EltAnchorPush(SEXP);
+void R_EltAnchorRelease(R_xlen_t);
 
 void R_expand_binding_value(SEXP);
 #ifdef IMMEDIATE_PROMISE_VALUES

--- a/src/main/altrep.c
+++ b/src/main/altrep.c
@@ -529,12 +529,12 @@ SEXP /*attribute_hidden*/ ALTSTRING_ELT(SEXP x, R_xlen_t i)
     val = ALTSTRING_DISPATCH(Elt, x, i);
 
     /* The method may have returned a freshly created CHARSXP that
-       nothing else references.  Anchor it, while GC is still disabled,
+       nothing else references.  Protect it, while GC is still disabled,
        so that it lives at least as long as R_alloc memory obtained
        here would -- the lifetime callers already respect for
-       translateChar() results (see R_EltAnchorPush in memory.c). */
+       translateChar() results (see vmaxprotect() in memory.c). */
     if (val != NULL && val != NA_STRING && val != R_BlankString)
-	R_EltAnchorPush(val);
+	vmaxprotect(val);
 
     R_GCEnabled = enabled;
     return val;

--- a/src/main/altrep.c
+++ b/src/main/altrep.c
@@ -528,6 +528,14 @@ SEXP /*attribute_hidden*/ ALTSTRING_ELT(SEXP x, R_xlen_t i)
 
     val = ALTSTRING_DISPATCH(Elt, x, i);
 
+    /* The method may have returned a freshly created CHARSXP that
+       nothing else references.  Anchor it on the R_alloc stack, while
+       GC is still disabled, so it lives at least until the enclosing
+       vmaxset() -- the same lifetime callers already respect for
+       translateChar() results. */
+    if (val != NULL && val != NA_STRING && val != R_BlankString)
+	R_VStackAnchor(val);
+
     R_GCEnabled = enabled;
     return val;
 }

--- a/src/main/altrep.c
+++ b/src/main/altrep.c
@@ -529,12 +529,12 @@ SEXP /*attribute_hidden*/ ALTSTRING_ELT(SEXP x, R_xlen_t i)
     val = ALTSTRING_DISPATCH(Elt, x, i);
 
     /* The method may have returned a freshly created CHARSXP that
-       nothing else references.  Anchor it on the R_alloc stack, while
-       GC is still disabled, so it lives at least until the enclosing
-       vmaxset() -- the same lifetime callers already respect for
-       translateChar() results. */
+       nothing else references.  Anchor it, while GC is still disabled,
+       so that it lives at least as long as R_alloc memory obtained
+       here would -- the lifetime callers already respect for
+       translateChar() results (see R_EltAnchorPush in memory.c). */
     if (val != NULL && val != NA_STRING && val != R_BlankString)
-	R_VStackAnchor(val);
+	R_EltAnchorPush(val);
 
     R_GCEnabled = enabled;
     return val;

--- a/src/main/context.c
+++ b/src/main/context.c
@@ -177,7 +177,7 @@ static void R_restore_globals(RCNTXT *cptr)
     R_BCFrame = cptr->bcframe;
     R_EvalDepth = cptr->evaldepth;
     vmaxset(cptr->vmax);
-    R_EltAnchorRelease(cptr->eltanchortop);
+    vmaxrelease(cptr->vmaxtop);
     R_interrupts_suspended = (Rboolean) cptr->intsusp;
     R_HandlerStack = cptr->handlerstack;
     R_RestartStack = cptr->restartstack;
@@ -270,7 +270,7 @@ void begincontext(RCNTXT * cptr, int flags,
     cptr->promargs = promargs;
     cptr->callfun = callfun;
     cptr->vmax = vmaxget();
-    cptr->eltanchortop = R_EltAnchorTop;
+    cptr->vmaxtop = vmaxtop;
     cptr->intsusp = R_interrupts_suspended;
     cptr->handlerstack = R_HandlerStack;
     cptr->restartstack = R_RestartStack;

--- a/src/main/context.c
+++ b/src/main/context.c
@@ -177,6 +177,7 @@ static void R_restore_globals(RCNTXT *cptr)
     R_BCFrame = cptr->bcframe;
     R_EvalDepth = cptr->evaldepth;
     vmaxset(cptr->vmax);
+    R_EltAnchorRelease(cptr->eltanchortop);
     R_interrupts_suspended = (Rboolean) cptr->intsusp;
     R_HandlerStack = cptr->handlerstack;
     R_RestartStack = cptr->restartstack;
@@ -269,6 +270,7 @@ void begincontext(RCNTXT * cptr, int flags,
     cptr->promargs = promargs;
     cptr->callfun = callfun;
     cptr->vmax = vmaxget();
+    cptr->eltanchortop = R_EltAnchorTop;
     cptr->intsusp = R_interrupts_suspended;
     cptr->handlerstack = R_HandlerStack;
     cptr->restartstack = R_RestartStack;

--- a/src/main/eval.c
+++ b/src/main/eval.c
@@ -1225,6 +1225,7 @@ SEXP eval(SEXP e, SEXP rho)
 	if (TYPEOF(op) == SPECIALSXP) {
 	    int save = R_PPStackTop, flag = PRIMPRINT(op);
 	    const void *vmax = vmaxget();
+	    R_xlen_t anchors = R_EltAnchorTop;
 	    PROTECT(e);
 	    R_Visible = flag != 1;
 	    tmp = PRIMFUN(op) (e, op, CDR(e), rho);
@@ -1241,10 +1242,12 @@ SEXP eval(SEXP e, SEXP rho)
 	    UNPROTECT(1);
 	    check_stack_balance(op, save);
 	    vmaxset(vmax);
+	    R_EltAnchorRelease(anchors);
 	}
 	else if (TYPEOF(op) == BUILTINSXP) {
 	    int save = R_PPStackTop, flag = PRIMPRINT(op);
 	    const void *vmax = vmaxget();
+	    R_xlen_t anchors = R_EltAnchorTop;
 	    RCNTXT cntxt;
 	    PROTECT(tmp = evalList(CDR(e), rho, e, 0));
 	    if (flag < 2) R_Visible = flag != 1;
@@ -1271,6 +1274,7 @@ SEXP eval(SEXP e, SEXP rho)
 	    UNPROTECT(1);
 	    check_stack_balance(op, save);
 	    vmaxset(vmax);
+	    R_EltAnchorRelease(anchors);
 	}
 	else if (TYPEOF(op) == CLOSXP) {
 	    SEXP pargs = promiseArgs(CDR(e), rho);
@@ -5349,8 +5353,10 @@ static R_INLINE double (*getMath1Fun(int i, SEXP call))(double) {
 	    for (int i = 0; i < nargs; i++)				\
 		cargs[i] = GETSTACK(i - nargs);				\
 	    void *vmax = vmaxget();					\
+	    R_xlen_t anchors = R_EltAnchorTop;				\
 	    SEXP val = R_doDotCall(ofun, nargs, cargs, call);		\
 	    vmaxset(vmax);						\
+	    R_EltAnchorRelease(anchors);				\
 	    R_BCNodeStackTop -= nargs;					\
 	    SETSTACK(-1, val);						\
 	    R_Visible = TRUE;						\
@@ -8132,6 +8138,7 @@ static SEXP bcEval_loop(struct bcEval_locals *ploc)
 	SEXP args = BUILTIN_CALL_FRAME_ARGS();
 	int flag;
 	const void *vmax = vmaxget();
+	R_xlen_t anchors = R_EltAnchorTop;
 	if (TYPEOF(fun) != BUILTINSXP)
 	  error(_("not a BUILTIN function"));
 	flag = PRIMPRINT(fun);
@@ -8151,6 +8158,7 @@ static SEXP bcEval_loop(struct bcEval_locals *ploc)
 	}
 	if (flag < 2) R_Visible = flag != 1;
 	vmaxset(vmax);
+	R_EltAnchorRelease(anchors);
 	POP_CALL_FRAME(value);
 	NEXT();
       }
@@ -8161,6 +8169,7 @@ static SEXP bcEval_loop(struct bcEval_locals *ploc)
 	SEXP fun = getPrimitive(symbol, SPECIALSXP);
 	int flag;
 	const void *vmax = vmaxget();
+	R_xlen_t anchors = R_EltAnchorTop;
 	if (RTRACE(fun)) {
 	  Rprintf("trace: ");
 	  PrintValue(symbol);
@@ -8170,6 +8179,7 @@ static SEXP bcEval_loop(struct bcEval_locals *ploc)
 	SEXP value = PRIMFUN(fun) (call, fun, markSpecialArgs(CDR(call)), rho);
 	if (flag < 2) R_Visible = flag != 1;
 	vmaxset(vmax);
+	R_EltAnchorRelease(anchors);
 	BCNPUSH(value);
 	NEXT();
       }

--- a/src/main/eval.c
+++ b/src/main/eval.c
@@ -1225,7 +1225,7 @@ SEXP eval(SEXP e, SEXP rho)
 	if (TYPEOF(op) == SPECIALSXP) {
 	    int save = R_PPStackTop, flag = PRIMPRINT(op);
 	    const void *vmax = vmaxget();
-	    R_xlen_t anchors = R_EltAnchorTop;
+	    R_xlen_t vtop = vmaxtop;
 	    PROTECT(e);
 	    R_Visible = flag != 1;
 	    tmp = PRIMFUN(op) (e, op, CDR(e), rho);
@@ -1242,12 +1242,12 @@ SEXP eval(SEXP e, SEXP rho)
 	    UNPROTECT(1);
 	    check_stack_balance(op, save);
 	    vmaxset(vmax);
-	    R_EltAnchorRelease(anchors);
+	    vmaxrelease(vtop);
 	}
 	else if (TYPEOF(op) == BUILTINSXP) {
 	    int save = R_PPStackTop, flag = PRIMPRINT(op);
 	    const void *vmax = vmaxget();
-	    R_xlen_t anchors = R_EltAnchorTop;
+	    R_xlen_t vtop = vmaxtop;
 	    RCNTXT cntxt;
 	    PROTECT(tmp = evalList(CDR(e), rho, e, 0));
 	    if (flag < 2) R_Visible = flag != 1;
@@ -1274,7 +1274,7 @@ SEXP eval(SEXP e, SEXP rho)
 	    UNPROTECT(1);
 	    check_stack_balance(op, save);
 	    vmaxset(vmax);
-	    R_EltAnchorRelease(anchors);
+	    vmaxrelease(vtop);
 	}
 	else if (TYPEOF(op) == CLOSXP) {
 	    SEXP pargs = promiseArgs(CDR(e), rho);
@@ -5353,10 +5353,10 @@ static R_INLINE double (*getMath1Fun(int i, SEXP call))(double) {
 	    for (int i = 0; i < nargs; i++)				\
 		cargs[i] = GETSTACK(i - nargs);				\
 	    void *vmax = vmaxget();					\
-	    R_xlen_t anchors = R_EltAnchorTop;				\
+	    R_xlen_t vtop = vmaxtop;					\
 	    SEXP val = R_doDotCall(ofun, nargs, cargs, call);		\
 	    vmaxset(vmax);						\
-	    R_EltAnchorRelease(anchors);				\
+	    vmaxrelease(vtop);						\
 	    R_BCNodeStackTop -= nargs;					\
 	    SETSTACK(-1, val);						\
 	    R_Visible = TRUE;						\
@@ -8138,7 +8138,7 @@ static SEXP bcEval_loop(struct bcEval_locals *ploc)
 	SEXP args = BUILTIN_CALL_FRAME_ARGS();
 	int flag;
 	const void *vmax = vmaxget();
-	R_xlen_t anchors = R_EltAnchorTop;
+	R_xlen_t vtop = vmaxtop;
 	if (TYPEOF(fun) != BUILTINSXP)
 	  error(_("not a BUILTIN function"));
 	flag = PRIMPRINT(fun);
@@ -8158,7 +8158,7 @@ static SEXP bcEval_loop(struct bcEval_locals *ploc)
 	}
 	if (flag < 2) R_Visible = flag != 1;
 	vmaxset(vmax);
-	R_EltAnchorRelease(anchors);
+	vmaxrelease(vtop);
 	POP_CALL_FRAME(value);
 	NEXT();
       }
@@ -8169,7 +8169,7 @@ static SEXP bcEval_loop(struct bcEval_locals *ploc)
 	SEXP fun = getPrimitive(symbol, SPECIALSXP);
 	int flag;
 	const void *vmax = vmaxget();
-	R_xlen_t anchors = R_EltAnchorTop;
+	R_xlen_t vtop = vmaxtop;
 	if (RTRACE(fun)) {
 	  Rprintf("trace: ");
 	  PrintValue(symbol);
@@ -8179,7 +8179,7 @@ static SEXP bcEval_loop(struct bcEval_locals *ploc)
 	SEXP value = PRIMFUN(fun) (call, fun, markSpecialArgs(CDR(call)), rho);
 	if (flag < 2) R_Visible = flag != 1;
 	vmaxset(vmax);
-	R_EltAnchorRelease(anchors);
+	vmaxrelease(vtop);
 	BCNPUSH(value);
 	NEXT();
       }

--- a/src/main/main.c
+++ b/src/main/main.c
@@ -1021,7 +1021,7 @@ void setup_Rmainloop(void)
     R_Toplevel.sysparent = R_BaseEnv;
     R_Toplevel.conexit = R_NilValue;
     R_Toplevel.vmax = NULL;
-    R_Toplevel.eltanchortop = 0;
+    R_Toplevel.vmaxtop = 0;
     R_Toplevel.nodestack = R_BCNodeStackTop;
     R_Toplevel.bcprottop = R_BCProtTop;
     R_Toplevel.cend = NULL;

--- a/src/main/main.c
+++ b/src/main/main.c
@@ -1021,6 +1021,7 @@ void setup_Rmainloop(void)
     R_Toplevel.sysparent = R_BaseEnv;
     R_Toplevel.conexit = R_NilValue;
     R_Toplevel.vmax = NULL;
+    R_Toplevel.eltanchortop = 0;
     R_Toplevel.nodestack = R_BCNodeStackTop;
     R_Toplevel.bcprottop = R_BCProtTop;
     R_Toplevel.cend = NULL;

--- a/src/main/memory.c
+++ b/src/main/memory.c
@@ -507,6 +507,8 @@ attribute_hidden SEXP do_maxNSize(SEXP call, SEXP op, SEXP args, SEXP rho)
 /* Miscellaneous Globals. */
 
 static SEXP R_VStack = NULL;		/* R_alloc stack pointer */
+static SEXP *R_EltAnchorStack = NULL;	/* ALTREP element anchor stack */
+static R_xlen_t R_EltAnchorSize = 0;
 static SEXP R_PreciousList = NULL;      /* List of Persistent Objects */
 static R_size_t R_LargeVallocSize = 0;
 static R_size_t R_SmallVallocSize = 0;
@@ -1827,6 +1829,9 @@ static int RunGenCollect(R_size_t size_needed)
     for (i = 0; i < R_PPStackTop; i++)	   /* Protected pointers */
 	FORWARD_NODE(R_PPStack[i]);
 
+    for (R_xlen_t a = 0; a < R_EltAnchorTop; a++) /* ALTREP elements */
+	FORWARD_NODE(R_EltAnchorStack[a]);
+
     FORWARD_NODE(R_VStack);		   /* R_alloc stack */
 
     for (R_bcstack_t *sp = R_BCNodeStackBase; sp < R_BCNodeStackTop; sp++) {
@@ -2304,28 +2309,71 @@ attribute_hidden void InitMemory(void)
     MARK_NOT_MUTABLE(R_LogicalNAValue);
 }
 
+/* The ALTREP element anchor stack holds CHARSXPs returned by ALTSTRING
+   Elt methods, which nothing else may reference (see ALTSTRING_ELT).
+   It is a GC root like R_PPStack, but entries are released by scope
+   rather than by count: the builtin/special dispatch in eval.c and
+   contexts save and restore R_EltAnchorTop as they do R_PPStackTop,
+   and vmaxset() releases what was anchored since the matching
+   vmaxget() when it can tell (see below).  An element thereby lives
+   at least as long as R_alloc memory obtained at the same point
+   would, which is the lifetime callers already respect for
+   translateChar() results.  Nothing is allocated on the R heap. */
+
+attribute_hidden void R_EltAnchorPush(SEXP s)
+{
+    /* the same element is commonly fetched several times in a row */
+    if (R_EltAnchorTop > 0 && R_EltAnchorStack[R_EltAnchorTop - 1] == s)
+	return;
+
+    if (R_EltAnchorTop >= R_EltAnchorSize) {
+	R_xlen_t newsize = R_EltAnchorSize ? 2 * R_EltAnchorSize : 1024;
+	SEXP *stack = realloc(R_EltAnchorStack, newsize * sizeof(SEXP));
+	if (stack == NULL)
+	    error(_("cannot grow the ALTREP element anchor stack"));
+	R_EltAnchorStack = stack;
+	R_EltAnchorSize = newsize;
+    }
+    R_EltAnchorStack[R_EltAnchorTop++] = s;
+}
+
+/* Release the entries above 'top'.  The top is never raised, as the
+   slots above it are stale. */
+attribute_hidden void R_EltAnchorRelease(R_xlen_t top)
+{
+    if (top < R_EltAnchorTop)
+	R_EltAnchorTop = top;
+}
+
 /* Since memory allocated from the heap is non-moving, R_alloc just
    allocates off the heap as RAWSXP/REALSXP and maintains the stack of
    allocations through the ATTRIB pointer.  The stack pointer R_VStack
-   is traced by the collector. */
+   is traced by the collector.
+
+   vmaxget() also remembers the anchor stack depth for the handle it
+   hands out, and vmaxset() releases the elements anchored since then
+   when given that handle back.  Only the most recent vmaxget() is
+   remembered, so an inner vmaxget() that got the same handle (nothing
+   was R_alloc'ed in between) leaves the outer vmaxset() unable to
+   release: those elements are then released by the enclosing builtin
+   dispatch or context instead.  A later vmaxget() can only have
+   recorded a depth at least as large, so an element anchored before
+   a scope began is never released by that scope's vmaxset(). */
+static const void *R_VmaxLastHandle = NULL;
+static R_xlen_t R_VmaxLastAnchorTop = 0;
+
 void *vmaxget(void)
 {
+    R_VmaxLastHandle = R_VStack;
+    R_VmaxLastAnchorTop = R_EltAnchorTop;
     return (void *) R_VStack;
 }
 
 void vmaxset(const void *ovmax)
 {
     R_VStack = (SEXP) ovmax;
-}
-
-/* Anchor an otherwise unreferenced object on the R_alloc stack so that,
-   like R_alloc memory, it stays alive until the enclosing vmaxset().
-   Cached CHARSXPs chain the string hash through their ATTRIB field, so
-   they cannot be linked in directly the way R_alloc's RAWSXPs are; a
-   cons cell carries the reference instead. */
-attribute_hidden void R_VStackAnchor(SEXP s)
-{
-    R_VStack = CONS(s, R_VStack);
+    if (ovmax == R_VmaxLastHandle)
+	R_EltAnchorRelease(R_VmaxLastAnchorTop);
 }
 
 char *R_alloc(size_t nelem, int eltsize)

--- a/src/main/memory.c
+++ b/src/main/memory.c
@@ -507,8 +507,8 @@ attribute_hidden SEXP do_maxNSize(SEXP call, SEXP op, SEXP args, SEXP rho)
 /* Miscellaneous Globals. */
 
 static SEXP R_VStack = NULL;		/* R_alloc stack pointer */
-static SEXP *R_EltAnchorStack = NULL;	/* ALTREP element anchor stack */
-static R_xlen_t R_EltAnchorSize = 0;
+static SEXP *vmaxstack = NULL;		/* vmax protection stack */
+static R_xlen_t vmaxstacksize = 0;
 static SEXP R_PreciousList = NULL;      /* List of Persistent Objects */
 static R_size_t R_LargeVallocSize = 0;
 static R_size_t R_SmallVallocSize = 0;
@@ -1829,8 +1829,8 @@ static int RunGenCollect(R_size_t size_needed)
     for (i = 0; i < R_PPStackTop; i++)	   /* Protected pointers */
 	FORWARD_NODE(R_PPStack[i]);
 
-    for (R_xlen_t a = 0; a < R_EltAnchorTop; a++) /* ALTREP elements */
-	FORWARD_NODE(R_EltAnchorStack[a]);
+    for (R_xlen_t a = 0; a < vmaxtop; a++) /* vmax-protected objects */
+	FORWARD_NODE(vmaxstack[a]);
 
     FORWARD_NODE(R_VStack);		   /* R_alloc stack */
 
@@ -2309,40 +2309,40 @@ attribute_hidden void InitMemory(void)
     MARK_NOT_MUTABLE(R_LogicalNAValue);
 }
 
-/* The ALTREP element anchor stack holds CHARSXPs returned by ALTSTRING
-   Elt methods, which nothing else may reference (see ALTSTRING_ELT).
-   It is a GC root like R_PPStack, but entries are released by scope
-   rather than by count: the builtin/special dispatch in eval.c and
-   contexts save and restore R_EltAnchorTop as they do R_PPStackTop,
-   and vmaxset() releases what was anchored since the matching
-   vmaxget() when it can tell (see below).  An element thereby lives
-   at least as long as R_alloc memory obtained at the same point
-   would, which is the lifetime callers already respect for
-   translateChar() results.  Nothing is allocated on the R heap. */
+/* The vmax protection stack keeps objects alive for the vmax scope:
+   an object passed to vmaxprotect() lives at least as long as R_alloc
+   memory obtained at the same point would, the lifetime callers
+   already respect for translateChar() results.  It is a GC root like
+   R_PPStack, but entries are released by scope rather than by count:
+   the builtin/special dispatch in eval.c and contexts save and restore
+   vmaxtop as they do R_PPStackTop, and vmaxset() releases what was
+   protected since the matching vmaxget() when it can tell (see below).
+   Nothing is allocated on the R heap.  ALTSTRING_ELT() uses it for
+   Elt results that nothing else may reference. */
 
-attribute_hidden void R_EltAnchorPush(SEXP s)
+attribute_hidden void vmaxprotect(SEXP s)
 {
-    /* the same element is commonly fetched several times in a row */
-    if (R_EltAnchorTop > 0 && R_EltAnchorStack[R_EltAnchorTop - 1] == s)
+    /* the same object is commonly protected several times in a row */
+    if (vmaxtop > 0 && vmaxstack[vmaxtop - 1] == s)
 	return;
 
-    if (R_EltAnchorTop >= R_EltAnchorSize) {
-	R_xlen_t newsize = R_EltAnchorSize ? 2 * R_EltAnchorSize : 1024;
-	SEXP *stack = realloc(R_EltAnchorStack, newsize * sizeof(SEXP));
+    if (vmaxtop >= vmaxstacksize) {
+	R_xlen_t newsize = vmaxstacksize ? 2 * vmaxstacksize : 1024;
+	SEXP *stack = realloc(vmaxstack, newsize * sizeof(SEXP));
 	if (stack == NULL)
-	    error(_("cannot grow the ALTREP element anchor stack"));
-	R_EltAnchorStack = stack;
-	R_EltAnchorSize = newsize;
+	    error(_("cannot grow the vmax protection stack"));
+	vmaxstack = stack;
+	vmaxstacksize = newsize;
     }
-    R_EltAnchorStack[R_EltAnchorTop++] = s;
+    vmaxstack[vmaxtop++] = s;
 }
 
 /* Release the entries above 'top'.  The top is never raised, as the
    slots above it are stale. */
-attribute_hidden void R_EltAnchorRelease(R_xlen_t top)
+attribute_hidden void vmaxrelease(R_xlen_t top)
 {
-    if (top < R_EltAnchorTop)
-	R_EltAnchorTop = top;
+    if (top < vmaxtop)
+	vmaxtop = top;
 }
 
 /* Since memory allocated from the heap is non-moving, R_alloc just
@@ -2350,30 +2350,30 @@ attribute_hidden void R_EltAnchorRelease(R_xlen_t top)
    allocations through the ATTRIB pointer.  The stack pointer R_VStack
    is traced by the collector.
 
-   vmaxget() also remembers the anchor stack depth for the handle it
-   hands out, and vmaxset() releases the elements anchored since then
+   vmaxget() also remembers the protection stack depth for the handle
+   it hands out, and vmaxset() releases the objects protected since then
    when given that handle back.  Only the most recent vmaxget() is
    remembered, so an inner vmaxget() that got the same handle (nothing
    was R_alloc'ed in between) leaves the outer vmaxset() unable to
-   release: those elements are then released by the enclosing builtin
+   release: those objects are then released by the enclosing builtin
    dispatch or context instead.  A later vmaxget() can only have
-   recorded a depth at least as large, so an element anchored before
+   recorded a depth at least as large, so an object protected before
    a scope began is never released by that scope's vmaxset(). */
-static const void *R_VmaxLastHandle = NULL;
-static R_xlen_t R_VmaxLastAnchorTop = 0;
+static const void *vmaxlast = NULL;
+static R_xlen_t vmaxlasttop = 0;
 
 void *vmaxget(void)
 {
-    R_VmaxLastHandle = R_VStack;
-    R_VmaxLastAnchorTop = R_EltAnchorTop;
+    vmaxlast = R_VStack;
+    vmaxlasttop = vmaxtop;
     return (void *) R_VStack;
 }
 
 void vmaxset(const void *ovmax)
 {
     R_VStack = (SEXP) ovmax;
-    if (ovmax == R_VmaxLastHandle)
-	R_EltAnchorRelease(R_VmaxLastAnchorTop);
+    if (ovmax == vmaxlast)
+	vmaxrelease(vmaxlasttop);
 }
 
 char *R_alloc(size_t nelem, int eltsize)

--- a/src/main/memory.c
+++ b/src/main/memory.c
@@ -2318,6 +2318,16 @@ void vmaxset(const void *ovmax)
     R_VStack = (SEXP) ovmax;
 }
 
+/* Anchor an otherwise unreferenced object on the R_alloc stack so that,
+   like R_alloc memory, it stays alive until the enclosing vmaxset().
+   Cached CHARSXPs chain the string hash through their ATTRIB field, so
+   they cannot be linked in directly the way R_alloc's RAWSXPs are; a
+   cons cell carries the reference instead. */
+attribute_hidden void R_VStackAnchor(SEXP s)
+{
+    R_VStack = CONS(s, R_VStack);
+}
+
 char *R_alloc(size_t nelem, int eltsize)
 {
     R_size_t size = nelem * eltsize;


### PR DESCRIPTION
Follow-up to #314, stacked on its commit: the first commit here is #314 unchanged and the second is this change. If #314 is merged first this rebases to the second commit alone; if this approach is preferred, #314 can be closed in its favour.

## Motivation

#314 anchors each `ALTSTRING_ELT()` result by consing a cell onto the R_alloc stack. That is correct, but it is a heap allocation per element fetched on the ALTREP path, and it is visible in tight loops: `d == "5"` over a fully expanded 1e7-element `deferred_string` goes from 31 ms on trunk to 93 ms, with the cons cells also feeding the collector.

## The change

The anchor moves off the R heap onto a dedicated stack, `vmaxstack`: a malloc'd `SEXP` array traced by `RunGenCollect()` like `R_PPStack`, with internal `vmaxprotect()` / `vmaxrelease()` in `memory.c` and a depth `vmaxtop`. The names follow `vmaxget()` / `vmaxset()` because the lifetime is the vmax scope; nothing new is exported. `ALTSTRING_ELT()` protects the method's result while GC is still disabled, exactly where #314 consed.

Entries are released by scope rather than by count, using the same seams #314 relies on:

* the BUILTIN/SPECIAL dispatch in `eval()` and `bcEval()` and the bytecode `DOTCALL` save and restore `vmaxtop` as they already do `R_PPStackTop`;
* `RCNTXT` records it in `begincontext()` and `R_restore_globals()` restores it on unwind, so error paths release anchors;
* `vmaxset()` releases what was anchored since the matching `vmaxget()`, when it can tell: `vmaxget()` remembers the anchor depth for the handle it hands out, and `vmaxset()` releases to that depth when given the same handle back. This covers the per-iteration `vmaxget()`/`vmaxset()` pattern in string loops (`do_charmatch`, `do_tolower`, `do_grep`, ...). Only the most recent `vmaxget()` is remembered, so an outer scope whose handle was reused by an inner one leaves release to the enclosing dispatch or context instead. A later `vmaxget()` can only have recorded a depth at least as large, so a scope's `vmaxset()` never releases an element anchored before the scope began.

The lifetime contract is unchanged from #314: an element lives at least as long as R_alloc memory obtained at the same point would, which is the lifetime callers already respect for `translateChar()` results. Consecutive fetches of the same element do not push twice (base code commonly fetches an element several times in a row). The array grows by doubling from 1024 entries and never shrinks.

## Validation

On an ASan build (aarch64-apple-darwin) with the bug report's ALTREP class, under `gctorture(TRUE)`:

* both MREs from PR#19135 (`charmatch()`, `substr()` on a 64MB element) run clean with correct results;
* `pmatch()` on 200 distinct fresh 1KB elements against 200 more, plus `charmatch()` with a latin1 target, runs clean (the case that needs every element of both vectors alive at once);
* a sweep of `paste`, `grepl`, `toupper`, `strsplit`, `sort`, `match`, `factor`, `==` and materialisation over 200 fresh elements gives results identical to the same calls on a materialised copy, with no sanitizer reports.

Memory peaks over a million fresh 200-byte elements (Vcells "max used" in MB, with a GC forced every 10000 allocations so the number is live memory rather than uncollected garbage) are identical to #314 on every operation:

| op | #314 | this PR |
|---|---|---|
| paste | 890 | 890 |
| grepl | 909 | 909 |
| toupper | 662 | 662 |
| nchar | 451 | 451 |
| substr | 455 | 455 |
| match | 459 | 459 |
| `==` | 451 | 451 |

For reference the column itself is about 447 MB here, because the test class also `R_alloc()`s a buffer per fetch; a class that does not would retain the CHARSXPs alone. What each builtin retains is set by its own vmax scoping, not by the anchoring mechanism: `nchar`, `substr`, `match` and `==` hold every element until they return, and `toupper`, `grepl` and `paste` additionally hold the fetch from their encoding pre-scan loops, which sit outside their per-element vmax scope. Fetches inside a per-element scope are released each iteration under both approaches.

Timing of `d == "5"` on a fully expanded 1e7-element `deferred_string` (median of 7, -O2):

| build | elapsed |
|---|---|
| trunk | 0.031 s |
| #314 | 0.093 s |
| this PR | 0.042 s |
