### PR TITLE
report errors and warnings whose call has an undecodable name, instead of recursing

### DIFF
--- a/src/main/deparse.c
+++ b/src/main/deparse.c
@@ -223,6 +223,12 @@ SEXP deparse1w(SEXP call, bool abbrev, int opts)
     return deparse1WithCutoff(call, abbrev, R_print.cutoff, backtick, opts, -1);
 }
 
+static void deparse_cleanup(void *data)
+{
+    LocalParseData *l = (LocalParseData *) data;
+    R_FreeStringBuffer(&(l->buffer));
+}
+
 static SEXP deparse1WithCutoff(SEXP call, bool abbrev, int cutoff,
 			       bool backtick, int opts, int nlines)
 {
@@ -260,6 +266,14 @@ static SEXP deparse1WithCutoff(SEXP call, bool abbrev, int cutoff,
     localData.backtick = backtick;
     localData.opts = opts;
     localData.strvec = R_NilValue;
+
+    /* Set up a context to free the heap-allocated buffer when an error
+       signalled during deparsing unwinds past this frame */
+    RCNTXT cntxt;
+    begincontext(&cntxt, CTXT_CCODE, R_NilValue, R_BaseEnv, R_BaseEnv,
+		 R_NilValue, R_NilValue);
+    cntxt.cend = &deparse_cleanup;
+    cntxt.cenddata = &localData;
 
     PrintDefaults(); /* from global options() */
     savedigits = R_print.digits;
@@ -309,6 +323,7 @@ static SEXP deparse1WithCutoff(SEXP call, bool abbrev, int cutoff,
 	warning(_("deparse may be not be source()able in R < 2.7.0"));
 #endif
     /* somewhere lower down might have allocated ... */
+    endcontext(&cntxt);
     R_FreeStringBuffer(&(localData.buffer));
     UNPROTECT(1);
     return svec;

--- a/src/main/gram.c
+++ b/src/main/gram.c
@@ -5684,15 +5684,21 @@ int isValidName(const char *name)
 	/* This is not necessarily correct for stateful MBCS */
 	mbstate_t mb_st;
 	mbs_init(&mb_st);
-	used = Mbrtowc(&wc, p, n, &mb_st); p += used; n -= used;
-	if(used == 0) return 0;
+	/* mbrtowc, not Mbrtowc: an undecodable string is not a valid name,
+	   and must not signal an error, as this is reached while deparsing
+	   calls for error messages */
+	used = mbrtowc(&wc, p, n, &mb_st);
+	if((int) used <= 0) return 0;
+	p += used; n -= used;
 	if (wc != L'.' && !iswalpha(wc) ) return 0;
 	if (wc == L'.') {
 	    /* We don't care about other than ASCII digits */
 	    if(isdigit(0xff & (int)*p)) return 0;
 	    /* Mbrtowc(&wc, p, n, NULL); if(iswdigit(wc)) return 0; */
 	}
-	while((used = Mbrtowc(&wc, p, n, &mb_st))) {
+	while(n > 0) {
+	    used = mbrtowc(&wc, p, n, &mb_st);
+	    if((int) used <= 0) break;
 	    if (!(iswalnum(wc) || wc == L'.' || wc == L'_')) break;
 	    p += used; n -= used;
 	}

--- a/src/main/gram.y
+++ b/src/main/gram.y
@@ -3375,15 +3375,21 @@ int isValidName(const char *name)
 	/* This is not necessarily correct for stateful MBCS */
 	mbstate_t mb_st;
 	mbs_init(&mb_st);
-	used = Mbrtowc(&wc, p, n, &mb_st); p += used; n -= used;
-	if(used == 0) return 0;
+	/* mbrtowc, not Mbrtowc: an undecodable string is not a valid name,
+	   and must not signal an error, as this is reached while deparsing
+	   calls for error messages */
+	used = mbrtowc(&wc, p, n, &mb_st);
+	if((int) used <= 0) return 0;
+	p += used; n -= used;
 	if (wc != L'.' && !iswalpha(wc) ) return 0;
 	if (wc == L'.') {
 	    /* We don't care about other than ASCII digits */
 	    if(isdigit(0xff & (int)*p)) return 0;
 	    /* Mbrtowc(&wc, p, n, NULL); if(iswdigit(wc)) return 0; */
 	}
-	while((used = Mbrtowc(&wc, p, n, &mb_st))) {
+	while(n > 0) {
+	    used = mbrtowc(&wc, p, n, &mb_st);
+	    if((int) used <= 0) break;
 	    if (!(iswalnum(wc) || wc == L'.' || wc == L'_')) break;
 	    p += used; n -= used;
 	}


### PR DESCRIPTION
In a multibyte locale, signalling an error whose call contains a symbol
that is not decodable in the current encoding destroys the error report
entirely:

```r
nm <- rawToChar(as.raw(c(0x65,0x30,0x30,0x2e,0xDD,0x2e,0x44,0x44,0x45)))
# "e00.\xdd.DDE" -- 0xDD is invalid UTF-8
do.call(nm, list())
```

Expected:

```
Error in `e00.\xdd.DDE`() : could not find function "e00.\xdd.DDE"
```

Actual (UTF-8 locale, trunk r90464):

```
Error: no more error handlers available (recursive errors?); invoking 'abort' restart
```

The warning path is worse -- a plain `warning()` from such a call becomes
a fatal error, halts the script, and loses the pending warnings:

```
Warning message:
Error: invalid multibyte string at '<dd>.DDE'
In addition: Lost warning messages
Execution halted
```

Each occurrence also leaks the deparse string buffer (caught by
LeakSanitizer in r-oss-fuzz CI, see below).

The chain:

1. `verrorcall_dflt` / `warningcall_dflt` deparse the call for the
   "Error in ..." prefix via `deparse1s`, which uses `backtick=TRUE`.
2. Deparsing the symbol goes through `quotify` -> `isValidName`
   (gram.y), which uses the `Mbrtowc` wrapper. For an undecodable byte
   sequence, `Mbrtowc` **signals** ("invalid multibyte string at ...",
   util.c) -- an error inside error handling.
3. The recursion runs until "no more error handlers available", and the
   abort restart unwinds to top level.
4. The longjmp out of `deparse1WithCutoff` skips
   `R_FreeStringBuffer(&(localData.buffer))`, leaking the buffer.

Such symbols arise in ordinary use: `do.call` with a string in the wrong
encoding, `as.name()`/`install()` from package C code, or `parse()` of
backtick names containing `\x` escapes, which the parser accepts -- the
fuzzer's input was ``1:11?0 |>`e00.\xDD.DDE` ``. In the C locale the same
input deparses fine (`` `e00.\335.DDE` `` with octal escapes); only
multibyte locales are affected.

## Fix (two commits)

**1. `isValidName` must not signal** (gram.y; gram.c hand-synced, and
regenerating with bison gives the same function). A name that cannot be
decoded in the current locale is simply not a valid name -- use plain
`mbrtowc` and treat a negative return as "invalid". `quotify` then falls
through to `EncodeString`, which already escapes invalid bytes. Other
callers of `isValidName` (make.names, tag printing in print.c) either
validate the string beforehand or are strictly better served by
"invalid encoding => not a valid name" than by an error mid-print.

**2. Free the deparse buffer on unwind** (deparse.c).
`deparse1WithCutoff` frees its heap buffer only on the normal return
path; any error signalled inside deparsing (encoding errors as above,
allocation failures on large objects, ...) leaked it. Add a `CTXT_CCODE`
cleanup context -- the same idiom `do_dput`/`do_dump` in the same file
already use for connections.

Fix 1 alone removes the recursion for this input class; fix 2 makes the
leak structurally impossible for any error signalled during deparse.

## Measurements

Driving the bad call 1000 times through `R_ToplevelExec` (mirroring the
fuzz harness) on unpatched trunk r90464, macOS `leaks` with
`MallocStackLogging`:

```
Process 30875: 1000 leaks for 640000 total leaked bytes.

STACK OF 1000 INSTANCES OF 'ROOT LEAK: <malloc in R_AllocStringBuffer>':
...
4   R    verrorcall_dflt + 872      errors.c:811
3   R    deparse1WithCutoff + 180   deparse.c:270
2   R    print2buff + 208           deparse.c:1570
1   R    R_AllocStringBuffer + 112  memory.c:4970
```

Patched: `0 leaks for 0 total leaked bytes`, zero "no more error
handlers" messages, and the intended error/warning messages are printed.

The corresponding LeakSanitizer report from ClusterFuzzLite batch fuzzing
of `parse()` in https://github.com/r-devel/r-oss-fuzz:

```
Direct leak of 512 byte(s) in 1 object(s) allocated from:
    #0 malloc
    #1 R_AllocStringBuffer src/main/memory.c:4970:23
    #2 print2buff src/main/deparse.c:1569:5
    #3 deparse1WithCutoff src/main/deparse.c:267:5
    #4 verrorcall_dflt src/main/errors.c:811:22
    ...
    #8 raiseParseError src/main/gram.c:6842:5
    #9 xxpipe src/main/gram.c
```

## Verification

Applied to trunk r90464 and rebuilt:

- No new compiler warnings.
- `do.call(nm, list())` prints `Error in `e00.\xdd.DDE`() : could not
  find function ...`; the warning variant prints `In `e00.\xdd.DDE`() :
  boom` and execution continues.
- The fuzzer's parse input now yields the intended message:
  `` Error in `e00.\xdd.DDE` : The pipe operator requires a function call
  as RHS ``.
- `isValidName` behaviour unchanged for decodable names: make.names,
  deparse/dput of valid, keyword, non-syntactic, and UTF-8 names all
  unchanged.
- No leaked `R_AllocStringBuffer` blocks after 1000 failing deparses
  (figures above).
