### PR TITLE
grow environment hash tables at 0.75 bindings per chain, to prime sizes that suit the PJW hash

### DIFF
--- a/doc/NEWS.Rd
+++ b/doc/NEWS.Rd
@@ -109,7 +109,9 @@
       about twice as fast.  The load
       factor and the initial size of the table can be set at startup
       with environment variables \env{R_CHARSXP_CACHE_LOAD_FACTOR} and
-      \env{R_CHARSXP_CACHE_INITIAL_SIZE}, see \code{?EnvVar}.
+      \env{R_CHARSXP_CACHE_INITIAL_SIZE}, and the size of the (fixed
+      size) symbol table with \env{R_SYMBOL_TABLE_SIZE}, see
+      \code{?EnvVar}.
     }
   }
 

--- a/doc/NEWS.Rd
+++ b/doc/NEWS.Rd
@@ -106,7 +106,11 @@
       bucket), and \code{unserialize()} and hence \code{readRDS()} read
       character vectors in batches which prefetch the cache entries
       they will need.  Reading a file of a million distinct strings is
-      about twice as fast.  The load
+      about twice as fast.  The garbage collector no longer sweeps the
+      whole cache on every collection, only the buckets holding strings
+      young enough to have died, which removes a per-collection cost
+      that grew with the number of strings a session had ever created.
+      The load
       factor and the initial size of the table can be set at startup
       with environment variables \env{R_CHARSXP_CACHE_LOAD_FACTOR} and
       \env{R_CHARSXP_CACHE_INITIAL_SIZE}, and the size of the (fixed

--- a/doc/NEWS.Rd
+++ b/doc/NEWS.Rd
@@ -99,6 +99,17 @@
       \item \code{rfree1way} also accepts \code{offset} terms equal to
       the number of simulated observations, allowing to sample from more
       complex models.
+
+      \item Creating character strings is faster: the internal cache of
+      \code{CHARSXP}s now doubles its hash table at 0.75 strings per
+      bucket rather than at 85\% bucket occupancy (about 1.9 per
+      bucket), and \code{unserialize()} and hence \code{readRDS()} read
+      character vectors in batches which prefetch the cache entries
+      they will need.  Reading a file of a million distinct strings is
+      about twice as fast.  The load
+      factor and the initial size of the table can be set at startup
+      with environment variables \env{R_CHARSXP_CACHE_LOAD_FACTOR} and
+      \env{R_CHARSXP_CACHE_INITIAL_SIZE}, see \code{?EnvVar}.
     }
   }
 

--- a/doc/NEWS.Rd
+++ b/doc/NEWS.Rd
@@ -116,6 +116,16 @@
       \env{R_CHARSXP_CACHE_INITIAL_SIZE}, and the size of the (fixed
       size) symbol table with \env{R_SYMBOL_TABLE_SIZE}, see
       \code{?EnvVar}.
+
+      \item Hashed environments grow their hash table to a prime of
+      about twice the size once it holds more than 0.75 bindings per
+      chain, rather than by 20\% at a threshold which counted bindings
+      and occupied chains inconsistently and left the table at one to
+      two bindings per chain.  Filling an environment with a million
+      bindings one at a time moves each binding about 1.5 times on the
+      way instead of 5.7, and lookups in large environments visit fewer
+      bindings.  \code{env.profile()} now reports the number of
+      non-empty chains correctly.
     }
   }
 

--- a/doc/manual/R-ints.texi
+++ b/doc/manual/R-ints.texi
@@ -1342,7 +1342,10 @@ usually a cache miss, so the table is doubled once it holds more than
 @code{R_CHARSXP_CACHE_LOAD_FACTOR} (default 0.75) strings per bucket.
 The initial number of buckets (default 65536) can be set with
 @code{R_CHARSXP_CACHE_INITIAL_SIZE}; both are read from the environment
-when @R{} starts.  Code which interns many strings at once, such as
+when @R{} starts.  Each bucket records the age (generation) of its
+youngest @code{CHARSXP}, so that a collection of the younger generations
+only sweeps the buckets which can contain a dead string rather than the
+whole cache.  Code which interns many strings at once, such as
 @code{unserialize}, can compute the hashes ahead of the lookups with
 @code{R_CharHash} and prefetch the buckets and chain heads, see
 @file{src/main/serialize.c}.

--- a/doc/manual/R-ints.texi
+++ b/doc/manual/R-ints.texi
@@ -610,7 +610,7 @@ table.
 Environments in @R{} usually have a hash table, and nowadays that is the
 default in @code{new.env()}.  It is stored as a @code{VECSXP} where
 @code{length} is used for the allocated size of the table and
-@code{truelength} is the number of primary slots in use---the pointer to
+@code{truelength} is the number of bindings it holds---the pointer to
 the @code{VECSXP} is part of the header of a @code{SEXP} of type
 @code{ENVSXP}, and this points to @code{R_NilValue} if the environment
 is not hashed.
@@ -619,9 +619,13 @@ For the pros and cons of hashing, see a basic text on Computer Science.
 
 The code to implement hashed environments is in @file{src/main/envir.c}.
 Unless set otherwise (e.g.@: by the @code{size} argument of
-@code{new.env()}) the initial table size is @code{29}.  The table will
-be resized by a factor of 1.2 once the load factor (the proportion of
-primary slots in use) reaches 85%.
+@code{new.env()}) the initial table size is @code{29}.  Once the table
+holds more than 0.75 bindings per slot it moves to a prime size of
+about twice as many slots: each binding on a chain visited by a lookup
+is usually a cache miss, so the load factor sets the cost of a lookup,
+and the sizes are chosen so that the hash function, a base-16
+polynomial of the characters, spreads names with running numbers
+evenly (sizes near a small multiple of a power of two do not).
 
 The hash chains are stored as pairlist elements of the @code{VECSXP}:
 items are inserted at the front of the pairlist.  Hashing is principally

--- a/doc/manual/R-ints.texi
+++ b/doc/manual/R-ints.texi
@@ -1333,6 +1333,20 @@ requests to create a @code{CHARSXP} should be @emph{via} a call to
 @code{mkCharLenCE}.  Any encoding given in @code{mkCharLenCE} call will
 be ignored if the string's bytes are all @acronym{ASCII} characters.
 
+The cache is a hash table whose size is a power of two, with the
+@code{CHARSXP}s in each bucket chained through their @code{ATTRIB}
+fields.  The chains are weak: the garbage collector removes
+@code{CHARSXP}s which are no longer referenced from elsewhere.  A lookup
+walks the chain for its bucket and each @code{CHARSXP} visited is
+usually a cache miss, so the table is doubled once it holds more than
+@code{R_CHARSXP_CACHE_LOAD_FACTOR} (default 0.75) strings per bucket.
+The initial number of buckets (default 65536) can be set with
+@code{R_CHARSXP_CACHE_INITIAL_SIZE}; both are read from the environment
+when @R{} starts.  Code which interns many strings at once, such as
+@code{unserialize}, can compute the hashes ahead of the lookups with
+@code{R_CharHash} and prefetch the buckets and chain heads, see
+@file{src/main/serialize.c}.
+
 
 @node Warnings and errors
 @section Warnings and errors

--- a/src/include/Defn.h
+++ b/src/include/Defn.h
@@ -1594,6 +1594,7 @@ void R_ReleaseMSet(SEXP mset, int keepSize);
 extern0 SEXP	R_CurrentExpr;	    /* Currently evaluating expression */
 extern0 SEXP	R_ReturnedValue;    /* Slot for return-ing values */
 extern0 SEXP*	R_SymbolTable;	    /* The symbol table */
+extern0 int	R_SymbolTableSize;  /* its number of buckets, fixed at startup */
 #ifdef R_USE_SIGNALS
 extern0 RCNTXT R_Toplevel;	      /* Storage for the toplevel context */
 extern0 RCNTXT* R_ToplevelContext;  /* The toplevel context */

--- a/src/include/Defn.h
+++ b/src/include/Defn.h
@@ -925,6 +925,14 @@ extern0 SEXP    R_dot_GenericDefEnv;  /* ".GenericDefEnv" */
 
 extern0 SEXP	R_StringHash;       /* Global hash of CHARSXPs */
 extern0 R_xlen_t R_StringHashCount; /* number of CHARSXPs in it */
+/* One byte per bucket: the age of its youngest CHARSXP, where 0 is a
+   node in New space, 1 and 2 the old generations, and 3 an empty
+   bucket.  A collection of the generations up to some level only has
+   to sweep the buckets whose youngest node is that young, which is the
+   difference between touching every cached string on every collection
+   and touching the strings created since the last one. */
+extern0 unsigned char *R_StringHashAges;
+#define R_STRINGHASH_EMPTY 3
 
 
  /* writable char access for R internal use only */

