### PR TITLE
free radix sort's scratch buffers when an error unwinds

### DIFF
--- a/src/main/radixsort.c
+++ b/src/main/radixsort.c
@@ -24,6 +24,7 @@
 #include <config.h>
 #endif
 
+#define R_USE_SIGNALS 1 /* for the cleanup context */
 #include <Defn.h>
 #include <Internal.h>
 
@@ -1543,6 +1544,34 @@ static void dsort(double *x, int *o, int n)
     }
 }
 
+/* The scratch buffers are file statics reused across calls, and
+   do_radixsort frees them on its normal return.  An error signalled
+   mid-sort (the Error() macro, an allocation failure) unwinds past that
+   and the next call overwrites the pointers with fresh allocations, so
+   free them from a cleanup context as well.  xsub is do_radixsort's own
+   local; its address is the context data. */
+static void radix_cleanup(void *data)
+{
+    void **pxsub = data;
+
+    /* same order as the normal path: drop the marks planted on the
+       CHARSXPs, then restore the truelengths that had been saved */
+    for (int i = 0; i < ustr_n; i++)
+        SET_TRLEN(ustr[i], 0);
+    maxlen = 1;
+    ustr_n = 0;
+    savetl_end();
+    free(ustr);                ustr=NULL;          ustr_alloc=0;
+    gsfree();
+    free(radix_xsub);          radix_xsub=NULL;    radix_xsuballoc=0;
+    free(*pxsub); free(newo);  *pxsub=newo=NULL;
+    free(xtmp);                xtmp=NULL;          xtmp_alloc=0;
+    free(otmp);                otmp=NULL;          otmp_alloc=0;
+    free(csort_otmp);          csort_otmp=NULL;    csort_otmp_alloc=0;
+    free(cradix_counts);       cradix_counts=NULL; cradix_counts_alloc=0;
+    free(cradix_xtmp);         cradix_xtmp=NULL;   cradix_xtmp_alloc=0;
+}
+
 attribute_hidden SEXP do_radixsort(SEXP call, SEXP op, SEXP args, SEXP rho)
 {
     int n = -1, narg = 0, ngrp, tmp, *osub, thisgrpn;
@@ -1550,6 +1579,7 @@ attribute_hidden SEXP do_radixsort(SEXP call, SEXP op, SEXP args, SEXP rho)
     bool isSorted = true, retGrp;
     void *xd;
     int *o = NULL;
+    void *xsub = NULL;
 
     /* ML: FIXME: Here are just two of the dangerous assumptions here */
     if (sizeof(int) != 4) {
@@ -1632,6 +1662,12 @@ attribute_hidden SEXP do_radixsort(SEXP call, SEXP op, SEXP args, SEXP rho)
         checkEncodings(x);
     }
     
+    RCNTXT cntxt;
+    begincontext(&cntxt, CTXT_CCODE, R_NilValue, R_BaseEnv, R_BaseEnv,
+		 R_NilValue, R_NilValue);
+    cntxt.cend = &radix_cleanup;
+    cntxt.cenddata = &xsub;
+
     savetl_init();   // from now on use Error not error.
 
     switch (TYPEOF(x)) {
@@ -1696,7 +1732,6 @@ attribute_hidden SEXP do_radixsort(SEXP call, SEXP op, SEXP args, SEXP rho)
     }
     
     int maxgrpn = gsmax[flip];   // biggest group in the first arg
-    void *xsub = NULL;           // local
 // This was not valid C23, and clang 15 warns it was not valid C99 either.
 //    int (*f) ();  // called with fn pointer, int
 //    void (*g) (); // called with fn pointer, int *, int
@@ -1930,15 +1965,8 @@ attribute_hidden SEXP do_radixsort(SEXP call, SEXP op, SEXP args, SEXP rho)
         }
     }
     
-    gsfree();
-    free(radix_xsub);          radix_xsub=NULL;    radix_xsuballoc=0;
-    free(xsub); free(newo);    xsub=newo=NULL;
-    free(xtmp);                xtmp=NULL;          xtmp_alloc=0;
-    free(otmp);                otmp=NULL;          otmp_alloc=0;
-    free(csort_otmp);          csort_otmp=NULL;    csort_otmp_alloc=0;
-
-    free(cradix_counts);       cradix_counts=NULL; cradix_counts_alloc=0;
-    free(cradix_xtmp);         cradix_xtmp=NULL;   cradix_xtmp_alloc=0;
+    endcontext(&cntxt);
+    radix_cleanup(&xsub);
     // TO DO: use xtmp already got
 
     UNPROTECT(1);


### PR DESCRIPTION
`do_radixsort` in `src/main/radixsort.c` allocates the per-column scratch
buffers `xsub` and `newo` with `malloc`, and frees them, along with the
file-static working buffers (`radix_xsub`, `xtmp`, `otmp`, `csort_otmp`,
`cradix_*`, the group-size stacks, `ustr`), only on its normal return. An
error signalled mid-sort unwinds past those frees. The `Error()` macro
fires when a key column past the first is of an unsupported type, and there
are allocation-failure and stack-overflow paths as well.

Because the buffers are file statics, the next call overwrites the pointers
with fresh allocations, so the leak is unbounded across calls rather than a
one-off.

## Reproducer

```r
n <- 1e6
for (i in 1:100)
    try(order(rep(1L, n), complex(n), method = "radix"), silent = TRUE)
# each call: "Arg 2 is type 'complex', not yet supported"
```

`order()` sorts by the first key, then the type of the second key is
checked inside the column loop, after `xsub`/`newo` were allocated for the
first key's largest tie group. A `complex` or `raw` second key reaches the
`Error()`. On unpatched trunk r90492 (aarch64-apple-darwin25.6.0), macOS
`leaks` reports ~11.8 MB leaked per call (12 bytes per element of the
largest tie group); patched, zero.

## A latent correctness bug falls out of the same defect

The string-grouping path marks the cached CHARSXPs via their truelength
and clears the marks only on the normal return. When an error unwinds
first, the marks are left in place, so the *next* radix-sort call aborts:

```r
try(order(c("b", "a", "b"), complex(3), method = "radix"), silent = TRUE)
sort(c("b", "a", "b"), method = "radix")
#> Error: Internal error. ustr isn't empty when starting cgroup: ustr_n=2 ...
```

## Fix

Move the whole teardown into a `radix_cleanup()` invoked from a
`CTXT_CCODE` cleanup context, so it runs on the error unwind as well as the
normal return (the idiom `do_dput` / `deparse1WithCutoff` use). The cleanup
restores the truelengths and resets `ustr_n` / `maxlen` in the same order
the normal path did; `do_radixsort`'s own local `xsub` is reached through
the context data pointer. The file needs `R_USE_SIGNALS` for the context
API, as `scan.c` and `deparse.c` already set.

Verified on a patched build: the leak is gone, `reg-tests-1c/1d/1e` pass,
the post-error grouping results match a clean process exactly and are
identical across repeated calls, and the "Internal error" abort above no
longer occurs.

Found by a static scan for resources released only on the normal return
path (a checker written for this sweep), reproduced with the macOS leaks
tool.
