### PR TITLE
validate ALTREP compact sequence state on unserialize

### DIFF
--- a/src/main/altclasses.c
+++ b/src/main/altclasses.c
@@ -86,6 +86,15 @@ static SEXP new_compact_realseq(R_xlen_t, double, double);
 
 static SEXP compact_intseq_Unserialize(SEXP class, SEXP state)
 {
+    /* state is the serialized info vector (see compact_intseq_Serialized_state):
+       a numeric vector of length 3.  A crafted serialized stream can supply
+       any object here, so reject a malformed state with a clean error rather
+       than reading REAL0/INTEGER0 off the end of a short or wrong-typed
+       (or non-vector) object. */
+    if ((TYPEOF(state) != REALSXP && TYPEOF(state) != INTSXP) ||
+	XLENGTH(state) < 3)
+	error("invalid compact_intseq serialized state");
+
     R_xlen_t n = COMPACT_INTSEQ_SERIALIZED_STATE_LENGTH(state);
     int n1 = COMPACT_INTSEQ_SERIALIZED_STATE_FIRST(state);
     int inc = COMPACT_INTSEQ_SERIALIZED_STATE_INCR(state);
@@ -363,6 +372,12 @@ static SEXP compact_realseq_Serialized_state(SEXP x)
 
 static SEXP compact_realseq_Unserialize(SEXP class, SEXP state)
 {
+    /* as for compact_intseq_Unserialize: the info vector read below is a
+       length-3 REALSXP, but a crafted stream can supply anything, so reject
+       a malformed state rather than reading REAL0 off the end. */
+    if (TYPEOF(state) != REALSXP || XLENGTH(state) < 3)
+	error("invalid compact_realseq serialized state");
+
     double inc = COMPACT_REALSEQ_INFO_INCR(state);
     R_xlen_t len = COMPACT_REALSEQ_INFO_LENGTH(state);
     double n1 = COMPACT_REALSEQ_INFO_FIRST(state);


### PR DESCRIPTION
`compact_intseq_Unserialize()` and `compact_realseq_Unserialize()` in
`src/main/altclasses.c` reconstruct a compact ALTREP sequence from its
serialized *state*: a numeric vector of length three holding the sequence
length, first value and increment. They read those three slots without
checking that the state is a numeric vector of length >= 3:

```c
static SEXP compact_intseq_Unserialize(SEXP class, SEXP state)
{
    R_xlen_t n = COMPACT_INTSEQ_SERIALIZED_STATE_LENGTH(state); /* [0] */
    int n1     = COMPACT_INTSEQ_SERIALIZED_STATE_FIRST(state);  /* [1] */
    int inc    = COMPACT_INTSEQ_SERIALIZED_STATE_INCR(state);   /* [2] */
    ...
```

`ReadItem()` hands `state` to the class method as whatever object the
stream supplied. On the write side it is always the length-3 `REALSXP`
info vector, but a crafted serialized stream can put any object there, so
the `[1]`/`[2]` reads run off the end of a short vector, and a non-vector
state makes `REAL0`/`INTEGER0` compute an invalid data pointer.

## Reproducers (found by fuzzing R with libFuzzer + AddressSanitizer)

- **oss-fuzz 5857824396345344** (reproducible): the state is a length-1
  `INTSXP`, so reading the increment at `[2]` is a 4-byte
  heap-buffer-overflow read at `altclasses.c:91`.
- **oss-fuzz 5360206129987584**: a null-dereference at `altclasses.c:89`
  from a state whose data pointer is invalid.

Both reach the method through `unserialize()` / `readRDS()`:

```
compact_intseq_Unserialize     src/main/altclasses.c:91
altrep_UnserializeEX_default   src/main/altrep.c:694
ReadItem_Recursive             src/main/serialize.c:1925
R_Unserialize                  src/main/serialize.c:2300
```

Whether the out-of-bounds read faults depends on heap layout: a length-1
integer state shares a vector node with slack, so on many builds the read
returns adjacent memory and the existing "increment N not supported"
error masks it; on the oss-fuzz build the read lands in an ASan redzone
and traps. Either way it is an out-of-bounds read of attacker-controlled
serialized data.

## Fix

Validate the state before reading it and raise a clean R error for a
malformed one, in both the integer and real constructors. The real
sequence path has no known reproducer but reads its state the same way,
so it gets the same guard.

## Validation

Built R with AddressSanitizer (clang, glibc 2.31) and ran both
reproducers through `unserialize()`:

- **Before:** the length-1 integer state is read at index 2 (confirmed by
  instrumenting the method).
- **After:** both inputs raise `invalid compact_intseq serialized state`
  and unserialization stops before any out-of-bounds read.

No regression test is included: on a normal build the unpatched code also
returns a clean error for these inputs (the fault is ASan- and
layout-dependent), so a functional test could not distinguish the fixed
from the unfixed build. `unserialize()` of untrusted data is documented
as unsafe; this is a robustness fix so malformed input fails cleanly
rather than reading out of bounds.