--- a/src/include/Defn.h
+++ b/src/include/Defn.h
@@ -924,6 +924,7 @@ extern0 SEXP    R_dot_GenericCallEnv;  /* ".GenericCallEnv" */
 extern0 SEXP    R_dot_GenericDefEnv;  /* ".GenericDefEnv" */
 
 extern0 SEXP	R_StringHash;       /* Global hash of CHARSXPs */
+extern0 R_xlen_t R_StringHashCount; /* number of CHARSXPs in it */
 
 
  /* writable char access for R internal use only */
@@ -1850,6 +1851,13 @@ SEXP R_FindPackageEnv(SEXP info);
 Rboolean R_HasFancyBindings(SEXP rho); // envir.c
 void R_RestoreHashCount(SEXP rho); // envir.c
 SEXP R_lsInternal(SEXP, Rboolean); // envir.c
+
+/* interning many strings at once, see the CHARSXP cache in envir.c */
+unsigned int R_CharHash(const char *name, int len);
+void R_CharHashPrefetchBucket(unsigned int hash);
+void R_CharHashPrefetchChain(unsigned int hash);
+SEXP R_mkCharLenCEHash(const char *name, int len, cetype_t enc,
+		       unsigned int hash);
 
 void R_XDREncodeDouble(double d, void *buf);
 double R_XDRDecodeDouble(void *buf);

--- a/src/library/base/man/EnvVar.Rd
+++ b/src/library/base/man/EnvVar.Rd
@@ -86,6 +86,14 @@
       rehashing the cache as it grows.  Read at startup only.}
     \item{\env{R_COMPLETION}:}{Optional.  If set to \code{FALSE},
       command-line completion is not used.  (Not used by the macOS GUI.)}
+    \item{\env{R_SYMBOL_TABLE_SIZE}:}{Optional.  The number of buckets
+      in \R's internal symbol table, rounded up to a prime, between 1024
+      and \eqn{2^{26}} (default 49157).  The table does not grow, and
+      symbols are never removed, so a session which creates many more
+      symbols than that, for example by using an environment with a
+      million keys, looks them up faster with a larger table.  A session
+      with the standard packages attached holds about ten thousand
+      symbols.  Read at startup only.}
     \item{\env{R_DEFAULT_PACKAGES}:}{A comma-separated list of packages
       which are to be attached in every session.  See \code{\link{options}}.}
     \item{\env{R_DOC_DIR}:}{The location of the \R \file{doc}

--- a/src/library/base/man/EnvVar.Rd
+++ b/src/library/base/man/EnvVar.Rd
@@ -73,6 +73,17 @@
       \code{!is.na(\link{Sys.getenv}("R_BATCH", NA))}.}
     \item{\env{R_BROWSER}:}{The path to the default browser.  Used to
       set the default value of \code{\link{options}("browser")}.}
+    \item{\env{R_CHARSXP_CACHE_LOAD_FACTOR}:}{Optional.  The number of
+      cached strings per hash bucket beyond which \R's internal cache
+      of character strings doubles its hash table, between 0.1 and 10
+      (default 0.75).  Smaller values make creating strings faster at
+      the cost of a larger table.  Read at startup only; see the
+      \sQuote{R Internals} manual.}
+    \item{\env{R_CHARSXP_CACHE_INITIAL_SIZE}:}{Optional.  The initial
+      number of buckets in that hash table, rounded up to a power of
+      two, between 1024 and \eqn{2^{30}} (default 65536).  Setting this
+      to about the number of distinct strings a session will use avoids
+      rehashing the cache as it grows.  Read at startup only.}
     \item{\env{R_COMPLETION}:}{Optional.  If set to \code{FALSE},
       command-line completion is not used.  (Not used by the macOS GUI.)}
     \item{\env{R_DEFAULT_PACKAGES}:}{A comma-separated list of packages

--- a/src/library/base/man/environment.Rd
+++ b/src/library/base/man/environment.Rd
@@ -86,8 +86,8 @@ env.profile(env)
 
   \code{env.profile} returns a list with the following components:
   \code{size} the number of chains that can be stored in the hash table,
-  \code{nchains} the number of non-empty chains in the table (as
-  reported by \code{HASHPRI}), and \code{counts} an integer vector
+  \code{nchains} the number of non-empty chains in the table, and
+  \code{counts} an integer vector
   giving the length of each chain (zero for empty chains).  This
   function is intended to assess the performance of hashed environments.
   When \code{env} is a non-hashed environment, \code{NULL} is returned.

--- a/src/main/envir.c
+++ b/src/main/envir.c
@@ -4642,11 +4642,14 @@ static unsigned int char_hash(const char *s, int len)
        differ only in a running number djb2 leaves those correlated, so
        such keys land in neighbouring buckets and their chains are about
        20% longer than for random keys.  Do not be tempted to fix that
-       with a finalizer mix (or a prime table size): the correlation
-       means a run of such strings is inserted, and later walked by the
-       garbage collector, in nearly sequential memory order, and mixing
-       the bits made collections with millions of cached strings four
-       times slower. */
+       with a finalizer mix, a prime table size or an open-addressed
+       table (which needs the mix): the correlation is what lets a run
+       of such keys walk the bucket array sequentially.  With a million
+       cached strings, mixing the bits took inserting consecutive keys
+       from 87 to 168 ns and looking them up in creation order from 29
+       to 42 ns, gained nothing on random keys, and made full
+       collections 10% slower, since the sweep visits the cache in
+       bucket order. */
     return h;
 }
 

--- a/src/main/envir.c
+++ b/src/main/envir.c
@@ -4598,6 +4598,23 @@ attribute_hidden SEXP mkCharWUTF8(const wchar_t *wname)
 static unsigned int char_hash_size = 65536;
 static unsigned int char_hash_mask = 65535;
 
+/* The table doubles once it holds more than char_hash_load cached
+   strings per bucket.  A lookup walks a chain of CHARSXPs scattered
+   over the heap, each of them a cache miss, and an insertion walks the
+   whole chain, so the load factor matters more to the cost of
+   interning a string than anything else in mkCharLenCE().  The table
+   used to double at 85% bucket occupancy, about 1.9 strings per bucket,
+   which cost about twice as much per lookup as the current default.
+   Both the load factor and the initial size can be set from the
+   environment when R starts up. */
+static double char_hash_load = 0.75;
+#define CHAR_HASH_LOAD_MIN 0.1
+#define CHAR_HASH_LOAD_MAX 10.0
+#define CHAR_HASH_SIZE_MIN 1024
+#define CHAR_HASH_SIZE_MAX 1073741824 /* 2^30, the largest power of two
+					 a VECSXP could hold before long
+					 vectors */
+
 static unsigned int char_hash(const char *s, int len)
 {
     /* djb2 as from http://www.cse.yorku.ca/~oz/hash.html */
@@ -4606,12 +4623,74 @@ static unsigned int char_hash(const char *s, int len)
     unsigned int h = 5381;
     for (p = (char *) s, i = 0; i < len; p++, i++)
 	h = ((h << 5) + h) + (*p);
+    /* The bucket is selected by the low bits alone, and for keys which
+       differ only in a running number djb2 leaves those correlated, so
+       such keys land in neighbouring buckets and their chains are about
+       20% longer than for random keys.  Do not be tempted to fix that
+       with a finalizer mix (or a prime table size): the correlation
+       means a run of such strings is inserted, and later walked by the
+       garbage collector, in nearly sequential memory order, and mixing
+       the bits made collections with millions of cached strings four
+       times slower. */
     return h;
 }
 
 attribute_hidden void InitStringHash(void)
 {
+    const char *arg;
+
+    /* out-of-range values are ignored, as for the R_GC_* variables */
+    arg = getenv("R_CHARSXP_CACHE_LOAD_FACTOR");
+    if (arg != NULL && arg[0]) {
+	double load = atof(arg);
+	if (CHAR_HASH_LOAD_MIN <= load && load <= CHAR_HASH_LOAD_MAX)
+	    char_hash_load = load;
+    }
+    arg = getenv("R_CHARSXP_CACHE_INITIAL_SIZE");
+    if (arg != NULL && arg[0]) {
+	double size = atof(arg);
+	if (CHAR_HASH_SIZE_MIN <= size && size <= CHAR_HASH_SIZE_MAX) {
+	    unsigned int n = CHAR_HASH_SIZE_MIN;
+	    while (n < size)
+		n *= 2;
+	    char_hash_size = n;
+	    char_hash_mask = n - 1;
+	}
+    }
+
     R_StringHash = R_NewHashTable(char_hash_size);
+    R_StringHashCount = 0;
+}
+
+/* Helpers for code which interns many strings in a row, such as
+   unserialize().  Computing the hash ahead of the lookup lets the
+   caller prefetch the bucket, and a little later the head of its
+   chain, so that the cache misses which dominate mkCharLenCE() overlap
+   with other work.  A resize between the prefetch and the lookup only
+   wastes the prefetch. */
+
+#if defined(__GNUC__) || defined(__clang__)
+# define PREFETCH(p) __builtin_prefetch(p)
+#else
+# define PREFETCH(p) do { } while (0)
+#endif
+
+attribute_hidden unsigned int R_CharHash(const char *name, int len)
+{
+    return char_hash(name, len);
+}
+
+attribute_hidden void R_CharHashPrefetchBucket(unsigned int hash)
+{
+    PREFETCH(VECTOR_PTR_RO(R_StringHash) + (hash & char_hash_mask));
+}
+
+attribute_hidden void R_CharHashPrefetchChain(unsigned int hash)
+{
+    SEXP chain = VECTOR_ELT(R_StringHash, hash & char_hash_mask);
+
+    if (chain != R_NilValue)
+	PREFETCH(chain);
 }
 
 /* #define DEBUG_GLOBAL_STRING_HASH 1 */
