### PR TITLE
resize environment hash tables without rehashing the strings

### DIFF
--- a/doc/NEWS.Rd
+++ b/doc/NEWS.Rd
@@ -329,6 +329,13 @@
       zeros now, similarly to \code{lm()} via \code{glm.control()}; correct
       AIC and logLik() for this case, fixing \PR{16008}, thanks to \I{Bill
 	Dunlap} and \I{Mauricio Vargas}.
+
+      \item Hashed environments keep an exact count of their bindings.
+      Previously an insert counted bindings while a resize,
+      \code{attach()} and loading a saved environment counted occupied
+      chains, so \code{env.profile()} reported a wrong number of chains
+      and the resize threshold compared against a mixture of the two.
+      \code{env.profile()} now reports the number of non-empty chains.
     }
   }
 }

--- a/doc/manual/R-ints.texi
+++ b/doc/manual/R-ints.texi
@@ -367,7 +367,7 @@ types are a @code{VECTOR_SEXPREC}, which again consists of the header
 and the same three pointers, but followed by two integers giving the
 length and `true length'@footnote{The only current use is for hash tables of
 environments (@code{VECSXP}s), where @code{length} is the size of the table
-and @code{truelength} is the number of primary slots in use, for the
+and @code{truelength} is the number of bindings it holds, for the
 reference hash tables in serialization (@code{VECSXP}s), and for `growable'
 vectors (atomic vectors, @code{VECSXP}s and @code{EXPRSXP}s) which are
 created by slightly over-committing when enlarging a vector during
@@ -610,7 +610,7 @@ table.
 Environments in @R{} usually have a hash table, and nowadays that is the
 default in @code{new.env()}.  It is stored as a @code{VECSXP} where
 @code{length} is used for the allocated size of the table and
-@code{truelength} is the number of primary slots in use---the pointer to
+@code{truelength} is the number of bindings it holds---the pointer to
 the @code{VECSXP} is part of the header of a @code{SEXP} of type
 @code{ENVSXP}, and this points to @code{R_NilValue} if the environment
 is not hashed.
@@ -620,8 +620,8 @@ For the pros and cons of hashing, see a basic text on Computer Science.
 The code to implement hashed environments is in @file{src/main/envir.c}.
 Unless set otherwise (e.g.@: by the @code{size} argument of
 @code{new.env()}) the initial table size is @code{29}.  The table will
-be resized by a factor of 1.2 once the load factor (the proportion of
-primary slots in use) reaches 85%.
+be resized by a factor of 1.2 once it holds more than 0.85 bindings per
+slot.
 
 The hash chains are stored as pairlist elements of the @code{VECSXP}:
 items are inserted at the front of the pairlist.  Hashing is principally

--- a/src/library/base/man/environment.Rd
+++ b/src/library/base/man/environment.Rd
@@ -86,8 +86,8 @@ env.profile(env)
 
   \code{env.profile} returns a list with the following components:
   \code{size} the number of chains that can be stored in the hash table,
-  \code{nchains} the number of non-empty chains in the table (as
-  reported by \code{HASHPRI}), and \code{counts} an integer vector
+  \code{nchains} the number of non-empty chains in the table, and
+  \code{counts} an integer vector
   giving the length of each chain (zero for empty chains).  This
   function is intended to assess the performance of hashed environments.
   When \code{env} is a non-hashed environment, \code{NULL} is returned.

--- a/src/main/envir.c
+++ b/src/main/envir.c
@@ -247,6 +247,18 @@ attribute_hidden int R_Newhashpjw(const char *s)
     return h;
 }
 
