### PR TITLE
free rWishart's work matrices when 'scal' is not positive-definite

### DIFF
--- a/src/library/stats/src/rWishart.c
+++ b/src/library/stats/src/rWishart.c
@@ -85,11 +85,14 @@ rWishart(SEXP ns, SEXP nuP, SEXP scal)
     if (!isMatrix(scal) || !isReal(scal) || dims[0] != dims[1])
 	error(_("'scal' must be a square, real matrix"));
     if (n <= 0) n = 1;
-    // allocate early to avoid memory leaks in R_Callocs below.
     PROTECT(ans = alloc3DArray(REALSXP, dims[0], dims[0], n));
     psqr = dims[0] * dims[0];
-    tmp = R_Calloc(psqr, double);
-    scCp = R_Calloc(psqr, double);
+    /* R_alloc, not R_Calloc: the positive-definiteness check below signals
+       an error, which would leak R_Calloc'd buffers; R_alloc lives on the
+       R heap and is reclaimed when the call returns or an error unwinds */
+    const void *vmax = vmaxget();
+    tmp = (double *) R_alloc(psqr, sizeof(double));
+    scCp = (double *) R_alloc(psqr, sizeof(double));
 
     Memcpy(scCp, REAL(scal), psqr);
     if (psqr)
@@ -115,7 +118,7 @@ rWishart(SEXP ns, SEXP nuP, SEXP scal)
     }
 
     PutRNGstate();
-    R_Free(scCp); R_Free(tmp);
+    vmaxset(vmax);
     UNPROTECT(1);
     return ans;
 }


### PR DESCRIPTION
`rWishart` in `src/library/stats/src/rWishart.c` `R_Calloc`s two p-by-p work
matrices, `tmp` and `scCp`, then factors `scCp` with LAPACK `dpotrf` and
signals an error when the matrix is not positive-definite. That error
unwinds past the `R_Free` at the end of the function, leaking both buffers
(2 p^2 doubles) on every call.

## Reproducer

```r
for (i in 1:300) try(rWishart(1, 3, matrix(0, 2, 2)), silent = TRUE)
# 'scal' matrix is not positive-definite
```

On unpatched trunk r90492 (aarch64-apple-darwin25.6.0), macOS `leaks`
reports the two matrices leaked per call; patched, zero.

The comment "allocate early to avoid memory leaks in R_Callocs below"
refers to the `alloc3DArray`, which is protected on the stack; it does not
cover the `dpotrf` failure between the `R_Calloc`s and the `R_Free`.

## Fix

Allocate the two work matrices with `R_alloc` under `vmaxget` / `vmaxset`
instead of `R_Calloc` / `R_Free`, so they live on the R heap and are
reclaimed whether the call returns normally or an error unwinds. Both are
plain scratch buffers that die with the call, so this is a direct
substitution.

Verified on a patched build: the leak is gone and `rWishart` output is
unchanged (correct dimensions, symmetric matrices).

Found by a static scan for resources released only on the normal return
path (a checker written for this sweep), reproduced with the macOS leaks
tool.