@@ -4742,6 +4821,14 @@ static void reportInvalidString(SEXP cval, int actionWhenInvalid)
 
 SEXP mkCharLenCE(const char *name, int len, cetype_t enc)
 {
+    return R_mkCharLenCEHash(name, len, enc, char_hash(name, len));
+}
+
+/* As mkCharLenCE(), with the hash of the bytes already computed by
+   R_CharHash(), for callers which prefetch ahead of the lookup. */
+attribute_hidden SEXP
+R_mkCharLenCEHash(const char *name, int len, cetype_t enc, unsigned int hash)
+{
     SEXP cval, chain;
     unsigned int hashcode;
     int need_enc;
@@ -4790,7 +4877,7 @@ SEXP mkCharLenCE(const char *name, int len, cetype_t enc)
     default: need_enc = 0;
     }
 
-    hashcode = char_hash(name, len) & char_hash_mask;
+    hashcode = hash & char_hash_mask;
 
     /* Search for a cached value */
     cval = R_NilValue;
@@ -4833,14 +4920,15 @@ SEXP mkCharLenCE(const char *name, int len, cetype_t enc)
 	/* this is a destructive modification */
 	chain = SET_CXTAIL(cval, chain);
 	SET_VECTOR_ELT(R_StringHash, hashcode, chain);
+	R_StringHashCount++;
 
 	/* resize the hash table if necessary with the new entry still
 	   protected.
 	   Maximum possible power of two is 2^30 for a VECSXP.
 	   FIXME: this has changed with long vectors.
 	*/
-	if (R_HashSizeCheck(R_StringHash)
-	    && char_hash_size < 1073741824 /* 2^30 */)
+	if ((double) R_StringHashCount > char_hash_load * char_hash_size
+	    && char_hash_size < CHAR_HASH_SIZE_MAX)
 	    R_StringHash_resize(char_hash_size * 2);
 
 	if (checkValid && !IS_ASCII(cval)) {

--- a/src/main/envir.c
+++ b/src/main/envir.c
@@ -4615,6 +4615,21 @@ static double char_hash_load = 0.75;
 					 a VECSXP could hold before long
 					 vectors */
 
+static unsigned char *NewStringHashAges(unsigned int size);
+
+/* Bucket heads are stored without the old-to-new write barrier.  The
+   cache is weak and the collector maintains it explicitly (see
+   RunGenCollect), so recording the table as an old node with young
+   children is not needed for correctness, and it is expensive: the
+   collector would forward every bucket head on every collection, which
+   touches a header per bucket, and would keep young heads alive through
+   the minor collections which should have reclaimed them. */
+static R_INLINE void SetStringHashBucket(SEXP table, unsigned int i,
+					 SEXP chain)
+{
+    ((SEXP *) STDVEC_DATAPTR(table))[i] = chain;
+}
+
 static unsigned int char_hash(const char *s, int len)
 {
     /* djb2 as from http://www.cse.yorku.ca/~oz/hash.html */
@@ -4660,6 +4675,19 @@ attribute_hidden void InitStringHash(void)
 
     R_StringHash = R_NewHashTable(char_hash_size);
     R_StringHashCount = 0;
+    R_StringHashAges = NewStringHashAges(char_hash_size);
+}
+
+/* Ages for a new table of the given size, all marked as holding a new
+   node so that the next collection sweeps every bucket and records the
+   truth.  The collector copes with NULL by sweeping everything. */
+static unsigned char *NewStringHashAges(unsigned int size)
+{
+    unsigned char *ages = (unsigned char *) malloc(size);
+
+    if (ages != NULL)
+	memset(ages, 0, size);
+    return ages;
 }
 
 /* Helpers for code which interns many strings in a row, such as
@@ -4716,6 +4744,7 @@ static void R_StringHash_resize(unsigned int newsize)
        therefore the only point where GC can occur. */
     new_table = R_NewHashTable(newsize);
     newmask = newsize - 1;
+    unsigned char *new_ages = NewStringHashAges(newsize);
 
     /* transfer chains from old table to new table */
     for (counter = 0; counter < LENGTH(old_table); counter++) {
@@ -4725,19 +4754,18 @@ static void R_StringHash_resize(unsigned int newsize)
 	    next = CXTAIL(chain);
 	    new_hashcode = char_hash(CHAR(val), LENGTH(val)) & newmask;
 	    new_chain = VECTOR_ELT(new_table, new_hashcode);
-	    /* If using a primary slot then increase HASHPRI */
-	    if (ISNULL(new_chain))
-		SET_HASHPRI(new_table, HASHPRI(new_table) + 1);
 	    /* move the current chain link to the new chain */
 	    /* this is a destructive modification */
 	    new_chain = SET_CXTAIL(val, new_chain);
-	    SET_VECTOR_ELT(new_table, new_hashcode, new_chain);
+	    SetStringHashBucket(new_table, new_hashcode, new_chain);
 	    chain = next;
 	}
     }
     R_StringHash = new_table;
     char_hash_size = newsize;
     char_hash_mask = newmask;
+    free(R_StringHashAges);
+    R_StringHashAges = new_ages;
 #ifdef DEBUG_GLOBAL_STRING_HASH
     newsize = HASHSIZE(new_table);
     newpri = HASHPRI(new_table);
@@ -4915,12 +4943,12 @@ R_mkCharLenCEHash(const char *name, int len, cetype_t enc, unsigned int hash)
 	SET_CACHED(cval);  /* Mark it */
 	/* add the new value to the cache */
 	chain = VECTOR_ELT(R_StringHash, hashcode);
-	if (ISNULL(chain))
-	    SET_HASHPRI(R_StringHash, HASHPRI(R_StringHash) + 1);
 	/* this is a destructive modification */
 	chain = SET_CXTAIL(cval, chain);
-	SET_VECTOR_ELT(R_StringHash, hashcode, chain);
+	SetStringHashBucket(R_StringHash, hashcode, chain);
 	R_StringHashCount++;
+	if (R_StringHashAges != NULL)
+	    R_StringHashAges[hashcode] = 0; /* the bucket now holds a new node */
 
 	/* resize the hash table if necessary with the new entry still
 	   protected.

--- a/src/main/envir.c
+++ b/src/main/envir.c
@@ -3172,7 +3172,7 @@ static int BuiltinSize(int all, int intern)
     int count = 0;
     SEXP s;
     int j;
-    for (j = 0; j < HSIZE; j++) {
+    for (j = 0; j < R_SymbolTableSize; j++) {
 	for (s = R_SymbolTable[j]; s != R_NilValue; s = CDR(s)) {
 	    if (intern) {
 		if (INTERNAL(CAR(s)) != R_NilValue)
@@ -3193,7 +3193,7 @@ BuiltinNames(int all, int intern, SEXP names, int *indx)
 {
     SEXP s;
     int j;
-    for (j = 0; j < HSIZE; j++) {
+    for (j = 0; j < R_SymbolTableSize; j++) {
 	for (s = R_SymbolTable[j]; s != R_NilValue; s = CDR(s)) {
 	    if (intern) {
 		if (INTERNAL(CAR(s)) != R_NilValue)
@@ -3213,7 +3213,7 @@ BuiltinValues(int all, int intern, SEXP values, int *indx)
 {
     SEXP s, vl;
     int j;
-    for (j = 0; j < HSIZE; j++) {
+    for (j = 0; j < R_SymbolTableSize; j++) {
 	for (s = R_SymbolTable[j]; s != R_NilValue; s = CDR(s)) {
 	    if (intern) {
 		if (INTERNAL(CAR(s)) != R_NilValue) {
@@ -3694,7 +3694,7 @@ void R_LockEnvironment(SEXP env, Rboolean bindings)
 	if (bindings) {
 	    SEXP s;
 	    int j;
-	    for (j = 0; j < HSIZE; j++)
+	    for (j = 0; j < R_SymbolTableSize; j++)
 		for (s = R_SymbolTable[j]; s != R_NilValue; s = CDR(s))
 		    if(SYMVALUE(CAR(s)) != R_UnboundValue)
 			LOCK_BINDING(CAR(s));

--- a/src/main/envir.c
+++ b/src/main/envir.c
@@ -195,7 +195,9 @@ attribute_hidden Rboolean R_envHasNoSpecialSymbols (SEXP env)
   Hash Tables
 
   We use a basic separate chaining algorithm.	A hash table consists
-  of SEXP (vector) which contains a number of SEXPs (lists).
+  of SEXP (vector) which contains a number of SEXPs (lists).  Its
+  truelength holds the number of bindings in the table, so that the
+  load factor is known exactly.
 
   The only non-static function is R_NewHashedEnv, which allows code to
   request a hashed environment.  All others are static to allow
@@ -203,10 +205,35 @@ attribute_hidden Rboolean R_envHasNoSpecialSymbols (SEXP env)
 */
 
 #define HASHSIZE(x)	     ((int) STDVEC_LENGTH(x))
