### PR TITLE
grow environment hash tables at 0.75 bindings per chain, to prime sizes that suit the PJW hash

### DIFF
--- a/doc/NEWS.Rd
+++ b/doc/NEWS.Rd
@@ -329,6 +329,13 @@
       zeros now, similarly to \code{lm()} via \code{glm.control()}; correct
       AIC and logLik() for this case, fixing \PR{16008}, thanks to \I{Bill
 	Dunlap} and \I{Mauricio Vargas}.
+
+      \item Hashed environments keep an exact count of their bindings.
+      Previously an insert counted bindings while a resize,
+      \code{attach()} and loading a saved environment counted occupied
+      chains, so \code{env.profile()} reported a wrong number of chains
+      and the resize threshold compared against a mixture of the two.
+      \code{env.profile()} now reports the number of non-empty chains.
     }
   }
 }

--- a/doc/NEWS.Rd
+++ b/doc/NEWS.Rd
@@ -107,6 +107,13 @@
       \item \code{tools::add_datalist()} now returns a logical
       (invisibly, instead of \code{NULL}), indicating if it did add
       a \file{data/datalist} file (addressing parts of \PR{18015}).
+
+      \item Hashed environments grow their hash table to a prime of
+      about twice the size once it holds more than 0.75 bindings per
+      chain, rather than by 20\% at 85\% full.  Filling an environment
+      with a million bindings one at a time moves each binding about
+      1.5 times on the way instead of 5.7, and lookups in large
+      environments visit fewer bindings.
     }
   }
 

--- a/doc/manual/R-ints.texi
+++ b/doc/manual/R-ints.texi
@@ -367,7 +367,7 @@ types are a @code{VECTOR_SEXPREC}, which again consists of the header
 and the same three pointers, but followed by two integers giving the
 length and `true length'@footnote{The only current use is for hash tables of
 environments (@code{VECSXP}s), where @code{length} is the size of the table
-and @code{truelength} is the number of primary slots in use, for the
+and @code{truelength} is the number of bindings it holds, for the
 reference hash tables in serialization (@code{VECSXP}s), and for `growable'
 vectors (atomic vectors, @code{VECSXP}s and @code{EXPRSXP}s) which are
 created by slightly over-committing when enlarging a vector during
@@ -610,7 +610,7 @@ table.
 Environments in @R{} usually have a hash table, and nowadays that is the
 default in @code{new.env()}.  It is stored as a @code{VECSXP} where
 @code{length} is used for the allocated size of the table and
-@code{truelength} is the number of primary slots in use---the pointer to
+@code{truelength} is the number of bindings it holds---the pointer to
 the @code{VECSXP} is part of the header of a @code{SEXP} of type
 @code{ENVSXP}, and this points to @code{R_NilValue} if the environment
 is not hashed.
@@ -620,8 +620,8 @@ For the pros and cons of hashing, see a basic text on Computer Science.
 The code to implement hashed environments is in @file{src/main/envir.c}.
 Unless set otherwise (e.g.@: by the @code{size} argument of
 @code{new.env()}) the initial table size is @code{29}.  The table will
-be resized by a factor of 1.2 once the load factor (the proportion of
-primary slots in use) reaches 85%.
+be resized by a factor of 1.2 once it holds more than 0.85 bindings per
+slot.
 
 The hash chains are stored as pairlist elements of the @code{VECSXP}:
 items are inserted at the front of the pairlist.  Hashing is principally

--- a/doc/manual/R-ints.texi
+++ b/doc/manual/R-ints.texi
@@ -619,9 +619,13 @@ For the pros and cons of hashing, see a basic text on Computer Science.
 
 The code to implement hashed environments is in @file{src/main/envir.c}.
 Unless set otherwise (e.g.@: by the @code{size} argument of
-@code{new.env()}) the initial table size is @code{29}.  The table will
-be resized by a factor of 1.2 once it holds more than 0.85 bindings per
-slot.
+@code{new.env()}) the initial table size is @code{29}.  Once the table
+holds more than 0.75 bindings per slot it moves to a prime size of
+about twice as many slots: each binding on a chain visited by a lookup
+is usually a cache miss, so the load factor sets the cost of a lookup,
+and the sizes are chosen so that the hash function, a base-16
+polynomial of the characters, spreads names with running numbers
+evenly (sizes near a small multiple of a power of two do not).
 
 The hash chains are stored as pairlist elements of the @code{VECSXP}:
 items are inserted at the front of the pairlist.  Hashing is principally