+/* Index of 'symbol' in 'table', from the hash cached in the name's
+   CHARSXP, computing and caching that hash if needed. */
+static int hashIndex(SEXP symbol, SEXP table)
+{
+    SEXP c = PRINTNAME(symbol);
+    if( !HASHASH(c) ) {
+	SET_HASHVALUE(c, R_Newhashpjw(CHAR(c)));
+	SET_HASHASH(c, 1);
+    }
+    return HASHVALUE(c) % HASHSIZE(table);
+}
+
 /*----------------------------------------------------------------------
 
   R_HashSet
@@ -435,37 +447,20 @@ static SEXP R_HashResize(SEXP table)
     if (TYPEOF(table) != VECSXP)
 	error("first argument ('table') not of type VECSXP, from R_HashResize");
 
-    /* This may have to change.	 The growth rate should
-       be independent of the size (not implemented yet) */
-    /* hash_grow = HASHSIZE(table); */
-
-    /* Allocate the new hash table */
+    /* Allocate the new hash table.  The names' hashes are cached in
+       their CHARSXPs, so the strings are not rehashed. */
     SEXP new_table = R_NewHashTable(1 + (int)(HASHSIZE(table) * HASHTABLEGROWTHRATE));
-    for (int counter = 0; counter < length(table); counter++) {
+    for (int counter = 0; counter < HASHSIZE(table); counter++) {
 	SEXP chain = VECTOR_ELT(table, counter);
 	while (!ISNULL(chain)) {
-	    int new_hashcode = R_Newhashpjw(CHAR(PRINTNAME(TAG(chain)))) %
-		HASHSIZE(new_table);
-	    SEXP new_chain = VECTOR_ELT(new_table, new_hashcode);
-	    SEXP tmp_chain = chain;
-	    chain = CDR(chain);
-	    SETCDR(tmp_chain, new_chain);
-	    SET_VECTOR_ELT(new_table, new_hashcode,  tmp_chain);
-#ifdef MIKE_DEBUG
-	    fprintf(stdout, "HASHSIZE = %d\nHASHCOUNT = %d\ncounter = %d\nHASHCODE = %d\n",
-		    HASHSIZE(table), HASHCOUNT(table), counter, new_hashcode);
-#endif
+	    int new_hashcode = hashIndex(TAG(chain), new_table);
+	    SEXP next = CDR(chain);
+	    SETCDR(chain, VECTOR_ELT(new_table, new_hashcode));
+	    SET_VECTOR_ELT(new_table, new_hashcode, chain);
+	    chain = next;
 	}
     }
     SET_HASHCOUNT(new_table, HASHCOUNT(table));
-    /* Some debugging statements */
-#ifdef MIKE_DEBUG
-    fprintf(stdout, "Resized O.K.\n");
-    fprintf(stdout, "Old size: %d, New size: %d\n",
-	    HASHSIZE(table), HASHSIZE(new_table));
-    fprintf(stdout, "Old count: %d, New count: %d\n",
-	    HASHCOUNT(table), HASHCOUNT(new_table));
-#endif
     return new_table;
 } /* end R_HashResize */
 
@@ -519,12 +514,7 @@ static SEXP R_HashFrame(SEXP rho)
     table = HASHTAB(rho);
     frame = FRAME(rho);
     while (!ISNULL(frame)) {
-	if( !HASHASH(PRINTNAME(TAG(frame))) ) {
-	    SET_HASHVALUE(PRINTNAME(TAG(frame)),
-			  R_Newhashpjw(CHAR(PRINTNAME(TAG(frame)))));
-	    SET_HASHASH(PRINTNAME(TAG(frame)), 1);
-	}
-	hashcode = HASHVALUE(PRINTNAME(TAG(frame))) % HASHSIZE(table);
+	hashcode = hashIndex(TAG(frame), table);
 	chain = VECTOR_ELT(table, hashcode);
 	SET_HASHCOUNT(table, HASHCOUNT(table) + 1);
 	tmp_chain = frame;
@@ -699,16 +689,6 @@ attribute_hidden void InitGlobalEnv(void)
 }
 
 #ifdef USE_GLOBAL_CACHE