-#define HASHPRI(x)	     ((int) STDVEC_TRUELENGTH(x))
-#define HASHTABLEGROWTHRATE  1.2
+#define HASHCOUNT(x)	     ((int) STDVEC_TRUELENGTH(x))
+#define SET_HASHCOUNT(x,v)   SET_TRUELENGTH(x,v)
+#define HASHTABLELOAD	     0.75
 #define HASHMINSIZE	     29
-#define SET_HASHPRI(x,v)     SET_TRUELENGTH(x,v)
+
+/* Sizes a table grows through: the first prime above 1.618 times each
+   power of two from 2^5 to 2^30.  A table more than HASHTABLELOAD full
+   moves to the next of these, about twice its size.  The sizes matter
+   because R_Newhashpjw() is a base-16 polynomial of the characters and
+   the hash is reduced by division: with sizes near a small multiple of
+   a power of two, such as 2n + 1 from 29 (15 * 2^k - 1) or the primes
+   just above a power of two, names which differ in a running number
+   collapse onto a fraction of the chains (a table of a million such
+   names had 23% of its chains in use where a uniform hash gives 40%,
+   and twice the lookups of a uniform table).  Simulated over a million
+   names of six shapes, these sizes are within a few percent of uniform,
+   while the old growth by 1.2 avoided the problem by accident. */
+static const int HashTableSizes[] = {
+    53, 107, 211, 419,
+    829, 1657, 3319, 6637,
+    13259, 26513, 53047, 106087,
+    212081, 424163, 848321, 1696649,
+    3393311, 6786529, 13573067, 27146107,
+    54292219, 108584447, 217168859, 434337707,
+    868675439, 1737350779
+};
+#define NHASHTABLESIZES (sizeof(HashTableSizes) / sizeof(HashTableSizes[0]))
+
+static int hashIndex(SEXP symbol, SEXP table);
 #define HASHCHAIN(table, i)  ((SEXP *) STDVEC_DATAPTR(table))[i]
 
 #define IS_HASHED(x)	     (HASHTAB(x) != R_NilValue)
@@ -267,11 +294,10 @@ static void R_HashSet(int hashcode, SEXP symbol, SEXP table, SEXP value,
 	}
     if (frame_locked)
 	error(_("cannot add bindings to a locked environment"));
-    if (ISNULL(chain))
-	SET_HASHPRI(table, HASHPRI(table) + 1);
     /* Add the value into the chain */
     SET_VECTOR_ELT(table, hashcode, CONS(value, VECTOR_ELT(table, hashcode)));
     SET_TAG(VECTOR_ELT(table, hashcode), symbol);
+    SET_HASHCOUNT(table, HASHCOUNT(table) + 1);
     return;
 }
 
@@ -357,7 +383,7 @@ static SEXP R_NewHashTable(int size)
 
     /* Allocate hash table in the form of a vector */
     PROTECT(table = allocVector(VECSXP, size));
-    SET_HASHPRI(table, 0);
+    SET_HASHCOUNT(table, 0);
     UNPROTECT(1);
     return(table);
 }
@@ -404,9 +430,8 @@ static void R_HashDelete(int hashcode, SEXP symbol, SEXP env, int *found)
     if (*found) {
 	if (env == R_GlobalEnv)
 	    R_DirtyImage = 1;
-	if (list == R_NilValue)
-	    SET_HASHPRI(hashtab, HASHPRI(hashtab) - 1);
 	SET_VECTOR_ELT(hashtab, idx, list);
+	SET_HASHCOUNT(hashtab, HASHCOUNT(hashtab) - 1);
     }
 }
 
@@ -430,39 +455,27 @@ static SEXP R_HashResize(SEXP table)
     if (TYPEOF(table) != VECSXP)
 	error("first argument ('table') not of type VECSXP, from R_HashResize");
 
-    /* This may have to change.	 The growth rate should
-       be independent of the size (not implemented yet) */
-    /* hash_grow = HASHSIZE(table); */
-
-    /* Allocate the new hash table */
-    SEXP new_table = R_NewHashTable(1 + (int)(HASHSIZE(table) * HASHTABLEGROWTHRATE));
-    for (int counter = 0; counter < length(table); counter++) {
+    /* Move to the first of the sizes at least one and a half times the
+       current one: the next one up for a table already on the ladder,
+       as consecutive sizes are about double, and between one and a
+       half and three times for a table sized by the user.  The names'
+       hashes are cached in their CHARSXPs, so the strings are not
+       rehashed. */
+    int n = HASHSIZE(table), i = 0;
+    while (i < NHASHTABLESIZES - 1 && HashTableSizes[i] < 1.5 * n)
+	i++;
+    SEXP new_table = R_NewHashTable(HashTableSizes[i]);
+    for (int counter = 0; counter < n; counter++) {
 	SEXP chain = VECTOR_ELT(table, counter);
 	while (!ISNULL(chain)) {
-	    int new_hashcode = R_Newhashpjw(CHAR(PRINTNAME(TAG(chain)))) %
-		HASHSIZE(new_table);
-	    SEXP new_chain = VECTOR_ELT(new_table, new_hashcode);
-	    /* If using a primary slot then increase HASHPRI */
-	    if (ISNULL(new_chain))
-		SET_HASHPRI(new_table, HASHPRI(new_table) + 1);
-	    SEXP tmp_chain = chain;
-	    chain = CDR(chain);
-	    SETCDR(tmp_chain, new_chain);
-	    SET_VECTOR_ELT(new_table, new_hashcode,  tmp_chain);
-#ifdef MIKE_DEBUG
-	    fprintf(stdout, "HASHSIZE = %d\nHASHPRI = %d\ncounter = %d\nHASHCODE = %d\n",
-		    HASHSIZE(table), HASHPRI(table), counter, new_hashcode);
-#endif
+	    int new_hashcode = hashIndex(TAG(chain), new_table);
+	    SEXP next = CDR(chain);
+	    SETCDR(chain, VECTOR_ELT(new_table, new_hashcode));
+	    SET_VECTOR_ELT(new_table, new_hashcode, chain);
+	    chain = next;
 	}
     }
-    /* Some debugging statements */
-#ifdef MIKE_DEBUG
-    fprintf(stdout, "Resized O.K.\n");
-    fprintf(stdout, "Old size: %d, New size: %d\n",
-	    HASHSIZE(table), HASHSIZE(new_table));
-    fprintf(stdout, "Old pri: %d, New pri: %d\n",
-	    HASHPRI(table), HASHPRI(new_table));
-#endif
+    SET_HASHCOUNT(new_table, HASHCOUNT(table));
     return new_table;
 } /* end R_HashResize */
 
@@ -480,16 +493,16 @@ static SEXP R_HashResize(SEXP table)
 
 static int R_HashSizeCheck(SEXP table)
 {
-    int resize;
-    double thresh_val;
-
     /* Do some checking */
     if (TYPEOF(table) != VECSXP)
 	error("first argument ('table') not of type VECSXP, R_HashSizeCheck");
-    resize = 0; thresh_val = 0.85;
-    if ((double)HASHPRI(table) > (double)HASHSIZE(table) * thresh_val)
-	resize = 1;
-    return resize;
+    /* Every binding on a chain which a lookup visits is usually a cache
+       miss, so the load factor sets the cost of a lookup.  The table
+       used to grow by 20% at 85% of a count which mixed bindings and
+       occupied chains, which left it at one to two bindings per chain
+       and moved each binding about six times on the way to a million. */
+    return HASHCOUNT(table) > HASHTABLELOAD * HASHSIZE(table) &&
+	HASHSIZE(table) < HashTableSizes[NHASHTABLESIZES - 1];
 }
 
 
