### PR TITLE
free scan()'s line buffer when an error unwinds

### DIFF
--- a/src/main/scan.c
+++ b/src/main/scan.c
@@ -40,6 +40,7 @@
 #include <Rconnections.h>
 #include <errno.h>
 #include <Print.h>
+#include "RBufferUtils.h" /* for R_StringBuffer, used in LocalData */
 
 #include <rlocale.h> /* for btowc */
 
@@ -82,6 +83,9 @@ typedef struct {
     bool embedWarn;
     bool skipNul;
     char convbuf[100];
+    /* the string buffer scanVector/scanFrame are reading into, so the
+       scan_cleanup context can free it if an error unwinds mid-scan */
+    R_StringBuffer *sbuf;
 } LocalData;
 
 static SEXP insertString(char *str, LocalData *l)
@@ -319,9 +323,12 @@ static void scan_cleanup(void *data)
 	free(ld->quoteset);
 	ld->quoteset = NULL;
     }
+    if(ld->sbuf) {
+	R_FreeStringBuffer(ld->sbuf);
+	ld->sbuf = NULL;
+    }
 }
 
-#include "RBufferUtils.h"
 
 /*XX  Can we pass this routine an R_StringBuffer? appears so.
    But do we have to worry about continuation lines and whatever
@@ -569,6 +576,7 @@ static SEXP scanVector(SEXPTYPE type, R_xlen_t maxitems, R_xlen_t maxlines,
     else blocksize = SCAN_BLOCKSIZE;
 
     R_AllocStringBuffer(0, &strBuf);
+    d->sbuf = &strBuf;
     PROTECT(ans = allocVector(type, blocksize));
 
     nprev = 0; n = 0; linesread = 0; bch = 1;
@@ -636,11 +644,13 @@ static SEXP scanVector(SEXPTYPE type, R_xlen_t maxitems, R_xlen_t maxlines,
     if (n == 0) {
 	UNPROTECT(1);
 	R_FreeStringBuffer(&strBuf);
+	d->sbuf = NULL;
 	return allocVector(type,0);
     }
     if (n == maxitems) {
 	UNPROTECT(1);
 	R_FreeStringBuffer(&strBuf);
+	d->sbuf = NULL;
 	return ans;
     }
 
@@ -672,6 +682,7 @@ static SEXP scanVector(SEXPTYPE type, R_xlen_t maxitems, R_xlen_t maxlines,
     }
     UNPROTECT(1);
     R_FreeStringBuffer(&strBuf);
+    d->sbuf = NULL;
     return bns;
 }
 
@@ -697,6 +708,7 @@ static SEXP scanFrame(SEXP what, R_xlen_t maxitems, R_xlen_t maxlines,
     else blksize = SCAN_BLOCKSIZE;
 
     R_AllocStringBuffer(0, &buf);
+    d->sbuf = &buf;
     PROTECT(ans = allocVector(VECSXP, nc));
     for (i = 0; i < nc; i++) {
 	w = VECTOR_ELT(what, i);
@@ -845,6 +857,7 @@ static SEXP scanFrame(SEXP what, R_xlen_t maxitems, R_xlen_t maxlines,
     }
     UNPROTECT(1);
     R_FreeStringBuffer(&buf);
+    d->sbuf = NULL;
     return ans;
 }
 


### PR DESCRIPTION
`scanVector` and `scanFrame` in `src/main/scan.c` read fields into a local
`R_StringBuffer` and free it with `R_FreeStringBuffer` only on their normal
return. Both run under `do_scan`'s `scan_cleanup` cleanup context, but that
context frees only the connection and the quote set, not the buffer. Any
error signalled mid-scan unwinds past the free and leaks the buffer, at
least the 8 KB (`MAXELTSIZE`) initial allocation and more once a long field
has grown it.

The most common trigger is a field that does not match the requested type,
signalled by `expected()`; the interrupt check inside the read loop is
another.

## Reproducer

```r
for (i in 1:300) try(scan(text = "abc", what = 1), silent = TRUE)   # scanVector
for (i in 1:300) try(read.table(text = "1 2\n3"), silent = TRUE)    # scanFrame
```

On unpatched trunk r90492 (aarch64-apple-darwin25.6.0), macOS `leaks`
reports ~10 KB leaked per call for each; patched, zero.

## Fix

Hang the buffer on `LocalData`, which is what `do_scan` passes as the
cleanup context's data, so `scan_cleanup` frees it on the unwind too, the
same way it already frees the connection and quote set. `scanVector` and
`scanFrame` register their buffer in the new field right after allocating
it and clear the field before returning, so the pointer is never left
pointing at a dead stack frame. `RBufferUtils.h` moves above the
`LocalData` definition to make the `R_StringBuffer` type available there.

Verified on a patched build: both leaks gone, `scan` / `read.table` /
`count.fields` behave as before, and `reg-tests-1a/1c/1d` pass.

Found by a static scan for resources released only on the normal return
path (a checker written for this sweep), reproduced with the macOS leaks
tool.