-static int hashIndex(SEXP symbol, SEXP table)
-{
-    SEXP c = PRINTNAME(symbol);
-    if( !HASHASH(c) ) {
-	SET_HASHVALUE(c, R_Newhashpjw(CHAR(c)));
-	SET_HASHASH(c, 1);
-    }
-    return HASHVALUE(c) % HASHSIZE(table);
-}
-
 static void R_FlushGlobalCache(SEXP sym)
 {
     SEXP entry = R_HashGetLoc(hashIndex(sym, R_GlobalCache), sym,

--- a/src/main/envir.c
+++ b/src/main/envir.c
@@ -195,7 +195,9 @@ attribute_hidden Rboolean R_envHasNoSpecialSymbols (SEXP env)
   Hash Tables
 
   We use a basic separate chaining algorithm.	A hash table consists
-  of SEXP (vector) which contains a number of SEXPs (lists).
+  of SEXP (vector) which contains a number of SEXPs (lists).  Its
+  truelength holds the number of bindings in the table, so that the
+  load factor is known exactly.
 
   The only non-static function is R_NewHashedEnv, which allows code to
   request a hashed environment.  All others are static to allow
@@ -203,9 +205,14 @@ attribute_hidden Rboolean R_envHasNoSpecialSymbols (SEXP env)
 */
 
 #define HASHSIZE(x)	     ((int) STDVEC_LENGTH(x))
-#define HASHPRI(x)	     ((int) STDVEC_TRUELENGTH(x))
+#define HASHCOUNT(x)	     ((int) STDVEC_TRUELENGTH(x))
+#define SET_HASHCOUNT(x,v)   SET_TRUELENGTH(x,v)
 #define HASHTABLEGROWTHRATE  1.2
 #define HASHMINSIZE	     29
+
+/* The CHARSXP cache at the end of this file stores its number of
+   occupied chains in the same slot. */
+#define HASHPRI(x)	     ((int) STDVEC_TRUELENGTH(x))
 #define SET_HASHPRI(x,v)     SET_TRUELENGTH(x,v)
 #define HASHCHAIN(table, i)  ((SEXP *) STDVEC_DATAPTR(table))[i]
 
@@ -267,11 +274,10 @@ static void R_HashSet(int hashcode, SEXP symbol, SEXP table, SEXP value,
 	}
     if (frame_locked)
 	error(_("cannot add bindings to a locked environment"));
-    if (ISNULL(chain))
-	SET_HASHPRI(table, HASHPRI(table) + 1);
     /* Add the value into the chain */
     SET_VECTOR_ELT(table, hashcode, CONS(value, VECTOR_ELT(table, hashcode)));
     SET_TAG(VECTOR_ELT(table, hashcode), symbol);
+    SET_HASHCOUNT(table, HASHCOUNT(table) + 1);
     return;
 }
 
@@ -357,7 +363,7 @@ static SEXP R_NewHashTable(int size)
 
     /* Allocate hash table in the form of a vector */
     PROTECT(table = allocVector(VECSXP, size));
-    SET_HASHPRI(table, 0);
+    SET_HASHCOUNT(table, 0);
     UNPROTECT(1);
     return(table);
 }
@@ -404,9 +410,8 @@ static void R_HashDelete(int hashcode, SEXP symbol, SEXP env, int *found)
     if (*found) {
 	if (env == R_GlobalEnv)
 	    R_DirtyImage = 1;
-	if (list == R_NilValue)
-	    SET_HASHPRI(hashtab, HASHPRI(hashtab) - 1);
 	SET_VECTOR_ELT(hashtab, idx, list);
+	SET_HASHCOUNT(hashtab, HASHCOUNT(hashtab) - 1);
     }
 }
 
@@ -442,26 +447,24 @@ static SEXP R_HashResize(SEXP table)
 	    int new_hashcode = R_Newhashpjw(CHAR(PRINTNAME(TAG(chain)))) %
 		HASHSIZE(new_table);
 	    SEXP new_chain = VECTOR_ELT(new_table, new_hashcode);
-	    /* If using a primary slot then increase HASHPRI */
-	    if (ISNULL(new_chain))
-		SET_HASHPRI(new_table, HASHPRI(new_table) + 1);
 	    SEXP tmp_chain = chain;
 	    chain = CDR(chain);
 	    SETCDR(tmp_chain, new_chain);
 	    SET_VECTOR_ELT(new_table, new_hashcode,  tmp_chain);
 #ifdef MIKE_DEBUG