@@ -516,15 +529,9 @@ static SEXP R_HashFrame(SEXP rho)
     table = HASHTAB(rho);
     frame = FRAME(rho);
     while (!ISNULL(frame)) {
-	if( !HASHASH(PRINTNAME(TAG(frame))) ) {
-	    SET_HASHVALUE(PRINTNAME(TAG(frame)),
-			  R_Newhashpjw(CHAR(PRINTNAME(TAG(frame)))));
-	    SET_HASHASH(PRINTNAME(TAG(frame)), 1);
-	}
-	hashcode = HASHVALUE(PRINTNAME(TAG(frame))) % HASHSIZE(table);
+	hashcode = hashIndex(TAG(frame), table);
 	chain = VECTOR_ELT(table, hashcode);
-	/* If using a primary slot then increase HASHPRI */
-	if (ISNULL(chain)) SET_HASHPRI(table, HASHPRI(table) + 1);
+	SET_HASHCOUNT(table, HASHCOUNT(table) + 1);
 	tmp_chain = frame;
 	frame = CDR(frame);
 	SETCDR(tmp_chain, chain);
@@ -544,8 +551,7 @@ static SEXP R_HashFrame(SEXP rho)
 
    size: the total size of the hash table
 
-   nchains: the number of non-null chains in the table (as reported by
-	    HASHPRI())
+   nchains: the number of non-null chains in the table
 
    counts: an integer vector the same length as size giving the length of
 	   each chain (or zero if no chain is present).  This allows
@@ -566,8 +572,8 @@ static SEXP R_HashProfile(SEXP table)
     UNPROTECT(1);
 
     SET_VECTOR_ELT(ans, 0, ScalarInteger(length(table)));
-    SET_VECTOR_ELT(ans, 1, ScalarInteger(HASHPRI(table)));
 
+    int nchains = 0;
     PROTECT(chain_counts = allocVector(INTSXP, length(table)));
     for (i = 0; i < length(table); i++) {
 	chain = VECTOR_ELT(table, i);
@@ -576,8 +582,10 @@ static SEXP R_HashProfile(SEXP table)
 	    count++;
 	}
 	INTEGER(chain_counts)[i] = count;
+	if (count > 0)
+	    nchains++;
     }
-
+    SET_VECTOR_ELT(ans, 1, ScalarInteger(nchains));
     SET_VECTOR_ELT(ans, 2, chain_counts);
 
     UNPROTECT(2);
@@ -748,7 +756,6 @@ static void R_FlushGlobalCacheFromUserTable(SEXP udb)
 
 static void R_AddGlobalCache(SEXP symbol, SEXP place)
 {
-    int oldpri = HASHPRI(R_GlobalCache);
     R_HashSet(hashIndex(symbol, R_GlobalCache), symbol, R_GlobalCache, place,
 	      FALSE);
 #ifdef FAST_BASE_CACHE_LOOKUP
@@ -757,8 +764,7 @@ static void R_AddGlobalCache(SEXP symbol, SEXP place)
     else
 	UNSET_BASE_SYM_CACHED(symbol);
 #endif
-    if (oldpri != HASHPRI(R_GlobalCache) &&
-	HASHPRI(R_GlobalCache) > 0.85 * HASHSIZE(R_GlobalCache)) {
+    if (R_HashSizeCheck(R_GlobalCache)) {
 	R_GlobalCache = R_HashResize(R_GlobalCache);
 	SETCAR(R_GlobalCachePreserve, R_GlobalCache);
     }
@@ -4125,9 +4131,10 @@ attribute_hidden void R_RestoreHashCount(SEXP rho)
 	table = HASHTAB(rho);
 	size = HASHSIZE(table);
 	for (i = 0, count = 0; i < size; i++)
-	    if (VECTOR_ELT(table, i) != R_NilValue)
+	    for (SEXP chain = VECTOR_ELT(table, i); chain != R_NilValue;
+		 chain = CDR(chain))
 		count++;
-	SET_HASHPRI(table, count);
+	SET_HASHCOUNT(table, count);
     }
 }
 
@@ -4734,8 +4741,6 @@ static void R_StringHash_resize(unsigned int newsize)
     unsigned int counter, new_hashcode, newmask;
 #ifdef DEBUG_GLOBAL_STRING_HASH
     unsigned int oldsize = HASHSIZE(R_StringHash);
-    unsigned int oldpri = HASHPRI(R_StringHash);
-    unsigned int newsize, newpri;
 #endif
 
     /* Allocate the new hash table.  This could fail to allocate
@@ -4770,10 +4775,8 @@ static void R_StringHash_resize(unsigned int newsize)
     free(R_StringHashAges);
     R_StringHashAges = new_ages;
 #ifdef DEBUG_GLOBAL_STRING_HASH
-    newsize = HASHSIZE(new_table);
-    newpri = HASHPRI(new_table);
-    Rprintf("Resized: size %d => %d\tpri %d => %d\n",
-	    oldsize, newsize, oldpri, newpri);
+    Rprintf("Resized: size %u => %u holding %lld strings\n",
+	    oldsize, newsize, (long long) R_StringHashCount);
 #endif
 }
 
@@ -5041,7 +5044,7 @@ void do_show_cache(int n)
 {
     int i, j;
     Rprintf("Cache size: %d\n", LENGTH(R_StringHash));
-    Rprintf("Cache pri:  %d\n", HASHPRI(R_StringHash));
+    Rprintf("Cache count: %lld\n", (long long) R_StringHashCount);
     for (i = 0, j = 0; j < n && i < LENGTH(R_StringHash); i++) {
 	SEXP chain = VECTOR_ELT(R_StringHash, i);
 	if (! ISNULL(chain)) {
@@ -5068,7 +5071,7 @@ void do_write_cache()
     FILE *f = fopen("/tmp/CACHE", "w");
     if (f != NULL) {
 	fprintf(f, "Cache size: %d\n", LENGTH(R_StringHash));
-	fprintf(f, "Cache pri:  %d\n", HASHPRI(R_StringHash));
+	fprintf(f, "Cache count: %lld\n", (long long) R_StringHashCount);
 	for (i = 0; i < LENGTH(R_StringHash); i++) {
 	    SEXP chain = VECTOR_ELT(R_StringHash, i);
 	    if (! ISNULL(chain)) {

--- a/src/main/memory.c
+++ b/src/main/memory.c
@@ -1879,6 +1879,7 @@ static int RunGenCollect(R_size_t size_needed)
     {
 	SEXP t;
 	int nc = 0;
+	R_xlen_t ne = 0;
 	for (i = 0; i < LENGTH(R_StringHash); i++) {
 	    s = VECTOR_ELT_0(R_StringHash, i);
 	    t = R_NilValue;
@@ -1893,12 +1894,14 @@ static int RunGenCollect(R_size_t size_needed)
 		}
 		FORWARD_NODE(s);
 		FORWARD_NODE(CXHEAD(s));
+		ne++;
 		t = s;
 		s = CXTAIL(s);
 	    }
 	    if(VECTOR_ELT_0(R_StringHash, i) != R_NilValue) nc++;
 	}
 	SET_TRUELENGTH(R_StringHash, nc); /* SET_HASHPRI, really */
+	R_StringHashCount = ne;
     }
     /* chains are known to be marked so don't need to scan again */
     FORWARD_AND_PROCESS_ONE_NODE(R_StringHash, VECSXP);

--- a/src/main/memory.c
+++ b/src/main/memory.c
@@ -1923,8 +1923,6 @@ static int RunGenCollect(R_size_t size_needed)
 		    removed++;
 		    continue;
 		}
-		FORWARD_NODE(s);
-		FORWARD_NODE(CXHEAD(s));
 		unsigned char age = (unsigned char) (NODE_GENERATION(s) + 1);
 		if (age < youngest)
 		    youngest = age;

--- a/src/main/memory.c
+++ b/src/main/memory.c
@@ -1874,13 +1874,43 @@ static int RunGenCollect(R_size_t size_needed)
 
     DEBUG_CHECK_NODE_COUNTS("after processing forwarded list");
 