--- a/src/library/base/man/environment.Rd
+++ b/src/library/base/man/environment.Rd
@@ -86,8 +86,8 @@ env.profile(env)
 
   \code{env.profile} returns a list with the following components:
   \code{size} the number of chains that can be stored in the hash table,
-  \code{nchains} the number of non-empty chains in the table (as
-  reported by \code{HASHPRI}), and \code{counts} an integer vector
+  \code{nchains} the number of non-empty chains in the table, and
+  \code{counts} an integer vector
   giving the length of each chain (zero for empty chains).  This
   function is intended to assess the performance of hashed environments.
   When \code{env} is a non-hashed environment, \code{NULL} is returned.

--- a/src/main/envir.c
+++ b/src/main/envir.c
@@ -207,13 +207,36 @@ attribute_hidden Rboolean R_envHasNoSpecialSymbols (SEXP env)
 #define HASHSIZE(x)	     ((int) STDVEC_LENGTH(x))
 #define HASHCOUNT(x)	     ((int) STDVEC_TRUELENGTH(x))
 #define SET_HASHCOUNT(x,v)   SET_TRUELENGTH(x,v)
-#define HASHTABLEGROWTHRATE  1.2
+#define HASHTABLELOAD	     0.75
 #define HASHMINSIZE	     29
 
 /* The CHARSXP cache at the end of this file stores its number of
    occupied chains in the same slot. */
 #define HASHPRI(x)	     ((int) STDVEC_TRUELENGTH(x))
 #define SET_HASHPRI(x,v)     SET_TRUELENGTH(x,v)
+
+/* Sizes a table grows through: the first prime above 1.618 times each
+   power of two from 2^5 to 2^30.  A table more than HASHTABLELOAD full
+   moves to the next of these, about twice its size.  The sizes matter
+   because R_Newhashpjw() is a base-16 polynomial of the characters and
+   the hash is reduced by division: with sizes near a small multiple of
+   a power of two, such as 2n + 1 from 29 (15 * 2^k - 1) or the primes
+   just above a power of two, names which differ in a running number
+   collapse onto a fraction of the chains (a table of a million such
+   names had 23% of its chains in use where a uniform hash gives 40%,
+   and twice the lookups of a uniform table).  Simulated over a million
+   names of six shapes, these sizes are within a few percent of uniform,
+   while the old growth by 1.2 avoided the problem by accident. */
+static const int HashTableSizes[] = {
+    53, 107, 211, 419,
+    829, 1657, 3319, 6637,
+    13259, 26513, 53047, 106087,
+    212081, 424163, 848321, 1696649,
+    3393311, 6786529, 13573067, 27146107,
+    54292219, 108584447, 217168859, 434337707,
+    868675439, 1737350779
+};
+#define NHASHTABLESIZES (sizeof(HashTableSizes) / sizeof(HashTableSizes[0]))
 #define HASHCHAIN(table, i)  ((SEXP *) STDVEC_DATAPTR(table))[i]
 
 #define IS_HASHED(x)	     (HASHTAB(x) != R_NilValue)
@@ -447,10 +470,17 @@ static SEXP R_HashResize(SEXP table)
     if (TYPEOF(table) != VECSXP)
 	error("first argument ('table') not of type VECSXP, from R_HashResize");
 