-	    fprintf(stdout, "HASHSIZE = %d\nHASHPRI = %d\ncounter = %d\nHASHCODE = %d\n",
-		    HASHSIZE(table), HASHPRI(table), counter, new_hashcode);
+	    fprintf(stdout, "HASHSIZE = %d\nHASHCOUNT = %d\ncounter = %d\nHASHCODE = %d\n",
+		    HASHSIZE(table), HASHCOUNT(table), counter, new_hashcode);
 #endif
 	}
     }
+    SET_HASHCOUNT(new_table, HASHCOUNT(table));
     /* Some debugging statements */
 #ifdef MIKE_DEBUG
     fprintf(stdout, "Resized O.K.\n");
     fprintf(stdout, "Old size: %d, New size: %d\n",
 	    HASHSIZE(table), HASHSIZE(new_table));
-    fprintf(stdout, "Old pri: %d, New pri: %d\n",
-	    HASHPRI(table), HASHPRI(new_table));
+    fprintf(stdout, "Old count: %d, New count: %d\n",
+	    HASHCOUNT(table), HASHCOUNT(new_table));
 #endif
     return new_table;
 } /* end R_HashResize */
@@ -472,9 +475,9 @@ static SEXP R_HashResize(SEXP table)
 
   R_HashSizeCheck
 
-  Hash table size rechecking function.	Compares the load factor
-  (size/# of primary slots used)  to a particular threshold value.
-  Returns true if the table needs to be resized.
+  Hash table size rechecking function.	Compares the number of entries
+  in the table to a threshold fraction of its size.  Returns true if
+  the table needs to be resized.
 
 */
 
@@ -487,7 +490,7 @@ static int R_HashSizeCheck(SEXP table)
     if (TYPEOF(table) != VECSXP)
 	error("first argument ('table') not of type VECSXP, R_HashSizeCheck");
     resize = 0; thresh_val = 0.85;
-    if ((double)HASHPRI(table) > (double)HASHSIZE(table) * thresh_val)
+    if ((double)HASHCOUNT(table) > (double)HASHSIZE(table) * thresh_val)
 	resize = 1;
     return resize;
 }
@@ -523,8 +526,7 @@ static SEXP R_HashFrame(SEXP rho)
 	}
 	hashcode = HASHVALUE(PRINTNAME(TAG(frame))) % HASHSIZE(table);
 	chain = VECTOR_ELT(table, hashcode);
-	/* If using a primary slot then increase HASHPRI */
-	if (ISNULL(chain)) SET_HASHPRI(table, HASHPRI(table) + 1);
+	SET_HASHCOUNT(table, HASHCOUNT(table) + 1);
 	tmp_chain = frame;
 	frame = CDR(frame);
 	SETCDR(tmp_chain, chain);
@@ -544,8 +546,7 @@ static SEXP R_HashFrame(SEXP rho)
 
    size: the total size of the hash table
 
-   nchains: the number of non-null chains in the table (as reported by
-	    HASHPRI())
+   nchains: the number of non-null chains in the table
 
    counts: an integer vector the same length as size giving the length of
 	   each chain (or zero if no chain is present).  This allows
@@ -566,8 +567,8 @@ static SEXP R_HashProfile(SEXP table)
     UNPROTECT(1);
 
     SET_VECTOR_ELT(ans, 0, ScalarInteger(length(table)));
-    SET_VECTOR_ELT(ans, 1, ScalarInteger(HASHPRI(table)));
 
+    int nchains = 0;
     PROTECT(chain_counts = allocVector(INTSXP, length(table)));
     for (i = 0; i < length(table); i++) {
 	chain = VECTOR_ELT(table, i);
@@ -576,8 +577,10 @@ static SEXP R_HashProfile(SEXP table)
 	    count++;
 	}
 	INTEGER(chain_counts)[i] = count;
+	if (count > 0)
+	    nchains++;
     }
-
+    SET_VECTOR_ELT(ans, 1, ScalarInteger(nchains));
     SET_VECTOR_ELT(ans, 2, chain_counts);
 
     UNPROTECT(2);