-    /* process CHARSXP cache */
+    /* process CHARSXP cache: drop the CHARSXPs which did not survive.
+       Only nodes of the generations being collected can have died, and
+       each bucket records the age of its youngest node, so the buckets
+       whose youngest node is older than that are skipped without being
+       touched.  For the survivors the sweep records the age they will
+       have once this collection has promoted them, which is their
+       generation index plus one: nodes moved out of a collected old
+       generation already carry their new index (see the unmark loop
+       above) and nodes from New space are about to enter Old[0]. */
     if (R_StringHash != NULL) /* in case of GC during initialization */
     {
 	SEXP t;
-	int nc = 0;
-	R_xlen_t ne = 0;
-	for (i = 0; i < LENGTH(R_StringHash); i++) {
+	unsigned char *ages = R_StringHashAges;
+	int level = num_old_gens_to_collect;
+	R_xlen_t removed = 0;
+	int n = LENGTH(R_StringHash);
+	for (i = 0; i < n; i++) {
+	    if (ages != NULL) {
+		/* Eight buckets at a time: ages are 0 to 3, so a word
+		   holds no age 0 if it has no zero byte, and no age 0 or
+		   1 if every byte has bit 1 set. */
+		if (level < 2 && i % 8 == 0 && i + 8 <= n) {
+		    uint64_t w;
+		    memcpy(&w, ages + i, 8);
+		    bool none = level == 0 ?
+			((w - 0x0101010101010101ULL) & ~w &
+			 0x8080808080808080ULL) == 0 :
+			(w & 0x0202020202020202ULL) == 0x0202020202020202ULL;
+		    if (none) {
+			i += 7;
+			continue;
+		    }
+		}
+		if (ages[i] > level)
+		    continue;
+	    }
+	    unsigned char youngest = R_STRINGHASH_EMPTY;
 	    s = VECTOR_ELT_0(R_StringHash, i);
 	    t = R_NilValue;
 	    while (s != R_NilValue) {
@@ -1890,18 +1920,21 @@ static int RunGenCollect(R_size_t size_needed)
 		    else
 			CXTAIL(t) = CXTAIL(s);
 		    s = CXTAIL(s);
+		    removed++;
 		    continue;
 		}
 		FORWARD_NODE(s);
 		FORWARD_NODE(CXHEAD(s));
-		ne++;
+		unsigned char age = (unsigned char) (NODE_GENERATION(s) + 1);
+		if (age < youngest)
+		    youngest = age;
 		t = s;
 		s = CXTAIL(s);
 	    }
-	    if(VECTOR_ELT_0(R_StringHash, i) != R_NilValue) nc++;
+	    if (ages != NULL)
+		ages[i] = youngest;
 	}
-	SET_TRUELENGTH(R_StringHash, nc); /* SET_HASHPRI, really */
-	R_StringHashCount = ne;
+	R_StringHashCount -= removed;
     }
     /* chains are known to be marked so don't need to scan again */
     FORWARD_AND_PROCESS_ONE_NODE(R_StringHash, VECSXP);

--- a/src/main/memory.c
+++ b/src/main/memory.c
@@ -1786,7 +1786,7 @@ static int RunGenCollect(R_size_t size_needed)
     FORWARD_NODE(R_print.na_string_noquote);
 
     if (R_SymbolTable != NULL)             /* in case of GC during startup */
-	for (i = 0; i < HSIZE; i++) {      /* Symbol table */
+	for (i = 0; i < R_SymbolTableSize; i++) { /* Symbol table */
 	    FORWARD_NODE(R_SymbolTable[i]);
 	    SEXP s;
 	    for (s = R_SymbolTable[i]; s != R_NilValue; s = CDR(s))

--- a/src/main/names.c
+++ b/src/main/names.c
@@ -1216,11 +1216,35 @@ static SEXP mkSymMarker(SEXP pname)
     return ans;
 }
 
+/* the smallest prime not less than n, for n >= 2 */
+static int next_prime(int n)
+{
+    for (;; n++) {
+	int prime = 1;
+	for (int d = 2; d * d <= n; d++)
+	    if (n % d == 0) {
+		prime = 0;
+		break;
+	    }
+	if (prime)
+	    return n;
+    }
+}
+
 /* initialize the symbol table */
 attribute_hidden void InitNames(void)
 {
-    /* allocate the symbol table */
-    if (!(R_SymbolTable = (SEXP *) calloc(HSIZE, sizeof(SEXP))))
+    /* allocate the symbol table; R_SYMBOL_TABLE_SIZE in the environment
+       overrides the default number of buckets, rounded up to a prime
+       since the hash is reduced by division */
+    R_SymbolTableSize = HSIZE;
+    const char *arg = getenv("R_SYMBOL_TABLE_SIZE");
+    if (arg != NULL && arg[0]) {
+	double size = atof(arg);
+	if (1024 <= size && size <= 67108864 /* 2^26 */)
+	    R_SymbolTableSize = next_prime((int) size);
+    }
+    if (!(R_SymbolTable = (SEXP *) calloc(R_SymbolTableSize, sizeof(SEXP))))
 	R_Suicide("couldn't allocate memory for symbol table");
 
     /* Create marker values */
@@ -1244,7 +1268,7 @@ attribute_hidden void InitNames(void)
     MARK_NOT_MUTABLE(R_BlankScalarString);
 
     /* Initialize the symbol Table */
-    for (int i = 0; i < HSIZE; i++) R_SymbolTable[i] = R_NilValue;
+    for (int i = 0; i < R_SymbolTableSize; i++) R_SymbolTable[i] = R_NilValue;
 
     /* Set up a set of globals so that a symbol table search can be
        avoided when matching something like dim or dimnames. */
@@ -1265,6 +1289,15 @@ attribute_hidden void InitNames(void)
 
 
 /*  install - probe the symbol table */
+/* The symbol table is a chained hash table with a fixed number of
+   buckets, chosen when R starts up (see InitNames).  Symbols are never
+   removed.  Walking a chain costs about three cache misses per node
+   (the cons cell, the symbol and its print name), so a session which
+   creates many more symbols than there are buckets, such as one
+   holding an environment with a million keys, pays for it on every
+   lookup.  A session with the standard packages attached holds about
+   ten thousand symbols. */
+
 /*  If "name" is not found, it is installed in the symbol table.
     The symbol corresponding to the string "name" is returned. */
 
@@ -1274,7 +1307,7 @@ SEXP install(const char *name)
     int i, hashcode;
 
     hashcode = R_Newhashpjw(name);
-    i = hashcode % HSIZE;
+    i = hashcode % R_SymbolTableSize;
     /* Check to see if the symbol is already present;  if it is, return it. */
     for (sym = R_SymbolTable[i]; sym != R_NilValue; sym = CDR(sym))
 	if (strcmp(name, CHAR(PRINTNAME(CAR(sym)))) == 0) return (CAR(sym));
@@ -1307,7 +1340,7 @@ SEXP installNoTrChar(SEXP charSXP)
     } else {
 	hashcode = HASHVALUE(charSXP);
     }
-    i = hashcode % HSIZE;
+    i = hashcode % R_SymbolTableSize;
     /* Check to see if the symbol is already present;  if it is, return it. */
     for (sym = R_SymbolTable[i]; sym != R_NilValue; sym = CDR(sym))
 	if (strcmp(CHAR(charSXP), CHAR(PRINTNAME(CAR(sym)))) == 0) return (CAR(sym));

--- a/src/main/serialize.c
+++ b/src/main/serialize.c
@@ -1775,6 +1775,21 @@ ReadChar(R_inpstream_t stream, char *buf, int length, int levs)
     return mkCharLenCE(buf, length, CE_NATIVE);
 }
 
+/* Read the body of a CHARSXP whose length is known */
+static SEXP ReadCharsxp(R_inpstream_t stream, int length, int levs)
+{
+    /* these are currently limited to 2^31 -1 bytes */
+    if (length < 1000) {
+	char cbuf[length+1];
+	return ReadChar(stream, cbuf, length, levs);
+    } else {
+	char *cbuf = CallocCharBuf(length);
+	SEXP s = ReadChar(stream, cbuf, length, levs);
+	R_Free(cbuf);
+	return s;
+    }
+}
+
 static R_xlen_t ReadLENGTH (R_inpstream_t stream)
 {
     int len = InInteger(stream);
@@ -1884,6 +1899,134 @@ static SEXP ReadItem_Iterative(int flags, SEXP ref_table, R_inpstream_t stream)
     return sfirst;
 }
 