-    /* Allocate the new hash table.  The names' hashes are cached in
-       their CHARSXPs, so the strings are not rehashed. */
-    SEXP new_table = R_NewHashTable(1 + (int)(HASHSIZE(table) * HASHTABLEGROWTHRATE));
-    for (int counter = 0; counter < HASHSIZE(table); counter++) {
+    /* Move to the first of the sizes at least one and a half times the
+       current one: the next one up for a table already on the ladder,
+       as consecutive sizes are about double, and between one and a
+       half and three times for a table sized by the user.  The names'
+       hashes are cached in their CHARSXPs, so the strings are not
+       rehashed. */
+    int n = HASHSIZE(table), i = 0;
+    while (i < NHASHTABLESIZES - 1 && HashTableSizes[i] < 1.5 * n)
+	i++;
+    SEXP new_table = R_NewHashTable(HashTableSizes[i]);
+    for (int counter = 0; counter < n; counter++) {
 	SEXP chain = VECTOR_ELT(table, counter);
 	while (!ISNULL(chain)) {
 	    int new_hashcode = hashIndex(TAG(chain), new_table);
@@ -478,16 +508,16 @@ static SEXP R_HashResize(SEXP table)
 
 static int R_HashSizeCheck(SEXP table)
 {
-    int resize;
-    double thresh_val;
-
     /* Do some checking */
     if (TYPEOF(table) != VECSXP)
 	error("first argument ('table') not of type VECSXP, R_HashSizeCheck");
-    resize = 0; thresh_val = 0.85;
-    if ((double)HASHCOUNT(table) > (double)HASHSIZE(table) * thresh_val)
-	resize = 1;
-    return resize;
+    /* Every binding on a chain which a lookup visits is usually a cache
+       miss, so the load factor sets the cost of a lookup.  The table
+       used to grow by 20% at 85% full, which left it at one to two
+       bindings per chain and moved each binding about six times on the
+       way to a million. */
+    return HASHCOUNT(table) > HASHTABLELOAD * HASHSIZE(table) &&
+	HASHSIZE(table) < HashTableSizes[NHASHTABLESIZES - 1];
 }
 
 
@@ -731,7 +761,6 @@ static void R_FlushGlobalCacheFromUserTable(SEXP udb)
 
 static void R_AddGlobalCache(SEXP symbol, SEXP place)
 {
-    int oldcount = HASHCOUNT(R_GlobalCache);
     R_HashSet(hashIndex(symbol, R_GlobalCache), symbol, R_GlobalCache, place,
 	      FALSE);
 #ifdef FAST_BASE_CACHE_LOOKUP
@@ -740,8 +769,7 @@ static void R_AddGlobalCache(SEXP symbol, SEXP place)
     else
 	UNSET_BASE_SYM_CACHED(symbol);
 #endif
-    if (oldcount != HASHCOUNT(R_GlobalCache) &&
-	HASHCOUNT(R_GlobalCache) > 0.85 * HASHSIZE(R_GlobalCache)) {
+    if (R_HashSizeCheck(R_GlobalCache)) {
 	R_GlobalCache = R_HashResize(R_GlobalCache);
 	SETCAR(R_GlobalCachePreserve, R_GlobalCache);
     }
@@ -4822,8 +4850,11 @@ SEXP mkCharLenCE(const char *name, int len, cetype_t enc)
 	   protected.
 	   Maximum possible power of two is 2^30 for a VECSXP.
 	   FIXME: this has changed with long vectors.
-	*/
-	if (R_HashSizeCheck(R_StringHash)
+
+	   The cache uses its own hash and power-of-two sizes, so it
+	   keeps its old growth trigger, occupied chains above 85% of
+	   the size, rather than R_HashSizeCheck(). */
+	if (HASHPRI(R_StringHash) > 0.85 * HASHSIZE(R_StringHash)
 	    && char_hash_size < 1073741824 /* 2^30 */)
 	    R_StringHash_resize(char_hash_size * 2);
 

--- a/src/main/envir.c
+++ b/src/main/envir.c
@@ -247,6 +247,18 @@ attribute_hidden int R_Newhashpjw(const char *s)
     return h;
 }
 
+/* Index of 'symbol' in 'table', from the hash cached in the name's
+   CHARSXP, computing and caching that hash if needed. */
+static int hashIndex(SEXP symbol, SEXP table)
+{
+    SEXP c = PRINTNAME(symbol);
+    if( !HASHASH(c) ) {
+	SET_HASHVALUE(c, R_Newhashpjw(CHAR(c)));
+	SET_HASHASH(c, 1);
+    }
+    return HASHVALUE(c) % HASHSIZE(table);
+}
+
 /*----------------------------------------------------------------------
 
   R_HashSet
@@ -435,37 +447,20 @@ static SEXP R_HashResize(SEXP table)
     if (TYPEOF(table) != VECSXP)
 	error("first argument ('table') not of type VECSXP, from R_HashResize");
 
-    /* This may have to change.	 The growth rate should
-       be independent of the size (not implemented yet) */
-    /* hash_grow = HASHSIZE(table); */
-
-    /* Allocate the new hash table */
+    /* Allocate the new hash table.  The names' hashes are cached in
+       their CHARSXPs, so the strings are not rehashed. */
     SEXP new_table = R_NewHashTable(1 + (int)(HASHSIZE(table) * HASHTABLEGROWTHRATE));
-    for (int counter = 0; counter < length(table); counter++) {
+    for (int counter = 0; counter < HASHSIZE(table); counter++) {
 	SEXP chain = VECTOR_ELT(table, counter);
 	while (!ISNULL(chain)) {
-	    int new_hashcode = R_Newhashpjw(CHAR(PRINTNAME(TAG(chain)))) %
-		HASHSIZE(new_table);
-	    SEXP new_chain = VECTOR_ELT(new_table, new_hashcode);
-	    SEXP tmp_chain = chain;
-	    chain = CDR(chain);
-	    SETCDR(tmp_chain, new_chain);
-	    SET_VECTOR_ELT(new_table, new_hashcode,  tmp_chain);
-#ifdef MIKE_DEBUG
-	    fprintf(stdout, "HASHSIZE = %d\nHASHCOUNT = %d\ncounter = %d\nHASHCODE = %d\n",
-		    HASHSIZE(table), HASHCOUNT(table), counter, new_hashcode);
-#endif
+	    int new_hashcode = hashIndex(TAG(chain), new_table);
+	    SEXP next = CDR(chain);
+	    SETCDR(chain, VECTOR_ELT(new_table, new_hashcode));
+	    SET_VECTOR_ELT(new_table, new_hashcode, chain);
+	    chain = next;
 	}
     }
     SET_HASHCOUNT(new_table, HASHCOUNT(table));
-    /* Some debugging statements */
-#ifdef MIKE_DEBUG
-    fprintf(stdout, "Resized O.K.\n");
-    fprintf(stdout, "Old size: %d, New size: %d\n",
-	    HASHSIZE(table), HASHSIZE(new_table));
-    fprintf(stdout, "Old count: %d, New count: %d\n",
-	    HASHCOUNT(table), HASHCOUNT(new_table));
-#endif
     return new_table;
 } /* end R_HashResize */
 
@@ -519,12 +514,7 @@ static SEXP R_HashFrame(SEXP rho)
     table = HASHTAB(rho);
     frame = FRAME(rho);
     while (!ISNULL(frame)) {
-	if( !HASHASH(PRINTNAME(TAG(frame))) ) {
-	    SET_HASHVALUE(PRINTNAME(TAG(frame)),
-			  R_Newhashpjw(CHAR(PRINTNAME(TAG(frame)))));
-	    SET_HASHASH(PRINTNAME(TAG(frame)), 1);
-	}
-	hashcode = HASHVALUE(PRINTNAME(TAG(frame))) % HASHSIZE(table);
+	hashcode = hashIndex(TAG(frame), table);
 	chain = VECTOR_ELT(table, hashcode);
 	SET_HASHCOUNT(table, HASHCOUNT(table) + 1);
 	tmp_chain = frame;
@@ -699,16 +689,6 @@ attribute_hidden void InitGlobalEnv(void)
 }
 
 #ifdef USE_GLOBAL_CACHE
-static int hashIndex(SEXP symbol, SEXP table)
-{
-    SEXP c = PRINTNAME(symbol);
-    if( !HASHASH(c) ) {
-	SET_HASHVALUE(c, R_Newhashpjw(CHAR(c)));
-	SET_HASHASH(c, 1);
-    }
-    return HASHVALUE(c) % HASHSIZE(table);
-}
-
 static void R_FlushGlobalCache(SEXP sym)
 {
     SEXP entry = R_HashGetLoc(hashIndex(sym, R_GlobalCache), sym,

--- a/src/main/envir.c
+++ b/src/main/envir.c
@@ -195,7 +195,9 @@ attribute_hidden Rboolean R_envHasNoSpecialSymbols (SEXP env)
   Hash Tables
 
   We use a basic separate chaining algorithm.	A hash table consists
-  of SEXP (vector) which contains a number of SEXPs (lists).
+  of SEXP (vector) which contains a number of SEXPs (lists).  Its
+  truelength holds the number of bindings in the table, so that the
+  load factor is known exactly.
 
   The only non-static function is R_NewHashedEnv, which allows code to
   request a hashed environment.  All others are static to allow
@@ -203,9 +205,14 @@ attribute_hidden Rboolean R_envHasNoSpecialSymbols (SEXP env)
 */
 
 #define HASHSIZE(x)	     ((int) STDVEC_LENGTH(x))
-#define HASHPRI(x)	     ((int) STDVEC_TRUELENGTH(x))
+#define HASHCOUNT(x)	     ((int) STDVEC_TRUELENGTH(x))
+#define SET_HASHCOUNT(x,v)   SET_TRUELENGTH(x,v)
 #define HASHTABLEGROWTHRATE  1.2
 #define HASHMINSIZE	     29
+
+/* The CHARSXP cache at the end of this file stores its number of
+   occupied chains in the same slot. */
+#define HASHPRI(x)	     ((int) STDVEC_TRUELENGTH(x))
 #define SET_HASHPRI(x,v)     SET_TRUELENGTH(x,v)
 #define HASHCHAIN(table, i)  ((SEXP *) STDVEC_DATAPTR(table))[i]
 
@@ -267,11 +274,10 @@ static void R_HashSet(int hashcode, SEXP symbol, SEXP table, SEXP value,
 	}
     if (frame_locked)
 	error(_("cannot add bindings to a locked environment"));
-    if (ISNULL(chain))
-	SET_HASHPRI(table, HASHPRI(table) + 1);
     /* Add the value into the chain */
     SET_VECTOR_ELT(table, hashcode, CONS(value, VECTOR_ELT(table, hashcode)));
     SET_TAG(VECTOR_ELT(table, hashcode), symbol);
+    SET_HASHCOUNT(table, HASHCOUNT(table) + 1);
     return;
 }
 
@@ -357,7 +363,7 @@ static SEXP R_NewHashTable(int size)
 
     /* Allocate hash table in the form of a vector */
     PROTECT(table = allocVector(VECSXP, size));
-    SET_HASHPRI(table, 0);
+    SET_HASHCOUNT(table, 0);
     UNPROTECT(1);
     return(table);
 }
@@ -404,9 +410,8 @@ static void R_HashDelete(int hashcode, SEXP symbol, SEXP env, int *found)
     if (*found) {
 	if (env == R_GlobalEnv)
 	    R_DirtyImage = 1;
-	if (list == R_NilValue)
-	    SET_HASHPRI(hashtab, HASHPRI(hashtab) - 1);
 	SET_VECTOR_ELT(hashtab, idx, list);
+	SET_HASHCOUNT(hashtab, HASHCOUNT(hashtab) - 1);
     }
 }
 
@@ -442,26 +447,24 @@ static SEXP R_HashResize(SEXP table)
 	    int new_hashcode = R_Newhashpjw(CHAR(PRINTNAME(TAG(chain)))) %
 		HASHSIZE(new_table);
 	    SEXP new_chain = VECTOR_ELT(new_table, new_hashcode);
-	    /* If using a primary slot then increase HASHPRI */
-	    if (ISNULL(new_chain))
-		SET_HASHPRI(new_table, HASHPRI(new_table) + 1);
 	    SEXP tmp_chain = chain;
 	    chain = CDR(chain);
 	    SETCDR(tmp_chain, new_chain);
 	    SET_VECTOR_ELT(new_table, new_hashcode,  tmp_chain);
 #ifdef MIKE_DEBUG
-	    fprintf(stdout, "HASHSIZE = %d\nHASHPRI = %d\ncounter = %d\nHASHCODE = %d\n",
-		    HASHSIZE(table), HASHPRI(table), counter, new_hashcode);
+	    fprintf(stdout, "HASHSIZE = %d\nHASHCOUNT = %d\ncounter = %d\nHASHCODE = %d\n",
+		    HASHSIZE(table), HASHCOUNT(table), counter, new_hashcode);
 #endif
 	}
     }
+    SET_HASHCOUNT(new_table, HASHCOUNT(table));
     /* Some debugging statements */
 #ifdef MIKE_DEBUG
     fprintf(stdout, "Resized O.K.\n");
     fprintf(stdout, "Old size: %d, New size: %d\n",
 	    HASHSIZE(table), HASHSIZE(new_table));
-    fprintf(stdout, "Old pri: %d, New pri: %d\n",
-	    HASHPRI(table), HASHPRI(new_table));
+    fprintf(stdout, "Old count: %d, New count: %d\n",
+	    HASHCOUNT(table), HASHCOUNT(new_table));
 #endif
     return new_table;
 } /* end R_HashResize */
@@ -472,9 +475,9 @@ static SEXP R_HashResize(SEXP table)
 
   R_HashSizeCheck
 
-  Hash table size rechecking function.	Compares the load factor
-  (size/# of primary slots used)  to a particular threshold value.
-  Returns true if the table needs to be resized.
+  Hash table size rechecking function.	Compares the number of entries
+  in the table to a threshold fraction of its size.  Returns true if
+  the table needs to be resized.
 
 */
 
@@ -487,7 +490,7 @@ static int R_HashSizeCheck(SEXP table)
     if (TYPEOF(table) != VECSXP)
 	error("first argument ('table') not of type VECSXP, R_HashSizeCheck");
     resize = 0; thresh_val = 0.85;
-    if ((double)HASHPRI(table) > (double)HASHSIZE(table) * thresh_val)
+    if ((double)HASHCOUNT(table) > (double)HASHSIZE(table) * thresh_val)
 	resize = 1;
     return resize;
 }
@@ -523,8 +526,7 @@ static SEXP R_HashFrame(SEXP rho)
 	}
 	hashcode = HASHVALUE(PRINTNAME(TAG(frame))) % HASHSIZE(table);
 	chain = VECTOR_ELT(table, hashcode);