@@ -748,7 +751,7 @@ static void R_FlushGlobalCacheFromUserTable(SEXP udb)
 
 static void R_AddGlobalCache(SEXP symbol, SEXP place)
 {
-    int oldpri = HASHPRI(R_GlobalCache);
+    int oldcount = HASHCOUNT(R_GlobalCache);
     R_HashSet(hashIndex(symbol, R_GlobalCache), symbol, R_GlobalCache, place,
 	      FALSE);
 #ifdef FAST_BASE_CACHE_LOOKUP
@@ -757,8 +760,8 @@ static void R_AddGlobalCache(SEXP symbol, SEXP place)
     else
 	UNSET_BASE_SYM_CACHED(symbol);
 #endif
-    if (oldpri != HASHPRI(R_GlobalCache) &&
-	HASHPRI(R_GlobalCache) > 0.85 * HASHSIZE(R_GlobalCache)) {
+    if (oldcount != HASHCOUNT(R_GlobalCache) &&
+	HASHCOUNT(R_GlobalCache) > 0.85 * HASHSIZE(R_GlobalCache)) {
 	R_GlobalCache = R_HashResize(R_GlobalCache);
 	SETCAR(R_GlobalCachePreserve, R_GlobalCache);
     }
@@ -4125,9 +4128,10 @@ attribute_hidden void R_RestoreHashCount(SEXP rho)
 	table = HASHTAB(rho);
 	size = HASHSIZE(table);
 	for (i = 0, count = 0; i < size; i++)
-	    if (VECTOR_ELT(table, i) != R_NilValue)
+	    for (SEXP chain = VECTOR_ELT(table, i); chain != R_NilValue;
+		 chain = CDR(chain))
 		count++;
-	SET_HASHPRI(table, count);
+	SET_HASHCOUNT(table, count);
     }
 }
 

--- a/tests/reg-tests-1e.R
+++ b/tests/reg-tests-1e.R
@@ -3709,6 +3709,31 @@ stopifnot(identical(L00, ksmooth(x,y, x.points=NULL)),
 ## did seg.fault, trying to access x.points[1] from C
 
 
+## Hashed environments count their bindings exactly: env.profile() must
+## agree with the contents, also after removals and a serialization
+## round trip.
+e <- new.env(hash = TRUE)
+keys <- paste0("v", 1:5000)
+for(k in keys) assign(k, nchar(k), envir = e)
+p <- env.profile(e)
+stopifnot(sum(p$counts) == 5000L, p$nchains == sum(p$counts > 0L),
+          length(p$counts) == p$size)
+rm(list = keys[1:2500], envir = e)
+p <- env.profile(e)
+stopifnot(sum(p$counts) == 2500L, p$nchains == sum(p$counts > 0L),
+          identical(sort(ls(e)), sort(keys[2501:5000])))
+e2 <- unserialize(serialize(e, NULL))
+stopifnot(identical(env.profile(e2), env.profile(e)),
+          identical(mget(keys[2501:2510], e2), mget(keys[2501:2510], e)))
+for(k in keys[1:2500]) assign(k, 0L, envir = e2)
+p <- env.profile(e2)
+stopifnot(sum(p$counts) == 5000L,
+          identical(sort(ls(e2)), sort(keys)))
+rm(e, e2, keys, p)
+## env.profile()$nchains was the resize-time chain count, wrong after
+## any insert
+
+
 
 ## keep at end
 rbind(last =  proc.time() - .pt,


### PR DESCRIPTION
# Summary

`R_HashResize()` and `R_HashFrame()` rehashed every name's characters with `R_Newhashpjw()`, although the hash is cached in the name's CHARSXP the first time it is computed. Both now use the cached hash, through `hashIndex()`.

Second in the series split out of #320, stacked on #324 (this PR is the last commit); #326 builds on it.

## Changes

- `hashIndex()` moves out of the `USE_GLOBAL_CACHE` section: it never depended on the global cache, and `R_HashResize()` is compiled unconditionally, so a build with `USE_GLOBAL_CACHE` undefined would otherwise fail to link.
- The resize loop relinks the chain cells as before; the dead `MIKE_DEBUG` blocks and a stale comment are dropped.