+
+/*
+ * Reading character vectors
+ *
+ * Nearly every element of a STRSXP is a plain CHARSXP, and the dominant
+ * cost of reading one is not the stream but the lookup in the CHARSXP
+ * cache: the hash bucket and the chain hanging off it are cache misses
+ * on memory scattered across the heap.  Elements are therefore read in
+ * batches.  The bytes of each string are read first, its hash computed
+ * and its bucket prefetched; when a batch is complete the heads of its
+ * chains are prefetched too, and the cache is only consulted after the
+ * next batch has been read, by which time the memory has arrived.
+ * Anything unusual -- attributes, references, strings which may need
+ * encoding translation, or long strings -- takes the general path
+ * element by element.  Elements are stored by index, so the order in
+ * which they are interned does not matter.
+ */
+
+#define STRBATCH_SIZE 16
+#define STRBATCH_SCRATCH 16384
+
+typedef struct {
+    R_xlen_t index;
+    int offset, length;
+    cetype_t enc;
+    unsigned int hash;
+} strbatch_item_t;
+
+typedef struct {
+    int n, used;
+    char *scratch;
+    strbatch_item_t item[STRBATCH_SIZE];
+} strbatch_t;
+
+static void InternStringBatch(SEXP s, strbatch_t *b)
+{
+    for (int i = 0; i < b->n; i++) {
+	strbatch_item_t *it = b->item + i;
+	SET_STRING_ELT(s, it->index,
+		       R_mkCharLenCEHash(b->scratch + it->offset, it->length,
+					 it->enc, it->hash));
+    }
+    b->n = 0;
+    b->used = 0;
+}
+
+/* the encoding ReadChar() would hand to mkCharLenCE() for these flags,
+   or CE_ANY when the string may need translating */
+static R_INLINE cetype_t BatchEncoding(int levs)
+{
+    if (levs & UTF8_MASK)
+	return CE_UTF8;
+    if (levs & LATIN1_MASK)
+	return CE_LATIN1;
+    if (levs & BYTES_MASK)
+	return CE_BYTES;
+    if (levs & ASCII_MASK)
+	return CE_NATIVE;
+    return CE_ANY;
+}
+
+static void ReadStringVec(SEXP ref_table, R_inpstream_t stream, SEXP s,
+			  R_xlen_t len)
+{
+    const void *vmax = vmaxget();
+    strbatch_t batches[2], *cur = &batches[0], *prev = &batches[1];
+
+    for (int i = 0; i < 2; i++) {
+	batches[i].n = batches[i].used = 0;
+	batches[i].scratch = R_alloc(STRBATCH_SCRATCH, 1);
+    }
+
+    for (R_xlen_t count = 0; count < len; count++) {
+	int flags = InInteger(stream);
+	SEXPTYPE type;
+	int levs, objf, hasattr, hastag;
+
+	UnpackFlags(flags, &type, &levs, &objf, &hasattr, &hastag);
+	if (type != CHARSXP || hasattr || objf) {
+	    SET_STRING_ELT(s, count,
+			   ReadItem_Recursive(flags, ref_table, stream));
+	    continue;
+	}
+
+	int length = InInteger(stream);
+	if (length < -1)
+	    error(_("invalid length"));
+	if (length == -1) {
+	    SET_STRING_ELT(s, count, NA_STRING);
+	    continue;
+	}
+	cetype_t enc = BatchEncoding(levs);
+	if (enc == CE_ANY || length >= STRBATCH_SCRATCH) {
+	    SET_STRING_ELT(s, count, ReadCharsxp(stream, length, levs));
+	    continue;
+	}
+
+	if (cur->n == STRBATCH_SIZE ||
+	    cur->used + length + 1 > STRBATCH_SCRATCH) {
+	    /* the current batch is complete: its buckets have had time
+	       to arrive, so prefetch the chain heads, then intern the
+	       previous batch and start a new one in its place */
+	    for (int i = 0; i < cur->n; i++)
+		R_CharHashPrefetchChain(cur->item[i].hash);
+	    InternStringBatch(s, prev);
+	    strbatch_t *tmp = prev;
+	    prev = cur;
+	    cur = tmp;
+	}
+
+	char *buf = cur->scratch + cur->used;
+	InString(stream, buf, length);
+	buf[length] = '\0';
+
+	strbatch_item_t *it = cur->item + cur->n++;
+	it->index = count;
+	it->offset = cur->used;
+	it->length = length;
+	it->enc = enc;
+	it->hash = R_CharHash(buf, length);
+	R_CharHashPrefetchBucket(it->hash);
+	cur->used += length + 1;
+    }
+
+    InternStringBatch(s, prev);
+    InternStringBatch(s, cur);
+    vmaxset(vmax);
+}
 
 static SEXP ReadItem_Recursive (int flags, SEXP ref_table, R_inpstream_t stream)
 {
@@ -2017,20 +2160,13 @@ static SEXP ReadItem_Recursive (int flags, SEXP ref_table, R_inpstream_t stream)
 	    }
 	    break;
 	case CHARSXP:
-	    /* these are currently limited to 2^31 -1 bytes */
 	    length = InInteger(stream);
 	    if (length < -1)
 		error(_("invalid length"));
 	    else if (length == -1)
 		PROTECT(s = NA_STRING);
-	    else if (length < 1000) {
-		char cbuf[length+1];
-		PROTECT(s = ReadChar(stream, cbuf, length, levs));
-	    } else {
-		char *cbuf = CallocCharBuf(length);
-		PROTECT(s = ReadChar(stream, cbuf, length, levs));
-		R_Free(cbuf);
-	    }
+	    else
+		PROTECT(s = ReadCharsxp(stream, length, levs));
 	    break;
 	case LGLSXP:
 	case INTSXP:
@@ -2052,8 +2188,7 @@ static SEXP ReadItem_Recursive (int flags, SEXP ref_table, R_inpstream_t stream)
 	    len = ReadLENGTH(stream);
 	    PROTECT(s = allocVector(type, len));
 	    R_ReadItemDepth++;
-	    for (count = 0; count < len; ++count)
-		SET_STRING_ELT(s, count, ReadItem(ref_table, stream));
+	    ReadStringVec(ref_table, stream, s, len);
 	    R_ReadItemDepth--;
 	    break;
 	case VECSXP:

--- a/src/main/serialize.c
+++ b/src/main/serialize.c
@@ -1917,7 +1917,9 @@ static SEXP ReadItem_Iterative(int flags, SEXP ref_table, R_inpstream_t stream)
  * which they are interned does not matter.
  */
 