-	/* If using a primary slot then increase HASHPRI */
-	if (ISNULL(chain)) SET_HASHPRI(table, HASHPRI(table) + 1);
+	SET_HASHCOUNT(table, HASHCOUNT(table) + 1);
 	tmp_chain = frame;
 	frame = CDR(frame);
 	SETCDR(tmp_chain, chain);
@@ -544,8 +546,7 @@ static SEXP R_HashFrame(SEXP rho)
 
    size: the total size of the hash table
 
-   nchains: the number of non-null chains in the table (as reported by
-	    HASHPRI())
+   nchains: the number of non-null chains in the table
 
    counts: an integer vector the same length as size giving the length of
 	   each chain (or zero if no chain is present).  This allows
@@ -566,8 +567,8 @@ static SEXP R_HashProfile(SEXP table)
     UNPROTECT(1);
 
     SET_VECTOR_ELT(ans, 0, ScalarInteger(length(table)));
-    SET_VECTOR_ELT(ans, 1, ScalarInteger(HASHPRI(table)));
 
+    int nchains = 0;
     PROTECT(chain_counts = allocVector(INTSXP, length(table)));
     for (i = 0; i < length(table); i++) {
 	chain = VECTOR_ELT(table, i);
@@ -576,8 +577,10 @@ static SEXP R_HashProfile(SEXP table)
 	    count++;
 	}
 	INTEGER(chain_counts)[i] = count;
