### PR TITLE
free make.names() buffer on an invalid multibyte string

### DIFF
--- a/src/main/character.c
+++ b/src/main/character.c
@@ -1055,7 +1055,10 @@ attribute_hidden SEXP do_makenames(SEXP call, SEXP op, SEXP args, SEXP env)
 		}
 		wcstombs(tmp, wstr, strlen(tmp)+1);
 		R_Free(wstr);
-	    } else error(_("invalid multibyte string %lld"), (long long)i+1);
+	    } else {
+		R_Free(tmp);
+		error(_("invalid multibyte string %lld"), (long long)i+1);
+	    }
 	} else {
 	    for (p = tmp; *p; p++) {
 		if (*p == '.' || (allow_ && *p == '_')) /* leave alone */;


### PR DESCRIPTION
`do_makenames` in `src/main/character.c` `R_Calloc`s a per-element buffer
`tmp`, and in an mbcs locale converts it through `mbstowcs`. When the
string is not valid in the locale encoding, `mbstowcs` returns -1 and the
function signals `"invalid multibyte string"`, which unwinds past the
`R_Free(tmp)` at the end of the loop body and leaks the buffer.

## Reproducer

```r
for (i in 1:300) try(make.names("a\xff"), silent = TRUE)   # UTF-8 locale
```

On unpatched trunk r90492 (aarch64-apple-darwin25.6.0), macOS `leaks`
reports the buffer leaked per call; patched, zero. Only the first
character is validated before the `R_Calloc`, so the error fires after the
buffer exists.

## Fix

`R_Free(tmp)` before the `error()`.

Verified on a patched build: the leak is gone and `make.names` (including
the reserved-word and `unique = TRUE` paths) is unchanged;
`reg-tests-1c` passes.

Found by a static scan for resources released only on the normal return
path (a checker written for this sweep), reproduced with the macOS leaks
tool.