-#define STRBATCH_SIZE 16
+/* 32 measured 2 to 4% faster than 16 for an in-memory unserialize() of
+   a million strings, and 64 the same as 32 */
+#define STRBATCH_SIZE 32
 #define STRBATCH_SCRATCH 16384
 
 typedef struct {

--- a/tests/reg-tests-1e.R
+++ b/tests/reg-tests-1e.R
@@ -3729,6 +3729,22 @@ Sys.unsetenv(c("R_CHARSXP_CACHE_LOAD_FACTOR", "R_CHARSXP_CACHE_INITIAL_SIZE",
                "R_SYMBOL_TABLE_SIZE"))
 stopifnot(identical(out, "ok"))
 unlink(tf)
+## The collector only sweeps the buckets of the cache which hold strings
+## young enough to have died: churn strings through several generations
+## with frequent collections of every level, then check that what is
+## looked up is what was kept.
+keep <- paste0("keep", 1:20000)
+gctorture2(step = 2000)
+for(i in 1:6) {
+    tmp <- paste0("tmp", i, "_", 1:20000)
+    keep2 <- paste0("keep", 1:20000)
+    rm(tmp)
+}
+gctorture2(step = 0)
+invisible(gc())
+stopifnot(identical(keep2, keep), identical(unique(c(keep, keep2)), keep),
+          identical(match(paste0("keep", c(1, 20000)), keep2), c(1L, 20000L)))
+rm(keep, keep2)
 ## new in R 4.7.0
 
 

--- a/tests/reg-tests-1e.R
+++ b/tests/reg-tests-1e.R
@@ -3699,6 +3699,34 @@ stopifnot(
     identical(drop(aperm(a, c(1, 2, 3), resize = FALSE)), aperm(m, c(1, 2), resize = FALSE))
 )
 
+## The CHARSXP cache doubles at a configurable load factor, and
+## unserialize() reads character vectors in batches which prefetch the
+## cache: strings of every encoding, NA, empty, repeated and long strings
+## must round trip with their encodings, and a session started with a
+## tiny table and a low load factor (forcing many resizes) must work.
+x <- c(NA, "", "ascii", "\u00e9l\u00e8ve", iconv("caf\u00e9", "UTF-8", "latin1"),
+       strrep("z", 20000), paste0("id", 1:5000), "\u00e9", "ascii")
+y <- "\xff\xfe"; Encoding(y) <- "bytes"; x <- c(x, y)
+tf <- tempfile(fileext = ".rds")
+for(compress in c(TRUE, FALSE)) {
+    saveRDS(x, tf, compress = compress)
+    r <- readRDS(tf)
+    stopifnot(identical(r, x), identical(Encoding(r), Encoding(x)))
+}
+saveRDS(x, tf, ascii = TRUE)
+r <- readRDS(tf)
+stopifnot(identical(r, x), identical(Encoding(r), Encoding(x)))
+writeLines(c('x <- paste0("s", 1:2e5)',
+             'stopifnot(!anyDuplicated(x), identical(match(x, rev(x)), rev(seq_along(x))))',
+             'cat("ok\\n")'), tf)
+Sys.setenv(R_CHARSXP_CACHE_LOAD_FACTOR = "0.2", R_CHARSXP_CACHE_INITIAL_SIZE = "1024")
+out <- system2(file.path(R.home("bin"), "Rscript"), c("--vanilla", tf), stdout = TRUE)
+Sys.unsetenv(c("R_CHARSXP_CACHE_LOAD_FACTOR", "R_CHARSXP_CACHE_INITIAL_SIZE"))
+stopifnot(identical(out, "ok"))
+unlink(tf)
+## new in R 4.7.0
+
+
 ## keep at end
 rbind(last =  proc.time() - .pt,
       total = proc.time())

--- a/tests/reg-tests-1e.R
+++ b/tests/reg-tests-1e.R
@@ -3718,10 +3718,15 @@ r <- readRDS(tf)
 stopifnot(identical(r, x), identical(Encoding(r), Encoding(x)))
 writeLines(c('x <- paste0("s", 1:2e5)',
              'stopifnot(!anyDuplicated(x), identical(match(x, rev(x)), rev(seq_along(x))))',
+             'e <- list2env(setNames(as.list(seq_along(x)), x))',
+             'stopifnot(identical(unname(unlist(mget(x[c(1, 77777, 2e5)], e))), c(1L, 77777L, 200000L)),',
+             '          identical(as.name(x[5]), as.symbol("s5")))',
              'cat("ok\\n")'), tf)
-Sys.setenv(R_CHARSXP_CACHE_LOAD_FACTOR = "0.2", R_CHARSXP_CACHE_INITIAL_SIZE = "1024")
+Sys.setenv(R_CHARSXP_CACHE_LOAD_FACTOR = "0.2", R_CHARSXP_CACHE_INITIAL_SIZE = "1024",
+           R_SYMBOL_TABLE_SIZE = "1024")
 out <- system2(file.path(R.home("bin"), "Rscript"), c("--vanilla", tf), stdout = TRUE)
-Sys.unsetenv(c("R_CHARSXP_CACHE_LOAD_FACTOR", "R_CHARSXP_CACHE_INITIAL_SIZE"))
+Sys.unsetenv(c("R_CHARSXP_CACHE_LOAD_FACTOR", "R_CHARSXP_CACHE_INITIAL_SIZE",
+               "R_SYMBOL_TABLE_SIZE"))
 stopifnot(identical(out, "ok"))
 unlink(tf)
 ## new in R 4.7.0

--- a/tests/reg-tests-1e.R
+++ b/tests/reg-tests-1e.R
@@ -3745,6 +3745,27 @@ invisible(gc())
 stopifnot(identical(keep2, keep), identical(unique(c(keep, keep2)), keep),
           identical(match(paste0("keep", c(1, 20000)), keep2), c(1L, 20000L)))
 rm(keep, keep2)
+## Hashed environments double at 0.75 bindings per chain and count their
+## bindings exactly: env.profile() must agree with the contents, also
+## after removals and a serialization round trip.
+e <- new.env(hash = TRUE)
+keys <- paste0("v", 1:5000)
+for(k in keys) assign(k, nchar(k), envir = e)
+p <- env.profile(e)
+stopifnot(sum(p$counts) == 5000L, p$nchains == sum(p$counts > 0L),
+          sum(p$counts) <= 0.75 * p$size, length(p$counts) == p$size)
+rm(list = keys[1:2500], envir = e)
+p <- env.profile(e)
+stopifnot(sum(p$counts) == 2500L, p$nchains == sum(p$counts > 0L),
+          identical(sort(ls(e)), sort(keys[2501:5000])))
+e2 <- unserialize(serialize(e, NULL))
+stopifnot(identical(env.profile(e2), env.profile(e)),
+          identical(mget(keys[2501:2510], e2), mget(keys[2501:2510], e)))
+for(k in keys[1:2500]) assign(k, 0L, envir = e2)
+p <- env.profile(e2)
+stopifnot(sum(p$counts) == 5000L, sum(p$counts) <= 0.75 * p$size,
+          identical(sort(ls(e2)), sort(keys)))
+rm(e, e2, keys, p)
 ## new in R 4.7.0
 
 


### PR DESCRIPTION
## Summary

Hashed environments grow their table at a measured load factor instead of an inconsistent count, to prime sizes chosen for the PJW hash. Filling an environment with a million bindings one at a time is 2.7x faster, lookups in large environments visit 1.2 bindings instead of 1.75, and `env.profile()` reports the number of non-empty chains correctly.

Stacked on #316 (the cache in `main` still shares the bucket count and `R_HashSizeCheck()` with environment tables in five places which that PR rewrites); this PR is the last commit.

## What was wrong

- `R_HashSet()` increments the count for every new binding: its search loop always ends at an empty chain, so the `if (ISNULL(chain))` guard never failed. A resize, `attach()` and `R_RestoreHashCount()` (after loading a saved environment) count occupied chains instead. So `env.profile()$nchains` was wrong after any insert, and the resize threshold, 85% of that mixed count with 20% growth, was neither an occupancy nor a load: measured tables sat at 1.0 to 1.2 bindings per chain, 1.4 to 1.75 bindings visited per hit, and filling an environment to a million bindings moved each binding 5.7 times.
- Each binding visited on a chain is a cache miss on a cons cell somewhere in the heap, so the load factor sets the cost of a lookup, as for the CHARSXP cache in #316.

## Changes

- The table's truelength (`HASHCOUNT`, formerly `HASHPRI`) is the exact number of bindings, maintained by insert, delete, resize, `attach()` and the load-time restore. `env.profile()` counts non-empty chains itself, so its `nchains` is now correct.
- A table holding more than 0.75 bindings per chain moves to the next size of a ladder, the first prime above 1.618 times each power of two from 2^5 to 2^30; a user-sized table moves to the first ladder size at least 1.5 times its own. The global cache uses the same check.
- `R_HashResize()` uses the hash cached in each name's CHARSXP instead of rehashing the string.
- Documentation in R Internals and `?environment`; a regression test checks the count against the contents after inserts, removals and a serialization round trip.

## Why these sizes

The first attempt doubled to 2n + 1, which from 29 gives 15 * 2^k - 1, and lookups got *slower*: a million `key<N>` names occupied 23% of the chains where a uniform hash gives 40%. `R_Newhashpjw()` is a base-16 polynomial of the characters (`h = (h << 4) + c` with the top nibble folded back), and the index is the hash modulo the size, so a modulus near a small multiple of a power of two folds the lattice of digit values onto itself. Primes do not help by themselves: 2097169, the first prime above 2^21, is just as bad, while 2000001 and 1000003 are fine. The hash cannot change, because hashed environments are serialized with their chains in place and must stay readable, so only the sizes can. Simulated occupancy relative to a uniform hash, a million names at load 0.5, six name shapes:

| sizes | `key<N>` | `v<N>` random order | 8 random letters | `pkg.fun_<N>` | `<N>` | `my_var_<N>_x` |
|---|---|---|---|---|---|---|
| 2n + 1 from 29, at 2^21 | 0.59 | 0.58 | 0.97 | 0.68 | 0.53 | 0.78 |
| prime above 1.618 * 2^k | 0.97 to 1.08 | 0.99 to 1.06 | 1.00 | 0.95 to 1.08 | 0.96 to 1.09 | 1.00 to 1.04 |

The old growth by 1.2 produced irregular sizes and avoided the problem by accident (a grown table of 864,241 slots was at 0.88 of uniform).

## Measurements

aarch64 macOS, `-O2`, `R_SYMBOL_TABLE_SIZE=2000000` so that the symbol table does not dominate (with the default symbol table the million-key figures are all about 1.7 us higher on both sides). Nanoseconds per binding:

| 1e6 bindings | before | after |
|---|---|---|
| `list2env()` into a default-size environment (grows on the way) | 890 | 325 |
| `list2env()` into a presized environment | 346 | 294 |
| `assign()` one at a time (dominated by `assign()` itself) | 2565 | 2487 |
| `mget()`, grown table | 620 | 590 |
| bindings visited per hit, grown table | 1.75 | 1.22 |
| table slots | 864,241 | 1,696,649 |

| 1e5 bindings | before | after |
|---|---|---|
| `list2env()` into a default-size environment | 410 | 160 |
| `mget()` | 320 | 250 |

`attach()` of a 200,000-element list takes 652 ms instead of 614, since the presized table now resizes once. Loading and unloading `stats4` twenty times, and R startup, are unchanged. The table takes about 16 bytes per binding instead of 4 to 8, against the 56 bytes of the binding's cons cell.
