### PR TITLE
do not over-read past the string in Mbrtowc's invalid-string report

### DIFF
--- a/src/main/util.c
+++ b/src/main/util.c
@@ -1622,19 +1622,26 @@ size_t Mbrtowc(wchar_t *wc, const char *s, size_t n, mbstate_t *ps)
 	size_t sz = 4*strlen(s) + 1;
 	char err[sz], *q;
 	const char *p;
+	/* Bound each mbrtowc() by the bytes actually left before the
+	   terminating nul.  The previous code passed the caller's fixed
+	   count 'n' (typically R_MB_CUR_MAX) and decremented it in step with
+	   'p'; once it fell out of step it underflowed to a huge size_t, so
+	   mbrtowc() was told far more bytes were available than remained and
+	   could read past the end of 's' into unmapped memory. */
+	size_t nb = strlen(s);
 	for(p = s, q = err; *p; ) {
 	    /* don't do the first to keep ps state straight */
-	    if(p > s) used = mbrtowc(NULL, p, n, ps);
+	    if(p > s) used = mbrtowc(NULL, p, nb, ps);
 	    if(used == 0) break;
 	    else if((int) used > 0) {
 		memcpy(q, p, used);
 		p += used;
 		q += used; sz -= used;
-		n -= used;
+		nb -= used;
 	    } else {
 		snprintf(q, sz, "<%02x>", (unsigned char) *p++);
 		q += 4; sz -= 4;
-		n--;
+		nb--;
 	    }
 	}
 	*q = '\0';


### PR DESCRIPTION
`Mbrtowc()` (exported as `Rf_mbrtowc`) in `src/main/util.c` wraps
`mbrtowc()`. When the byte sequence is not valid in the current multibyte
locale it builds a human-readable rendering of the offending string, one
character at a time, for the error message:

```c
for(p = s, q = err; *p; ) {
    if(p > s) used = mbrtowc(NULL, p, n, ps);   /* n from the caller */
    if(used == 0) break;
    else if((int) used > 0) { ...; n -= used; }
    else { snprintf(...); p++; n--; }
}
```

`n` starts at the caller's fixed count (`Rf_isBlankString` and the other
callers pass `R_MB_CUR_MAX`), not the length of the string, and is
decremented in step with `p`. Once it falls out of step it underflows to
a huge `size_t`, so `mbrtowc()` is told far more bytes are available than
actually remain. glibc's UTF-8 converter then copies up to
`MAX_NEEDED_INPUT` bytes into its internal buffer bounded only by that
count, reading past the end of the string. When the string sits near the
end of a heap page the read crosses into unmapped memory and faults.

## Reproducer (found by fuzzing R with libFuzzer + AddressSanitizer)

**oss-fuzz 5931425707393024**: `as.complex()` of an invalid multibyte
string in a UTF-8 locale:

```
utf8_internal_loop_single        (glibc iconv)
__gconv_transform_utf8_internal  (glibc)
__mbrtowc                         (glibc)
Rf_mbrtowc                       src/main/util.c:1627
Rf_isBlankString                 src/main/util.c:453
Rf_ComplexFromString             src/main/coerce.c:281
```

`ComplexFromString()` -> `isBlankString()` calls `Mbrtowc(&wc, s,
R_MB_CUR_MAX, ...)`, which fails and enters the rendering loop above.

## Fix

Bound each `mbrtowc()` call by the number of bytes actually left before
the terminating nul, tracked in a dedicated counter, so the count can
never exceed the string and never underflows.

## Validation

Built R with AddressSanitizer (clang, glibc 2.31) and ran the reproducer
through `as.complex()`. The error path now reports the same
`invalid multibyte string at '...'` message with each `mbrtowc()` call
bounded by the remaining length. The wild read in the oss-fuzz report is
a hardware fault that depends on the string landing at the end of a heap
page (ClusterFuzz flags the testcase as non-reproducible for that
reason), so it is not deterministically reproducible in a normal build;
the fix removes the out-of-bounds read regardless.

The same over-read pattern applies wherever an oversized count is passed
into this loop; bounding by the remaining length fixes it at the source.
