### PR TITLE
close unserialize's iconv descriptors when an error unwinds

### DIFF
--- a/src/main/serialize.c
+++ b/src/main/serialize.c
@@ -2251,6 +2251,22 @@ static void DecodeVersion(int packed, int *v, int *p, int *s)
     *s = packed;
 }
 
+/* ReadChar opens iconv descriptors lazily and caches them in the stream;
+   close them both when unserialization finishes and when an error unwinds
+   out of it */
+static void CloseInStreamConverters(void *data)
+{
+    R_inpstream_t stream = data;
+    if (stream->nat2nat_obj && stream->nat2nat_obj != (void *)-1) {
+	Riconv_close(stream->nat2nat_obj);
+	stream->nat2nat_obj = NULL;
+    }
+    if (stream->nat2utf8_obj && stream->nat2utf8_obj != (void *)-1) {
+	Riconv_close(stream->nat2utf8_obj);
+	stream->nat2utf8_obj = NULL;
+    }
+}
+
 SEXP R_Unserialize(R_inpstream_t stream)
 {
     int version;
@@ -2291,18 +2307,17 @@ SEXP R_Unserialize(R_inpstream_t stream)
 
     /* Read the actual object back */
     PROTECT(ref_table = MakeReadRefTable());
-    obj =  ReadItem(ref_table, stream);
 
-    if (version == 3) {
-	if (stream->nat2nat_obj && stream->nat2nat_obj != (void *)-1) {
-	    Riconv_close(stream->nat2nat_obj);
-	    stream->nat2nat_obj = NULL;
-	}
-	if (stream->nat2utf8_obj && stream->nat2utf8_obj != (void *)-1) {
-	    Riconv_close(stream->nat2utf8_obj);
-	    stream->nat2utf8_obj = NULL;
-	}
-    }
+    RCNTXT cntxt;
+    begincontext(&cntxt, CTXT_CCODE, R_NilValue, R_BaseEnv, R_BaseEnv,
+		 R_NilValue, R_NilValue);
+    cntxt.cend = &CloseInStreamConverters;
+    cntxt.cenddata = stream;
+
+    obj = ReadItem(ref_table, stream);
+
+    endcontext(&cntxt);
+    CloseInStreamConverters(stream);
     UNPROTECT(1);
 
     return obj;


### PR DESCRIPTION
`ReadChar` in `src/main/serialize.c` translates the native-encoded strings
of a version-3 stream when the stream's writer ran in a different native
encoding than the reader. It opens up to two iconv descriptors lazily and
caches them in the `R_inpstream_t` (`nat2nat_obj`, `nat2utf8_obj`);
`R_Unserialize` closes them only on the normal return path. Any error
signalled after the first translated string longjmps past that close and
leaks both descriptors, per failing `unserialize()` / `readRDS()` /
`load()` call. With glibc a descriptor is about 33 KB (the gconv step
buffer dominates).

Reachable error paths include at least:

- `InString` signalling `"read error"` for a truncated stream,
- `mkCharLenCE` signalling `"embedded nul in string"` (the fuzzer's case),
- allocation failures anywhere later in the stream.

## Affected code

```c
    PROTECT(ref_table = MakeReadRefTable());
    obj =  ReadItem(ref_table, stream);          /* <-- may longjmp */

    if (version == 3) {
	if (stream->nat2nat_obj && stream->nat2nat_obj != (void *)-1) {
	    Riconv_close(stream->nat2nat_obj);   /* never reached on error */
```

## Reproducer

Serialize two native (unflagged) latin1 strings, rewrite the stream header
to claim a latin1 writer so that a UTF-8 reader has to translate, then
truncate the stream inside the second string:

```r
x <- iconv(c("héllo", "wörld"), "UTF-8", "latin1")
Encoding(x) <- "unknown"                    # write them as native strings
s <- serialize(x, NULL)                     # header names this session's UTF-8
len <- readBin(s[15:18], "integer", endian = "big")
s <- c(s[1:14], writeBin(10L, raw(), endian = "big"), charToRaw("ISO-8859-1"),
       s[-(1:(18 + len))])
unserialize(s)                              # translated: "héllo" "wörld"
bad <- head(s, -3)                          # truncate inside the second string
for (i in 1:2000)
    try(unserialize(bad), silent = TRUE)    # "read error"; leaks a descriptor each
```

The ClusterFuzzLite input that found this is a 61-byte version-3 stream
declaring `ANSI_X3.4-1968` as the writer encoding, holding one native
CHARSXP with a non-ASCII byte and an embedded nul: translation fails,
`mkCharLenCE` signals, and the descriptor opened for the attempt leaks.

## Measurements

Unpatched trunk r90486 (aarch64-apple-darwin25.6.0), macOS `leaks` with
`MallocStackLogging` after the loop above (2001 failing calls including
the one caught by `tryCatch`):

```
Process 55581: 6003 leaks for 928464 total leaked bytes.

STACK OF 2000 INSTANCES OF 'ROOT LEAK: <malloc in iconv_open_internal>':
1   R  iconv_open_internal + 80  sysutils.c:1359
      3 (464 bytes) ROOT LEAK: <malloc in iconv_open_internal ...> [96]
         2 (368 bytes) <malloc in _citrus_iconv_open ...> [48]
```

Patched, same loop, and the fuzzer's input replayed 2000 times:

```
Process 57679: 0 leaks for 0 total leaked bytes.
```

LeakSanitizer's view from the CI run (glibc; one descriptor per call):

```
==2371==ERROR: LeakSanitizer: detected memory leaks
Direct leak of 112 byte(s) in 1 object(s) allocated from:
    #1 __gconv_open
    #2 iconv_open
Indirect leak of 32640 byte(s) in 1 object(s) allocated from:
    #1 __gconv_open
SUMMARY: AddressSanitizer: 32960 byte(s) leaked in 3 allocation(s).
```

## Fix

Close the descriptors from a `CTXT_CCODE` cleanup context around
`ReadItem`, the same idiom `do_dput` / `do_dump` use for connections, so
the unwind closes them too. Translation of a mismatched-encoding stream,
`readRDS`, lazy loading, and `reg-tests-1d` / `reg-tests-1e` behave as
before.

Found by fuzzing R with libFuzzer + LeakSanitizer (r-devel/r-oss-fuzz,
ClusterFuzzLite batch run 34017923207).
