### PR TITLE
preserve the '=>' pipe value on the parser stack

### DIFF
--- a/src/main/gram.c
+++ b/src/main/gram.c
@@ -3588,7 +3588,12 @@ static SEXP xxpipe(SEXP lhs, SEXP rhs, YYLTYPE *lloc_rhs)
 	    SEXP alist = list1(R_MissingArg);
 	    SET_TAG(alist, var);
 	    SEXP fun = lang4(R_FunctionSymbol, alist, expr, R_NilValue);
-	    return lang2(fun, lhs);
+	    /* the result stays on the parser stack until the next
+	       reduction, so it must be preserved like any other value */
+	    PRESERVE_SV(ans = lang2(fun, lhs));
+	    RELEASE_SV(lhs);
+	    RELEASE_SV(rhs);
+	    return ans;
 	}
 
 	/* check for placeholder in the RHS function */

--- a/src/main/gram.y
+++ b/src/main/gram.y
@@ -1279,7 +1279,12 @@ static SEXP xxpipe(SEXP lhs, SEXP rhs, YYLTYPE *lloc_rhs)
 	    SEXP alist = list1(R_MissingArg);
 	    SET_TAG(alist, var);
 	    SEXP fun = lang4(R_FunctionSymbol, alist, expr, R_NilValue);
-	    return lang2(fun, lhs);
+	    /* the result stays on the parser stack until the next
+	       reduction, so it must be preserved like any other value */
+	    PRESERVE_SV(ans = lang2(fun, lhs));
+	    RELEASE_SV(lhs);
+	    RELEASE_SV(rhs);
+	    return ans;
 	}
 
 	/* check for placeholder in the RHS function */

--- a/tests/reg-tests-1e.R
+++ b/tests/reg-tests-1e.R
@@ -3710,6 +3710,21 @@ stopifnot(identical(L00, ksmooth(x,y, x.points=NULL)),
 
 
 
+## parsing '<lhs> |> <var> => <expr>' left the reduced call unprotected on the
+## parser stack, so a GC before the enclosing reduction could free it
+## (found by fuzzing; '=>' is still opt-in, and stays enabled once seen)
+Sys.setenv("_R_USE_PIPEBIND_" = "true")
+gctorture(TRUE)
+e <- parse(text = "x |> b => f(b) + { y <- 1; y <- 1; y <- 1; y <- 1; y <- 1 }",
+           keep.source = FALSE)
+gctorture(FALSE)
+Sys.unsetenv("_R_USE_PIPEBIND_")
+ex <- quote((function(b) f(b))(x)); ex[[1]] <- ex[[1]][[2]] # no `(` call
+stopifnot(identical(e[[1]][[2]], ex))
+## gave garbage (or a crash) for the LHS of '+' in R <= 4.6.x
+
+
+
 ## keep at end
 rbind(last =  proc.time() - .pt,
       total = proc.time())


### PR DESCRIPTION
`xxpipe` in `src/main/gram.y` handles the (still opt-in, `_R_USE_PIPEBIND_`)
form `lhs |> var => expr` by building the call `(function(var) expr)(lhs)`
and returning it directly. Every other reduce action in the parser puts its
result on the parse-state precious multi-set with `PRESERVE_SV`, because
the bison value stack is `malloc`ed memory the collector never scans; this
branch is the one exception. The new call therefore has no GC root while it
sits on the parser stack waiting for the enclosing reduction, and any
collection in that window frees it.

The lexer itself can trigger such a collection: a numeric literal like
`.1L` warns, and `warning()` evaluates the R-level `.signalSimpleWarning`
hook, whose argument matching allocates. The ClusterFuzzLite parse target
(which enables `=>`) found the resulting heap-use-after-free:

```
READ of size 8 ... in CHK memory.c:160 / Rf_protect
  Rf_list2 -> Rf_lang3 -> xxbinary gram.c:3511 -> Rf_yyparse
freed by ReleasePage <- RunGenCollect <- R_gc_internal <- CONS_NR
  <- Rf_matchArgs_NR <- ... <- vsignalWarning <- Rf_warning
  <- NumericValue gram.c:4992 <- yylex <- Rf_yyparse
```

The unprotected return dates from r80504 (2021-06-16, "Parse non-first-arg
pipe RHS as lambda call"), so R >= 4.2.0 is affected. R 4.1.x returned a
part of the still-preserved RHS instead and was safe.

## Affected code

```c
	/* allow x => log(x) on RHS */
	if (CAR(rhs) == R_PipeBindSymbol) {
	    ...
	    SEXP alist = list1(R_MissingArg);
	    SET_TAG(alist, var);
	    SEXP fun = lang4(R_FunctionSymbol, alist, expr, R_NilValue);
	    return lang2(fun, lhs);          /* <-- no PRESERVE_SV */
	}
```

## Reproducer

No sanitizer is needed; an ordinary build corrupts the parse tree as soon
as the freed cells are reused:

```r
Sys.setenv("_R_USE_PIPEBIND_" = "true")
gctorture(TRUE)
e <- parse(text = "x |> b => f(b) + { y <- 1; y <- 1; y <- 1; y <- 1; y <- 1 }",
           keep.source = FALSE)
gctorture(FALSE)
e[[1]][[2]]
## trunk r90496: pairlist(1)  (or a promise, or FUN(X[[i]], ...))
## expected:     (function(b) f(b))(x)
```

The same happens without `gctorture` when the block contains a few
thousand `y <- .1L` statements, i.e. the warning-driven collections of the
fuzz input. The fuzz input itself is a syntax error at column 490, but
bison's default reductions run `xxbinary` on the stale value before
`yyerror` fires; ASan only sees the access once the whole node page has
been released, which needs the fuzzer's heap churn.

## Fix

Preserve the result like every other reduce action, and release `lhs` and
`rhs` the way the fall-through path does:

```c
	    SEXP fun = lang4(R_FunctionSymbol, alist, expr, R_NilValue);
	    PRESERVE_SV(ans = lang2(fun, lhs));
	    RELEASE_SV(lhs);
	    RELEASE_SV(rhs);
	    return ans;
```

`gram.c` carries the same change by hand (it was generated with bison
3.8.2; nothing else in it moves). A `gctorture` regression test is added
to `tests/reg-tests-1e.R`, after the existing parse-error tests since the
`=>` switch stays enabled for the rest of the process once seen.

## Verification

On a build of this branch (aarch64-apple-darwin25.6.0):

- the `gctorture` reproducer and the 3000-warning variant both yield
  `(function(b) f(b))(x)`; an unpatched trunk build still fails them;
- `x |> f()`, `x |> f(y = _)`, `x |> _$a$b[[1]]`, `x |> b => g(b)`,
  chained `... => g(b, 2) |> h()`, and the non-symbol `=>` error all
  parse/deparse exactly as before;
- `tests/reg-tests-1e.R` passes in full, including the pre-existing
  "`=>` is disabled" parse-error case.
