### PR TITLE
free readChar()'s fixed-width buffer on an embedded nul

### DIFF
--- a/src/main/connections.c
+++ b/src/main/connections.c
@@ -5259,13 +5259,14 @@ rawFixedString(Rbyte *bytes, int len, int nbytes, int *np, int useBytes)
 	*p = '\0';
 	res = mkCharLenCE(buf, clen, CE_NATIVE);
     } else {
-	/* no terminator */
-	buf = R_chk_calloc(len + 1, 1);
+	/* no terminator; R_alloc, not R_chk_calloc: mkCharLenCE signals on an
+	   embedded nul (see the note above), which would leak the buffer.
+	   vmax is already bracketed above. */
+	buf = R_alloc((R_SIZE_T)len + 1, sizeof(char));
 	if (len)
 	    memcpy(buf, bytes + (*np), len);
 	*np += len;
 	res = mkCharLenCE(buf, len, CE_NATIVE);
-	R_Free(buf);
     }
     vmaxset(vmax);
     return res;


### PR DESCRIPTION
`rawFixedString` in `src/main/connections.c` backs `readChar()` on a raw
vector or a binary connection. In the `useBytes` (or non-UTF-8-locale)
branch it copies the requested bytes into an `R_chk_calloc` buffer and
passes them to `mkCharLenCE`, which signals `"embedded nul in string"` when
the bytes contain a nul. That error unwinds past the `R_Free`, leaking the
buffer on every call.

## Reproducer

```r
for (i in 1:400)
    try(readChar(as.raw(c(0x61, 0x00, 0x62)), 3, useBytes = TRUE), silent = TRUE)
```

On unpatched trunk r90492 (aarch64-apple-darwin25.6.0), macOS `leaks`
reports the buffer leaked per call; patched, zero.

## Fix

Allocate with `R_alloc` instead of `R_chk_calloc` / `R_Free`, under the
`vmaxget` / `vmaxset` bracket the function already sets up for its UTF-8
branch, so the buffer lives on the R heap and is reclaimed when the error
unwinds. The UTF-8 branch a few lines above already uses `R_alloc` for the
same reason; this makes the two branches consistent. It is the `readChar`
analogue of the unserialize buffer leak in PR #322 / Bugzilla 19157.

Verified on a patched build: the leak is gone and `readChar` on raw
vectors, files, and UTF-8 input is unchanged.

Found by a static scan for resources released only on the normal return
path (a checker written for this sweep), reproduced with the macOS leaks
tool.
