### PR TITLE
Support .bin/.src name postfix on repos to filter by package type

### DIFF
--- a/src/library/utils/R/packages.R
+++ b/src/library/utils/R/packages.R
@@ -992,6 +992,15 @@ contrib.url <- function(repos, type = getOption("pkgType"))
     type <- resolvePkgType(type)
     if(is.null(repos)) return(NULL)
     if(!length(repos)) return(character())
+    ## an optional ".bin"/".binary" or ".src"/".source" postfix on the
+    ## names of 'repos' declares that a repository only provides binary
+    ## resp. source packages: drop repositories not providing 'type'
+    if(!is.null(nm <- names(repos))) {
+        drop <- if(type == "source") grepl("[.](bin|binary)$", nm)
+                else grepl("[.](src|source)$", nm)
+        repos <- repos[!drop]
+        if(!length(repos)) return(character())
+    }
     if("@CRAN@" %in% repos && interactive()) {
         cat(gettext("--- Please select a CRAN mirror for use in this session ---"),
             "\n", sep = "")

--- a/src/library/utils/man/contrib.url.Rd
+++ b/src/library/utils/man/contrib.url.Rd
@@ -15,7 +15,8 @@ contrib.url(repos, type = getOption("pkgType"))
 }
 \arguments{
   \item{repos}{character vector, the base URL(s) of the repositories
-    to use.
+    to use.  Names can declare which package type(s) a repository
+    provides: see \sQuote{Details}.
   }
   \item{type}{character string, indicating which type of packages: see
     \code{\link{install.packages}}.
@@ -23,9 +24,20 @@ contrib.url(repos, type = getOption("pkgType"))
 }
 \details{
   If \code{type = "both"} this will use the source repository.
+
+  Not all repositories provide packages of all types.  A repository
+  whose name in \code{repos} ends in \code{".bin"} or \code{".binary"}
+  is declared to only provide binary packages, and one whose name ends
+  in \code{".src"} or \code{".source"} to only provide source packages.
+  Repositories not providing packages of the requested \code{type} are
+  dropped from the result.  For example, with
+\preformatted{  options(repos = c(CRAN.source = "https://cran.r-project.org",
+                    myrepo = "https://myrepo.example.com"))}
+  CRAN will only be used when looking for source packages.
 }
 \value{
-  A character vector of the same length as \code{repos}.
+  A character vector of the repository URLs providing packages of the
+  requested \code{type}, with the type-specific path appended to each.
 }
 \seealso{
   \code{\link{setRepositories}} to set \code{\link{options}("repos")},


### PR DESCRIPTION
Experiment for the proposal discussed in r-devel/custom-binary-packages#2 (alternative to #279): an optional `.bin`/`.binary` or `.src`/`.source` postfix on the *names* of `getOption("repos")` declares that a repository only provides binary resp. source packages. `contrib.url()` drops repositories that do not provide the requested type, so package lookups no longer warn about (or hit) repositories that cannot have packages of that type:

```r
# We have (custom) binaries only for r-universe
options(repos = c(
   CRAN.source = "https://cran.r-project.org",
   ropensci = "https://ropensci.r-universe.dev"
))
```

Notes:

- `contrib.url()` is the single choke point: all consumers (`available.packages`, `install.packages`, `download.packages`, `update.packages`, QC tools) go through it, and `install.packages(type = "both")` calls it separately with `"source"` and the binary type, so both halves are filtered correctly.
- Unnamed or conventionally-named `repos` vectors behave exactly as before, and older versions of R simply ignore the postfix.
- Both short (`.bin`/`.src`) and long (`.binary`/`.source`) suffix forms are accepted for now, since that question was left open in the issue; trimming to one form is trivial.
- Explicit type suffixes like `.windows.binary.clang-arm64` are not implemented in this minimal version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)