+	if (count > 0)
+	    nchains++;
     }
-
+    SET_VECTOR_ELT(ans, 1, ScalarInteger(nchains));
     SET_VECTOR_ELT(ans, 2, chain_counts);
 
     UNPROTECT(2);
@@ -748,7 +751,7 @@ static void R_FlushGlobalCacheFromUserTable(SEXP udb)
 
 static void R_AddGlobalCache(SEXP symbol, SEXP place)
 {
-    int oldpri = HASHPRI(R_GlobalCache);
+    int oldcount = HASHCOUNT(R_GlobalCache);
     R_HashSet(hashIndex(symbol, R_GlobalCache), symbol, R_GlobalCache, place,
 	      FALSE);
 #ifdef FAST_BASE_CACHE_LOOKUP
@@ -757,8 +760,8 @@ static void R_AddGlobalCache(SEXP symbol, SEXP place)
     else
 	UNSET_BASE_SYM_CACHED(symbol);
 #endif
-    if (oldpri != HASHPRI(R_GlobalCache) &&
-	HASHPRI(R_GlobalCache) > 0.85 * HASHSIZE(R_GlobalCache)) {
+    if (oldcount != HASHCOUNT(R_GlobalCache) &&
+	HASHCOUNT(R_GlobalCache) > 0.85 * HASHSIZE(R_GlobalCache)) {
 	R_GlobalCache = R_HashResize(R_GlobalCache);
 	SETCAR(R_GlobalCachePreserve, R_GlobalCache);
     }
@@ -4125,9 +4128,10 @@ attribute_hidden void R_RestoreHashCount(SEXP rho)
 	table = HASHTAB(rho);
 	size = HASHSIZE(table);
 	for (i = 0, count = 0; i < size; i++)
-	    if (VECTOR_ELT(table, i) != R_NilValue)
+	    for (SEXP chain = VECTOR_ELT(table, i); chain != R_NilValue;
+		 chain = CDR(chain))
 		count++;
-	SET_HASHPRI(table, count);
+	SET_HASHCOUNT(table, count);
     }
 }
 

