### PR TITLE
bound recoding of serialized strings

### DIFF
--- a/src/gnuwin32/Rdll.hide
+++ b/src/gnuwin32/Rdll.hide
@@ -544,6 +544,7 @@
  Rf_promiseArgs
  Rf_qchisq_appr
  Rf_reEnc3
+ Rf_reEnc4
  Rf_readS3VarsFromFrame
  Rf_regcomp
  Rf_regerror

--- a/src/include/Defn.h
+++ b/src/include/Defn.h
@@ -2448,6 +2448,8 @@ SEXP Rf_installTrChar(SEXP);
 
 const wchar_t *wtransChar(SEXP x); /* from sysutils.c */
 const char *Rf_reEnc3(const char *x, const char *fromcode, const char *tocode, int subst);
+const char *Rf_reEnc4(const char *x, size_t length, const char *fromcode,
+		     const char *tocode, int subst);
 
 #define mbs_init(x) memset(x, 0, sizeof(mbstate_t))
 size_t Mbrtowc(wchar_t *wc, const char *s, size_t n, mbstate_t *ps);

--- a/src/include/Rinternals.h
+++ b/src/include/Rinternals.h
@@ -1016,6 +1016,7 @@ void R_orderVector1(int *indx, int n, SEXP x,       Rboolean nalast, Rboolean de
 #define readS3VarsFromFrame	Rf_readS3VarsFromFrame
 #define reEnc			Rf_reEnc
 #define reEnc3			Rf_reEnc3
+#define reEnc4			Rf_reEnc4
 #define S3Class                 Rf_S3Class
 #define ScalarComplex		Rf_ScalarComplex
 #define ScalarInteger		Rf_ScalarInteger

--- a/src/main/envir.c
+++ b/src/main/envir.c
@@ -4726,7 +4726,7 @@ static void reportInvalidString(SEXP cval, int actionWhenInvalid)
 	else if (IS_LATIN1(cval))
 	    from = "CP1252";
 
-	native_str = reEnc3(CHAR(cval), from, "", 1);
+	native_str = reEnc4(CHAR(cval), LENGTH(cval), from, "", 1);
 	if (actionWhenInvalid == 1)
 	    warning("invalid string %s", native_str);
 	else if (actionWhenInvalid == 2)

--- a/src/main/serialize.c
+++ b/src/main/serialize.c
@@ -1684,17 +1684,18 @@ static char *native_fromcode(R_inpstream_t stream)
     return from;
 }
 
-static void invalid_utf8_warning(const char *buf, const char *from)
+static void invalid_utf8_warning(const char *buf, int length, const char *from)
 {
     const void *vmax = vmaxget();
     const char *native_buf;
 
     if (utf8Valid(buf)) {
-	native_buf = reEnc3(buf, "UTF-8", "", 1);
+	native_buf = reEnc4(buf, length, "UTF-8", "", 1);
 	warning(_("input string '%s' cannot be translated from '%s' to UTF-8, but is valid UTF-8"),
 		native_buf, from);
     } else {
-	native_buf = reEnc(reEnc3(buf, from, "UTF-8", 1), CE_UTF8, CE_NATIVE, 2);
+	native_buf = reEnc(reEnc4(buf, length, from, "UTF-8", 1),
+			   CE_UTF8, CE_NATIVE, 2);
 	warning(_("input string '%s' cannot be translated to UTF-8, is it valid in '%s'?"),
 		native_buf, from);
     }
@@ -1750,7 +1751,7 @@ ReadChar(R_inpstream_t stream, char *buf, int length, int levs)
 	if (known_to_be_utf8) {
 	    /* nat2nat_obj is converting to UTF-8, no need to use nat2utf8_obj */
 	    stream->nat2utf8_obj = (void *)-1;
-	    invalid_utf8_warning(buf, native_fromcode(stream));
+	    invalid_utf8_warning(buf, length, native_fromcode(stream));
 	}
     }
     /* try converting to UTF-8 */
@@ -1769,7 +1770,7 @@ ReadChar(R_inpstream_t stream, char *buf, int length, int levs)
 	SEXP ans = ConvertChar(stream->nat2utf8_obj, buf, length, CE_UTF8);
 	if (ans != R_NilValue)
 	    return ans;
-	invalid_utf8_warning(buf, native_fromcode(stream));
+	invalid_utf8_warning(buf, length, native_fromcode(stream));
     }
     /* no translation possible */
     return mkCharLenCE(buf, length, CE_NATIVE);
@@ -2272,6 +2273,8 @@ SEXP R_Unserialize(R_inpstream_t stream)
 	    error(_("invalid length of encoding name"));
 	InString(stream, stream->native_encoding, nelen);
 	stream->native_encoding[nelen] = '\0';
+	if (memchr(stream->native_encoding, '\0', nelen))
+	    error(_("embedded nul in encoding name"));
 	break;
     }
     default:
@@ -2364,6 +2367,8 @@ attribute_hidden SEXP R_SerializeInfo(R_inpstream_t stream)
 	char nbuf[nelen + 1];
 	InString(stream, nbuf, nelen);
 	nbuf[nelen] = '\0';
+	if (memchr(nbuf, '\0', nelen))
+	    error(_("embedded nul in encoding name"));
 	SET_VECTOR_ELT(ans, 4, mkString(nbuf));
     }
     setAttrib(ans, R_NamesSymbol, names);

