### PR TITLE
do not leak the string read buffer when unserialize errors mid-item

### DIFF
--- a/src/main/serialize.c
+++ b/src/main/serialize.c
@@ -1658,9 +1658,12 @@ ConvertChar(void *obj, char *inp, size_t inplen, cetype_t enc)
 	    }
 	    return mkCharLenCE(buf, (int)(buflen - bufleft), enc);
 	} else {
-	    char *buf = CallocCharBuf(buflen);
+	    /* R_alloc, not Calloc: mkCharLenCE can signal errors (e.g. for
+	       an embedded nul), which would leak a Calloc'd buffer */
+	    const void *vmax = vmaxget();
+	    char *buf = R_alloc(buflen + 1, sizeof(char));
 	    if (TryConvertString(obj, inp, inplen, buf, &bufleft) == -1) {
-		R_Free(buf);
+		vmaxset(vmax);
 		if (errno == E2BIG) {
 		    buflen *= 2;
 		    continue;
@@ -1668,7 +1671,7 @@ ConvertChar(void *obj, char *inp, size_t inplen, cetype_t enc)
 		    return R_NilValue;
 	    }
 	    SEXP ans = mkCharLenCE(buf, (int)(buflen - bufleft), enc);
-	    R_Free(buf);
+	    vmaxset(vmax);
 	    return ans;
 	}
     }
@@ -2027,9 +2030,12 @@ static SEXP ReadItem_Recursive (int flags, SEXP ref_table, R_inpstream_t stream)
 		char cbuf[length+1];
 		PROTECT(s = ReadChar(stream, cbuf, length, levs));
 	    } else {
-		char *cbuf = CallocCharBuf(length);
+		/* R_alloc, not Calloc: ReadChar can signal errors (truncated
+		   stream, embedded nul), which would leak a Calloc'd buffer */
+		const void *vmax = vmaxget();
+		char *cbuf = R_alloc((size_t)length + 1, sizeof(char));
 		PROTECT(s = ReadChar(stream, cbuf, length, levs));
-		R_Free(cbuf);
+		vmaxset(vmax);
 	    }
 	    break;
 	case LGLSXP:


### PR DESCRIPTION
`ReadItem` in `src/main/serialize.c` reads a CHARSXP of 1000 bytes or more
into a `CallocCharBuf` buffer. Any error signalled while that buffer is
live longjmps past the `R_Free`, leaking the whole buffer: `length + 1`
bytes per failing `unserialize()` call, where `length` is whatever the
(possibly corrupt) stream declares -- up to 2 GB.

Reachable error paths include at least:

- `InString` signalling `"read error"` for a truncated stream,
- `mkCharLenCE` signalling `"embedded nul in string"`,
- allocation failures inside the encoding-conversion path.

`ConvertChar` (same file) has the same defect one level down: it
`CallocCharBuf`s a conversion buffer and then calls `mkCharLenCE`, which
can signal.

## Affected code

```c
	    } else {
		char *cbuf = CallocCharBuf(length);        /* <-- leaks */
		PROTECT(s = ReadChar(stream, cbuf, length, levs));
		R_Free(cbuf);
	    }
```

`ReadChar` starts with `InString(stream, cbuf, length)`, which signals
`"read error"` as soon as the stream cannot supply `length` bytes; the
`R_Free(cbuf)` is never reached. The stack-buffer branch
(`length < 1000`) is unaffected, which is why small corrupt streams do
not show the problem.

## Reproducer

No hand-crafted bytes needed -- serialize a large string and truncate the
stream inside the string data:

```r
x <- strrep("a", 1e8)                 # 100e6-byte CHARSXP
bad <- head(serialize(x, NULL), 50)   # truncate mid-string
rm(x); invisible(gc())

for (i in 1:5)
    try(unserialize(bad), silent = TRUE)  # "read error"; leaks 1e8+1 bytes each
```

The embedded-nul path leaks the same way after the string data was read
in full: corrupt one byte of a valid stream to `0x00` and unserialize.

## Measurements

Unpatched trunk r90464 (aarch64-apple-darwin25.6.0), macOS `leaks` with
`MallocStackLogging` after the 5-call loop above:

```
Process 27141: 3 leaks for 320028672 total leaked bytes.

STACK OF 3 INSTANCES OF 'ROOT LEAK: <calloc in R_chk_calloc>':
...
4   R    R_Unserialize + 252       serialize.c:2296
3   R    ReadItem_Recursive + 4308  serialize.c:2056
2   R    ReadItem_Recursive + 6076  serialize.c:2030
1   R    R_chk_calloc + 28          memory.c:3551
```

(`leaks` scans conservatively, so stale stack pointers root one or two of
the five blocks; LeakSanitizer on Linux reports every one.) Patched: `0
leaks for 0 total leaked bytes` for the same loop.

This was found by LeakSanitizer in the ClusterFuzzLite batch fuzzing of
`unserialize` in https://github.com/r-devel/r-oss-fuzz, from a 33-byte
input declaring a 9,371,648-byte CHARSXP:

```
Direct leak of 9371649 byte(s) in 1 object(s) allocated from:
    #0 calloc
    #1 R_chk_calloc src/main/memory.c:3550:9
    #2 ReadItem_Recursive src/main/serialize.c:2030:16
    ...
    #6 R_Unserialize src/main/serialize.c:2294:12
```

The defect is independent of fuzzing: any truncated or corrupted
.rds / workspace file with a declared string length >= 1000 leaks on
every load attempt.

## Fix

Use `R_alloc` under `vmaxget`/`vmaxset` instead of `Calloc`/`R_Free` in
both places, so the buffer lives on the R heap and is reclaimed by the
context unwind when any of these errors is signalled. This is the same
idiom the neighbouring `InStringVec` already uses.

A side effect worth noting: the temporary buffer now counts against
`R_MAX_VSIZE`, so a corrupt stream declaring an absurd length fails with
the ordinary vector-limit error instead of Calloc-ing outside the limit.
That seems like an improvement for a buffer whose size is
attacker-controlled data.

## Verification

Applied to trunk r90464 and rebuilt:

- `serialize.c` compiles with no new warnings.
- The leak goes from ~100 MB per failing call to zero (figures above).
- Round-trips of short (< 1000 bytes, stack-buffer branch) and long
  strings, UTF-8 / latin1 / bytes encodings, via raw vectors, file
  connections, and `version = 2` streams: all identical.
- Truncated and nul-corrupted streams still produce the same error
  messages ("read error", "embedded nul in string").
