### PR TITLE
end lzma streams on the error paths in connections.c

### DIFF
--- a/src/main/connections.c
+++ b/src/main/connections.c
@@ -6973,13 +6973,15 @@ SEXP R_compress3(SEXP in)
     strm.next_out = buf + 5;
     strm.avail_out = outlen;
     while(!ret) ret = lzma_code(&strm, LZMA_FINISH);
-    if (ret != LZMA_STREAM_END || (strm.avail_in > 0)) {
+    bool zok = (ret == LZMA_STREAM_END && strm.avail_in == 0);
+    unsigned int total_out = (unsigned int) strm.total_out;
+    lzma_end(&strm);   /* before the warning: warn=2 turns it into a jump */
+    if (!zok) {
 	warning("internal error %d in R_compress3", ret);
 	outlen = inlen;
 	buf[4] = '0';
 	memcpy(buf+5, (char *)RAW(in), inlen);
-    } else outlen = (unsigned int) strm.total_out;
-    lzma_end(&strm);
+    } else outlen = total_out;
 
     /* printf("compressed %d to %d\n", inlen, outlen); */
     ans = allocVector(RAWSXP, outlen + 5);
@@ -7008,6 +7010,7 @@ SEXP R_decompress3(SEXP in, Rboolean *err)
 	init_filters();
 	ret = lzma_raw_decoder(&strm, filters);
 	if (ret != LZMA_OK) {
+	    lzma_end(&strm);
 	    warning("internal error %d in R_decompress3", (int)ret);
 	    *err = TRUE;
 	    return R_NilValue;
@@ -7018,6 +7021,7 @@ SEXP R_decompress3(SEXP in, Rboolean *err)
 	strm.avail_out = outlen;
 	ret = lzma_code(&strm, LZMA_RUN);
 	if (ret != LZMA_OK && (strm.avail_in > 0)) {
+	    lzma_end(&strm);
 	    warning("internal error %d in R_decompress3 %llu",
 		    (int)ret, (unsigned long long)strm.avail_in);
 	    *err = TRUE;
@@ -7352,6 +7356,11 @@ do_memDecompress(SEXP call, SEXP op, SEXP args, SEXP env)
 	lzma_stream strm = LZMA_STREAM_INIT;
 	lzma_ret ret;
 	while(1) {
+	    /* R_alloc before initialising the decoder: R_alloc can signal
+	       (outlen grows and may hit the vector limit), and doing it while
+	       a decoder is live would leak the decoder on that error */
+	    buf = (unsigned char *) R_alloc(outlen, sizeof(unsigned char));
+
 	    /* Initialize lzma_stream in each iteration. */
 	    /* probably at most 80Mb is required, but 512Mb seems OK as a limit */
 	    if (subtype == 1)
@@ -7361,7 +7370,6 @@ do_memDecompress(SEXP call, SEXP op, SEXP args, SEXP env)
 	    if (ret != LZMA_OK)
 		error(_("cannot initialize lzma decoder, error %d"), ret);
 
-	    buf = (unsigned char *) R_alloc(outlen, sizeof(unsigned char));
 	    strm.avail_in = inlen;
 	    strm.avail_out = outlen;
 	    strm.next_in = (unsigned char *) RAW(from);


### PR DESCRIPTION
Three xz/lzma paths in `src/main/connections.c` initialise an
`lzma_stream` and then take an error or warning exit before `lzma_end()`,
leaking the encoder or decoder state.

## R_decompress3 (no `warn = 2` needed)

On a corrupt compress-3 payload `lzma_code` fails; the function warns and
`return R_NilValue` without `lzma_end`. `lazyLoadDBfetch` retries the
decompression on every access of the object, so a damaged lazy-load
database leaks the decoder on each fetch.

```r
f <- tempfile()
tools:::makeLazyLoadDB(list(x = rep(1:100, 5000)), f, compress = 3)
rdb <- paste0(f, ".rdb"); b <- readBin(rdb, "raw", file.size(rdb))
mid <- length(b) %/% 2; b[seq(mid, mid + 200, by = 3)] <- as.raw(0xff)
writeBin(b, rdb)
e <- new.env(); lazyLoad(f, e)
for (i in 1:200) suppressWarnings(tryCatch(get("x", e), error = function(x) NULL))
```

macOS `leaks` on unpatched trunk r90492: ~6 MB per fetch, 1.25 GB over the
loop. Patched: zero.

## R_compress3 (`warn = 2`)

The "internal error" warning for incompressible input (the documented
fallback that stores the data uncompressed) fires before `lzma_end`. Under
`options(warn = 2)` it jumps and leaks the preset encoder, tens of MB per
call, e.g. `makeLazyLoadDB(compress = 3)` on incompressible data.

## do_memDecompress (xz)

The output buffer is `R_alloc`d after the decoder is initialised, so when
`outlen` grows past the vector limit the `R_alloc` error unwinds with the
decoder live: `memDecompress(memCompress(raw(3e8), "xz"), "xz")` under a
low `R_MAX_VSIZE`.

## Fix

End the stream before each error/warning exit. In `do_memDecompress`,
`R_alloc` the output buffer before initialising the decoder, so an
allocation failure cannot leak it. `R_compress3` reads `strm.total_out`
into a local before `lzma_end`, so the success path is unchanged.

Verified on a patched build: all three leaks gone, `memCompress` /
`memDecompress` and compress-3 lazy-load round trips unchanged,
`reg-tests-1c/1d` pass.

Found by a static scan for resources released only on the normal return
path (a checker written for this sweep), reproduced with the macOS leaks
tool.