--- a/src/main/sysutils.c
+++ b/src/main/sysutils.c
@@ -2223,7 +2223,7 @@ const wchar_t *wtransChar2(SEXP x)
 	return wcopyAndFreeStringBuffer(&cbuff);
 }
 
-static int reEncodeIconv(const char *x, R_StringBuffer *cbuff,
+static int reEncodeIconv(const char *x, size_t length, R_StringBuffer *cbuff,
                          const char *fromcode, const char *tocode, int subst)
 {
     void * obj;
@@ -2237,10 +2237,7 @@ static int reEncodeIconv(const char *x, R_StringBuffer *cbuff,
     R_AllocStringBuffer(0, cbuff);
 top_of_loop:
     inbuf = x;
-    if (fromWchar)
-	inb = wcslen((wchar_t *)inbuf) * sizeof(wchar_t);
-    else
-	inb = strlen(inbuf);
+    inb = length;
     outbuf = cbuff->data; outb = cbuff->bufsize - 3;
     /* First initialize output */
     Riconv (obj, NULL, NULL, &outbuf, &outb);
@@ -2348,7 +2345,7 @@ static int reEncode(const char *x, R_StringBuffer *cbuff,
     default: return 1;
     }
 
-    return reEncodeIconv(x, cbuff, fromcode, tocode, subst);
+    return reEncodeIconv(x, strlen(x), cbuff, fromcode, tocode, subst);
 }
 
 /* This may return a R_alloc-ed result, so the caller has to manage the
@@ -2390,8 +2387,18 @@ attribute_hidden
 const char *reEnc3(const char *x,
                    const char *fromcode, const char *tocode, int subst)
 {
+    size_t length = !strcmp(fromcode, TO_WCHAR)
+	? wcslen((wchar_t *) x) * sizeof(wchar_t) : strlen(x);
+    return reEnc4(x, length, fromcode, tocode, subst);
+}
+
+/* As reEnc3, with the input length supplied explicitly. */
+attribute_hidden
+const char *reEnc4(const char *x, size_t length,
+		   const char *fromcode, const char *tocode, int subst)
+{
     R_StringBuffer cbuff = {NULL, 0, MAXELTSIZE};
-    if (reEncodeIconv(x, &cbuff, fromcode, tocode, subst)) return x;
+    if (reEncodeIconv(x, length, &cbuff, fromcode, tocode, subst)) return x;
     size_t res = strlen(cbuff.data) + 1;
     char *p = R_alloc(res, 1);
     memcpy(p, cbuff.data, res);

--- a/src/main/sysutils.c
+++ b/src/main/sysutils.c
@@ -2165,7 +2165,9 @@ next_char:
     if(ttype == NT_FROM_NATIVE) Riconv_close(obj);
     if (mustWork && failed) {
 	const void *vmax = vmaxget();
-	const char *native_buf = reEnc3(cbuff->data, TO_WCHAR, "", 2);
+	const char *native_buf = reEnc4(cbuff->data,
+				       (size_t) (outbuf - cbuff->data),
+				       TO_WCHAR, "", 2);
 
 	/* copy to truncate (and mark as truncated) */
 	char err_buff[256];

--- a/tests/reg-tests-1b.R
+++ b/tests/reg-tests-1b.R
@@ -1731,6 +1731,21 @@ stopifnot(identical(input, res))
 unlink("serial")
 ## Just a test for possible regressions.
 
+## invalid encodings in serialized data
+wide <- if (.Platform$OS.type == "windows") "UTF-16LE" else
+    paste0("UCS-4", if (.Platform$endian == "little") "LE" else "BE")
+bad <- c(charToRaw(sprintf("A\n3\n6\n8\n%d\n%s16\n1\n9\n1\n",
+			   nchar(wide), wide)), as.raw(0xff))
+out <- suppressWarnings(unserialize(bad))
+stopifnot(identical(charToRaw(out), as.raw(0xff)))
+
+bad <- c(charToRaw("A\n3\n6\n8\n14\nUTF-8"), as.raw(0),
+	 charToRaw("padding!254\n"))
+assertError(unserialize(bad))
+con <- rawConnection(bad)
+assertError(infoRDS(con))
+close(con)
+
 
 ## mis-PROTECT()ion in printarray C code:
 df <- data.frame(a=1:2080, b=1001:2040, c=letters, d=LETTERS, e=1:1040)


### PR DESCRIPTION
A version-3 serialization stream can label a length-delimited string as the
platform's `wchar_t` encoding. When conversion failed, the warning path passed
that buffer to `reEnc3()`, which inferred a wide string from the encoding name
and called `wcslen()` beyond the serialized string's bounds.

Add `reEnc4()` for callers with an explicit byte length and use it for
length-delimited serialized strings, `CHARSXP` diagnostics, and buffered wide
string conversions. Keep `reEnc3()` for NUL-terminated inputs whose lengths
are not otherwise available. Also reject embedded NULs in version-3 encoding
names in both `unserialize()` and `infoRDS()`.

Validation:

- clean out-of-tree R build
- `reg-tests-1b.R`
- `reg-tests-1b.R` with an AddressSanitizer-built core
- original ClusterFuzz testcase and a direct platform-wide-encoding trigger
  under AddressSanitizer