--- a/tests/reg-tests-1e.R
+++ b/tests/reg-tests-1e.R
@@ -3709,15 +3709,15 @@ stopifnot(identical(L00, ksmooth(x,y, x.points=NULL)),
 ## did seg.fault, trying to access x.points[1] from C
 
 
-## Hashed environments count their bindings exactly: env.profile() must
-## agree with the contents, also after removals and a serialization
-## round trip.
+## Hashed environments grow at 0.75 bindings per chain and count their
+## bindings exactly: env.profile() must agree with the contents, also
+## after removals and a serialization round trip.
 e <- new.env(hash = TRUE)
 keys <- paste0("v", 1:5000)
 for(k in keys) assign(k, nchar(k), envir = e)
 p <- env.profile(e)
 stopifnot(sum(p$counts) == 5000L, p$nchains == sum(p$counts > 0L),
-          length(p$counts) == p$size)
+          sum(p$counts) <= 0.75 * p$size, length(p$counts) == p$size)
 rm(list = keys[1:2500], envir = e)
 p <- env.profile(e)
 stopifnot(sum(p$counts) == 2500L, p$nchains == sum(p$counts > 0L),
@@ -3727,7 +3727,7 @@ stopifnot(identical(env.profile(e2), env.profile(e)),
           identical(mget(keys[2501:2510], e2), mget(keys[2501:2510], e)))
 for(k in keys[1:2500]) assign(k, 0L, envir = e2)
 p <- env.profile(e2)
-stopifnot(sum(p$counts) == 5000L,
+stopifnot(sum(p$counts) == 5000L, sum(p$counts) <= 0.75 * p$size,
           identical(sort(ls(e2)), sort(keys)))
 rm(e, e2, keys, p)
 ## env.profile()$nchains was the resize-time chain count, wrong after

--- a/tests/reg-tests-1e.R
+++ b/tests/reg-tests-1e.R
@@ -3709,6 +3709,31 @@ stopifnot(identical(L00, ksmooth(x,y, x.points=NULL)),
 ## did seg.fault, trying to access x.points[1] from C
 
 
+## Hashed environments count their bindings exactly: env.profile() must
+## agree with the contents, also after removals and a serialization
+## round trip.
+e <- new.env(hash = TRUE)
+keys <- paste0("v", 1:5000)
+for(k in keys) assign(k, nchar(k), envir = e)
+p <- env.profile(e)
+stopifnot(sum(p$counts) == 5000L, p$nchains == sum(p$counts > 0L),
+          length(p$counts) == p$size)
+rm(list = keys[1:2500], envir = e)
+p <- env.profile(e)
+stopifnot(sum(p$counts) == 2500L, p$nchains == sum(p$counts > 0L),
+          identical(sort(ls(e)), sort(keys[2501:5000])))
+e2 <- unserialize(serialize(e, NULL))
+stopifnot(identical(env.profile(e2), env.profile(e)),
+          identical(mget(keys[2501:2510], e2), mget(keys[2501:2510], e)))
+for(k in keys[1:2500]) assign(k, 0L, envir = e2)
+p <- env.profile(e2)
+stopifnot(sum(p$counts) == 5000L,
+          identical(sort(ls(e2)), sort(keys)))
+rm(e, e2, keys, p)
+## env.profile()$nchains was the resize-time chain count, wrong after
+## any insert
+
+
 
 ## keep at end
 rbind(last =  proc.time() - .pt,


### PR DESCRIPTION
# Summary

Hashed environments grow their table at a measured load factor, to prime sizes chosen for the PJW hash. Filling an environment with a million bindings one at a time is 2.7x faster, and lookups in large environments visit 1.2 bindings per hit instead of 1.75.

Last in the series split out of #320 (which it supersedes), stacked on #324 and #325; this PR is the last commit. Unlike #320 the series applies directly to `main`: the CHARSXP cache keeps its own growth trigger (occupied chains above 85% of the size, now written out at its one call site), so nothing here depends on #316.

## Changes

- A table holding more than 0.75 bindings per chain moves to the next size of a ladder, the first prime above 1.618 times each power of two from 2^5 to 2^30; a user-sized table moves to the first ladder size at least 1.5 times its own. Every binding on a chain that a lookup visits is usually a cache miss, so the load factor sets the cost of a lookup.
- The global symbol cache grows through the same check.
- Documentation in R Internals; the regression test from #324 now also checks the 0.75 load bound.

## Why these sizes

The first attempt doubled to 2n + 1, which from 29 gives 15 * 2^k - 1, and lookups got *slower*: a million `key<N>` names occupied 23% of the chains where a uniform hash gives 40%. `R_Newhashpjw()` is a base-16 polynomial of the characters (`h = (h << 4) + c` with the top nibble folded back), and the index is the hash modulo the size, so a modulus near a small multiple of a power of two folds the lattice of digit values onto itself. Primes do not help by themselves: 2097169, the first prime above 2^21, is just as bad, while 2000001 and 1000003 are fine. The hash cannot change, because hashed environments are serialized with their chains in place and must stay readable, so only the sizes can. Simulated occupancy relative to a uniform hash, a million names at load 0.5, six name shapes:

| sizes | `key<N>` | `v<N>` random order | 8 random letters | `pkg.fun_<N>` | `<N>` | `my_var_<N>_x` |
|---|---|---|---|---|---|---|
| 2n + 1 from 29, at 2^21 | 0.59 | 0.58 | 0.97 | 0.68 | 0.53 | 0.78 |
| prime above 1.618 * 2^k | 0.97 to 1.08 | 0.99 to 1.06 | 1.00 | 0.95 to 1.08 | 0.96 to 1.09 | 1.00 to 1.04 |

The old growth by 1.2 produced irregular sizes and avoided the problem by accident (a grown table of 864,241 slots was at 0.88 of uniform).

## Measurements

aarch64 macOS, `-O2`, `R_SYMBOL_TABLE_SIZE=2000000` (via #316's env var) so that the symbol table does not dominate (with the default symbol table the million-key figures are all about 1.7 us higher on both sides). Nanoseconds per binding:

| 1e6 bindings | before | after |
|---|---|---|
| `list2env()` into a default-size environment (grows on the way) | 890 | 325 |
| `list2env()` into a presized environment | 346 | 294 |
| `assign()` one at a time (dominated by `assign()` itself) | 2565 | 2487 |
| `mget()`, grown table | 620 | 590 |
| bindings visited per hit, grown table | 1.75 | 1.22 |
| table slots | 864,241 | 1,696,649 |

| 1e5 bindings | before | after |
|---|---|---|
| `list2env()` into a default-size environment | 410 | 160 |
| `mget()` | 320 | 250 |

`attach()` of a 200,000-element list takes 652 ms instead of 614, since the presized table now resizes once. Loading and unloading `stats4` twenty times, and R startup, are unchanged. The table takes about 16 bytes per binding instead of 4 to 8, against the 56 bytes of the binding's cons cell.
